### PR TITLE
Added attributes to Spans

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
@@ -1,0 +1,40 @@
+package com.bugsnag.android.performance
+
+class Attributes : Collection<Pair<String, Any>> {
+    private val content = mutableMapOf<String, Any>()
+
+    override val size: Int
+        get() = content.size
+
+    val keys get() = content.keys.toSet()
+
+    operator fun set(key: String, value: String) {
+        content[key] = value
+    }
+
+    operator fun set(key: String, value: Long) {
+        content[key] = value
+    }
+
+    operator fun set(key: String, value: Double) {
+        content[key] = value
+    }
+
+    operator fun set(key: String, value: Boolean) {
+        content[key] = value
+    }
+
+    override fun iterator(): Iterator<Pair<String, Any>> =
+        content.asSequence().map { it.toPair() }.iterator()
+
+    override fun contains(element: Pair<String, Any>): Boolean {
+        val (key, value) = element
+        return content[key] == value
+    }
+
+    override fun containsAll(elements: Collection<Pair<String, Any>>): Boolean {
+        return elements.all { (key, value) -> content[key] == value }
+    }
+
+    override fun isEmpty(): Boolean = content.isEmpty()
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.performance
+
+interface HasAttributes {
+    val attributes: Attributes
+
+    fun setAttribute(key: String, value: String) {
+        attributes[key] = value
+    }
+
+    fun setAttribute(key: String, value: Long) {
+        attributes[key] = value
+    }
+
+    fun setAttribute(key: String, value: Double) {
+        attributes[key] = value
+    }
+
+    fun setAttribute(key: String, value: Boolean) {
+        attributes[key] = value
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
@@ -12,7 +12,10 @@ class Span internal constructor(
     val traceId: UUID,
     val id: Long = Random.nextLong(),
     private val processor: SpanProcessor,
-) : Closeable {
+) : Closeable, HasAttributes {
+
+    override val attributes: Attributes = Attributes()
+
     var name: String = name
         set(value) {
             if (endTime != NO_END_TIME) {
@@ -23,7 +26,6 @@ class Span internal constructor(
         }
 
     @set:JvmSynthetic
-    @set:JvmName("-setEndTime")
     var endTime: Long = NO_END_TIME
         internal set
 
@@ -33,6 +35,7 @@ class Span internal constructor(
      * also avoid the need for an array or List to contain the spans that are pending delivery.
      */
     @JvmField
+    @JvmSynthetic
     internal var previous: Span? = null
 
     fun end(endTime: Long) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
@@ -1,0 +1,35 @@
+@file:JvmName("AttributesJson")
+
+package com.bugsnag.android.performance.internal
+
+import android.util.JsonWriter
+import com.bugsnag.android.performance.Attributes
+
+internal fun JsonWriter.value(value: Attributes): JsonWriter {
+    beginArray()
+
+    value.forEach { (key, value) ->
+        beginObject() // attribute
+            .name("key").value(key)
+            .name("value")
+
+        toAttributeJson(value, this)
+
+        endObject() // attribute
+    }
+
+    return endArray()
+}
+
+private fun toAttributeJson(value: Any, json: JsonWriter) {
+    json.beginObject()
+    when (value) {
+        is String -> json.name("stringValue").value(value)
+        is Float -> json.name("doubleValue").value(value.toDouble())
+        is Double -> json.name("doubleValue").value(value)
+        is Boolean -> json.name("boolValue").value(value)
+        // int64 is JSON encoded as a String
+        is Long, Int, Short, Byte -> json.name("intValue").value(value.toString())
+    }
+    json.endObject()
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanJson.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanJson.kt
@@ -5,7 +5,6 @@ package com.bugsnag.android.performance.internal
 import android.util.JsonWriter
 import com.bugsnag.android.performance.Span
 
-@JvmName("-toJson")
 internal fun Span.toJson(json: JsonWriter) {
     json.beginObject()
         .name("name").value(name)
@@ -14,5 +13,10 @@ internal fun Span.toJson(json: JsonWriter) {
         .name("traceId").value(traceId.toHexString())
         .name("startTimeUnixNano").value(BugsnagClock.elapsedNanosToUnixTime(startTime).toString())
         .name("endTimeUnixNano").value(BugsnagClock.elapsedNanosToUnixTime(endTime).toString())
-        .endObject()
+
+    if (attributes.isNotEmpty()) {
+        json.name("attributes").value(attributes)
+    }
+
+    json.endObject()
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -27,6 +27,11 @@ class SpanJsonTest {
             testSpanProcessor,
         )
 
+        span.setAttribute("fps.average", 61.9)
+        span.setAttribute("frameTime.minimum", 1)
+        span.setAttribute("release", true)
+        span.setAttribute("my.custom.attribute", "Computer, belay that order.")
+
         span.end(currentTime)
 
         val json = StringWriter()
@@ -41,7 +46,25 @@ class SpanJsonTest {
                     "spanId": "00000000decafbad",
                     "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                     "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(0)}",
-                    "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(currentTime)}"
+                    "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(currentTime)}",
+                    "attributes": [
+                        {
+                            "key": "fps.average",
+                            "value": { "doubleValue": 61.9 }
+                        },
+                        {
+                            "key": "frameTime.minimum",
+                            "value": { "intValue": "1" }
+                        },
+                        {
+                            "key": "release",
+                            "value": { "boolValue": true }
+                        },
+                        {
+                            "key": "my.custom.attribute",
+                            "value": { "stringValue": "Computer, belay that order." }
+                        }
+                    ]
                 }
             """.trimIndent(),
             json
@@ -49,21 +72,9 @@ class SpanJsonTest {
     }
 
     private fun assertJsonEquals(expected: String, actual: String) {
-        val expectedObject = JSONObject(expected).toMap()
-        val actualObject = JSONObject(actual).toMap()
+        val expectedObject = JSONObject(expected).toString()
+        val actualObject = JSONObject(actual).toString()
 
         assertEquals(expectedObject, actualObject)
     }
-}
-
-private fun JSONObject.toMap(): Map<String, Any> {
-    val keys = names()!!
-    val content = HashMap<String, Any>(keys.length())
-
-    for (i in 0 until keys.length()) {
-        val key = keys.getString(i)
-        content[key] = get(key)
-    }
-
-    return content
 }

--- a/bugsnag-android-performance/src/test/resources/otel_trace_schema.json
+++ b/bugsnag-android-performance/src/test/resources/otel_trace_schema.json
@@ -75,6 +75,82 @@
         "endTimeUnixNano": {
           "type": "string",
           "pattern": "^-?[0-9]+$"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$def/KeyValue"
+          }
+        },
+        "droppedAttributesCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "AnyValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "stringValue": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "boolValue": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "intValue": {
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[+-]?[0-9]+$"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "doubleValue": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    "KeyValue": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/AnyValue"
+        }
+      }
+    },
+    "KeyValueList": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/KeyValue"
+          }
         }
       }
     }

--- a/examples/performance-exmaple/app/src/main/java/com/example/bugsang/android/performanceexample/MainActivity.kt
+++ b/examples/performance-exmaple/app/src/main/java/com/example/bugsang/android/performanceexample/MainActivity.kt
@@ -1,17 +1,17 @@
 package com.example.bugsang.android.performanceexample
 
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
+import android.view.Menu
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
-import android.view.Menu
-import android.view.MenuItem
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.Span
 import com.example.bugsang.android.performanceexample.databinding.ActivityMainBinding
+import com.google.android.material.snackbar.Snackbar
 
 class MainActivity : AppCompatActivity() {
 


### PR DESCRIPTION
## Goal
Add attributes to `Span`s and encode them into JSON.

## Design
Created a dedicated `Attributes` container class wrapping a `MutableMap` but enforcing the acceptable value types (`String`, `Long`, `Double` and `Boolean` to start with).

The `HasAttributes` interface will serve as a common marker for any objects that may have associated attributes, and also provides default implementations for the overloaded `setAttribute` function.

## Testing
Attributes of each available type were added to the `Span` unit tests.