### PR TITLE
`SpanTracker` to track Spans associated with other objects

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
@@ -18,11 +18,12 @@ class Span internal constructor(
 
     var name: String = name
         set(value) {
-            if (endTime != NO_END_TIME) {
-                throw IllegalStateException("span '$name' is closed and cannot be modified")
-            }
+            check(endTime == NO_END_TIME) { "span '$field' is closed and cannot be modified" }
+            val typeSeparator = field.indexOf('/')
 
-            field = value
+            field =
+                if (typeSeparator == -1) value
+                else field.substring(0, typeSeparator + 1) + value
         }
 
     @set:JvmSynthetic

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -1,0 +1,72 @@
+package com.bugsnag.android.performance.internal
+
+import android.os.SystemClock
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.Span.Companion.NO_END_TIME
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Container for [Span]s that are associated with other objects, which have their own
+ * lifecycles (`Activity`, `Fragment`, etc.). SpanTracker encapsulates tracking of the `Span`s
+ * that *might* be closed automatically *or* manually. As such a `Span` can be
+ * [marked as auto ended](markSpanAutomaticEnd) which will leave the `Span` open, but remember
+ * the `endTime`. If the `Span` is then [marked as leaked](markSpanLeaked) then its "auto end"
+ * time is used to close it.
+ */
+@JvmInline
+internal value class SpanTracker<T>(
+    private val backingStore: MutableMap<T, TrackedSpan> = ConcurrentHashMap<T, TrackedSpan>()
+) {
+    operator fun set(token: T, span: Span) {
+        backingStore[token] = TrackedSpan(span)
+    }
+
+    operator fun get(token: T): Span? {
+        return backingStore[token]?.span
+    }
+
+    /**
+     * Mark when a `Span` would have been ended automatically. *If* the associated `Span` is later
+     * marked as [leaked](markSpanLeaked) then its `endTime` will be set to [autoEndTime]. Otherwise
+     * this value will be discarded.
+     */
+    fun markSpanAutomaticEnd(token: T, autoEndTime: Long = SystemClock.elapsedRealtimeNanos()) {
+        backingStore[token]?.autoEndTime = autoEndTime
+    }
+
+    /**
+     * Attempt to mark a tracked `Span` as "leaked, closing it with its (automatic end)[markSpanAutomaticEnd].
+     * Returns `true` if the `Span` was marked as leaked, or `false` if the `Span` was already
+     * considered to be closed (or was not tracked).
+     */
+    fun markSpanLeaked(token: T): Boolean {
+        return backingStore.remove(token)?.markLeaked() == true
+    }
+
+    /**
+     * End the tracking of a `Span` marking its `endTime` if it has not already been closed.
+     * This *must* be called in order to ensure tokens can be garbage-collected.
+     */
+    fun endSpan(token: T, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
+        backingStore.remove(token)?.span?.end(endTime)
+    }
+
+    internal class TrackedSpan(val span: Span) {
+        var autoEndTime: Long = NO_END_TIME
+
+        fun markLeaked(): Boolean {
+            // this span has not leaked, ignore and return
+            if (span.endTime != NO_END_TIME) {
+                return false
+            }
+
+            if (autoEndTime != NO_END_TIME) {
+                span.end(autoEndTime)
+            } else {
+                span.end()
+            }
+
+            return true
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -30,7 +30,7 @@ class SpanTest {
             span.name = "cannot be renamed"
         }
 
-        assertEquals(newSpanName, span.name)
+        assertEquals("Test/$newSpanName", span.name)
     }
 
     @Test
@@ -65,7 +65,7 @@ class SpanTest {
     }
 
     private fun createTestSpan() = Span(
-        "test span",
+        "Test/test span",
         SpanKind.INTERNAL,
         0L,
         UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -1,0 +1,68 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.testSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class SpanTrackerTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun createSpanFactory() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun testAutomaticEndWithLeak() {
+        val autoEndTime = 100L
+
+        val tracker = SpanTracker<String>()
+        val span = spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        tracker["TestActivity"] = span
+
+        tracker.markSpanAutomaticEnd("TestActivity", autoEndTime)
+        tracker.markSpanLeaked("TestActivity")
+
+        assertEquals(autoEndTime, span.endTime)
+        assertNull(tracker["TestActivity"])
+    }
+
+    @Test
+    fun testAutomaticEndWithManualEnd() {
+        val autoEndTime = 100L
+        val realEndTime = 500L
+
+        val tracker = SpanTracker<String>()
+        val span = spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        tracker["TestActivity"] = span
+
+        // Activity.onResume
+        tracker.markSpanAutomaticEnd("TestActivity", autoEndTime)
+
+        // manually end the returned Span
+        span.end(realEndTime)
+
+        // Activity.onDestroy
+        tracker.markSpanLeaked("TestActivity")
+
+        assertEquals(realEndTime, span.endTime)
+        assertNull(tracker["TestActivity"])
+    }
+
+    @Test
+    fun testNormalEnd() {
+        val endTime = 150L
+
+        val tracker = SpanTracker<String>()
+        val span = spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        tracker["TestActivity"] = span
+
+        tracker.endSpan("TestActivity", endTime)
+
+        assertEquals(endTime, span.endTime)
+        assertNull(tracker["TestActivity"])
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
@@ -15,14 +15,14 @@ class TestSpanFactory {
         name: String = "Test/Span$spanCount",
         kind: SpanKind = SpanKind.INTERNAL,
         startTime: Long = spanCount,
-        endTime: (Long) -> Long = { it + 10L },
+        endTime: ((Long) -> Long)? = { it + 10L },
         traceId: UUID = UUID(0L, spanCount),
         spanId: Long = spanCount,
         processor: SpanProcessor
     ): Span {
         spanCount++
         return Span(name, kind, startTime, traceId, spanId, processor)
-            .apply { end(endTime(startTime)) }
+            .apply { if (endTime != null) end(endTime(startTime)) }
     }
 
     fun newSpans(

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.5.0' apply false
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0' apply false
-    id 'io.gitlab.arturbosch.detekt' version '1.17.1' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.21.0' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
## Goal
The `SpanTracker` encapsulates the tracking span objects that are associated with other objects which have their own lifecycle (`Activity`, `Fragment`, etc.).

## Design
The `SpanTracker` holds strong-references (assuming well defined external lifecycles) to "token" objects which are currently being tracked with an open `Span`. Each `Span` can be marked as "auto closed", closed manually, and marked as "leaked" (when it should have been user-ended but was not). In the case of "leaked" Spans, the "auto close" timestamp is used as its `endTime` - maintaining a reasonable default.

## Testing
New unit tests to test the expected behaviour of `SpanTracker`