### PR TITLE
Secondary scenarios don't always start

### DIFF
--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
@@ -15,12 +15,15 @@ abstract class Scenario(
             scenarioMetadata: String
         ): Scenario {
             try {
+                log("Class.forName(\"com.bugsnag.mazeracer.scenarios.$scenarioName\")")
                 val scenarioClass = Class.forName("com.bugsnag.mazeracer.scenarios.$scenarioName")
+                log("$scenarioName.getConstructor")
                 val constructor = scenarioClass.getConstructor(
                     PerformanceConfiguration::class.java,
                     String::class.java
                 )
 
+                log("$scenarioName.newInstance($config, $scenarioMetadata)")
                 return constructor.newInstance(config, scenarioMetadata) as Scenario
             } catch (cnfe: ClassNotFoundException) {
                 throw IllegalArgumentException("Cannot find scenario class $scenarioName", cnfe)


### PR DESCRIPTION
## Goal
Fix what appeared to be a scenario flake. Upon debugging I found that the scenario was being loaded, but never started causing the test to fail.

## Changeset
Create a dedicated `Handler` linked to the main-thread `Looper` for the test fixture. This avoids relying on the `decorView` and similar structures to get work back onto the main thread.

## Testing
Tests appear to consistently pass now.