### PR TITLE
Add internal utility functions to manipulate span chains

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
@@ -53,10 +53,19 @@ class Span internal constructor(
     @FloatRange(from = 0.0, to = 1.0)
     internal var samplingProbability: Double = 1.0
         internal set(value) {
-            require(field in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
+            require(value in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
             field = value
-            attributes.set("bugsnag.sampling.p", value)
+            attributes["bugsnag.sampling.p"] = value
         }
+
+    /*
+     * Internally Spans form a linked-list when they are queued for delivery. By making each `Span`
+     * into a natural link we avoid needing a dedicated `Link` structure or allocation, we
+     * also avoid the need for an array or List to contain the spans that are pending delivery.
+     */
+    @JvmField
+    @JvmSynthetic
+    internal var previous: Span? = null
 
     init {
         // Our "random" sampling value is actually derived from the traceId

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
@@ -1,0 +1,128 @@
+@file:JvmName("SpanChains")
+
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Span
+
+/**
+ * SpanChain is a type alias of [Span] to be used when a "list" of spans is expected instead of
+ * single span objects.
+ */
+internal typealias SpanChain = Span
+
+/**
+ * *Warning O(n) operation*
+ *
+ * Returns the number of `Span` objects in this `SpanChain`, by counting each  link in the chain.
+ * This should only be called on `SpanChain`s that are stable.
+ *
+ * @see toList
+ */
+internal val SpanChain.size: Int
+    get() {
+        var count = 0
+        var span: Span? = this
+
+        while (span != null) {
+            count++
+            span = span.previous
+        }
+
+        return count
+    }
+
+/**
+ * Find the head of this `SpanChain`, traversing up the chain until a `Span` with no "previous"
+ * node is found. This method should only be invoked on stable `SpanChain`s, that is: those
+ * only accessible be a single thread.
+ */
+internal fun SpanChain.head(): Span {
+    var span = this
+
+    // this awkward little dance of keeping `span.previous` local avoids extra null enforcement, and
+    // slightly side-steps some possible races
+    var previous = span.previous
+
+    while (previous != null) {
+        span = previous
+        previous = span.previous
+    }
+
+    return span
+}
+
+internal inline fun SpanChain.forEach(action: (Span) -> Unit) {
+    var span: Span? = this
+
+    while (span != null) {
+        action(span)
+        span = span.previous
+    }
+}
+
+internal inline fun SpanChain.find(predicate: (Span) -> Boolean): Span? {
+    var span: Span? = this
+    while (span != null) {
+        if (predicate(span)) {
+            return span
+        }
+
+        span = span.previous
+    }
+
+    return null
+}
+
+/**
+ * Filter this span chain (starting at this `SpanChain`) using the given [predicate] and return the
+ * new "tail" of the filtered chain. Unlike normal `filter` operations this is *destructive* once
+ * called the `Span`s in the chain should *only* be accessed by the returned value.
+ *
+ * @see toList
+ */
+internal inline fun SpanChain.filter(predicate: (Span) -> Boolean): Span? {
+    val root = find(predicate) ?: return null
+
+    var span: Span? = root
+    var tail = root
+    while (span != null) {
+        if (!predicate(span)) {
+            tail.previous = span.previous
+            span.previous?.let { tail = it }
+        }
+
+        span = span.previous
+    }
+
+    return root
+}
+
+internal fun SpanChain.toList(): List<Span> {
+    val list = ArrayList<Span>()
+    forEach(list::add)
+    return list
+}
+
+internal fun SpanChain?.isNotEmpty() = this != null
+
+internal fun SpanChain?.isEmpty() = this == null
+
+/**
+ * Join 2 `SpanChain` chains together, the returned `SpanChain` is the *tail* of the joined chain.
+ * This function (like most chain functions) is not thread-safe and should only be used on
+ * `SpanChain` chains where both are stable.
+ */
+@JvmName("concat")
+internal operator fun SpanChain?.plus(other: SpanChain): SpanChain {
+    if (this == null) return other
+    require(other != this) { "cannot join a Span chain to itself" }
+
+    val head = head()
+    if (head.previous != null) {
+        throw ConcurrentModificationException()
+    }
+
+    head.previous = other
+
+    return this
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
@@ -1,0 +1,110 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.testSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SpanChainTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun setupDependencies() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun filterFirstItem() {
+        val span1 = spanFactory.newSpan(spanId = 1L, processor = testSpanProcessor)
+        val span2 = spanFactory.newSpan(spanId = 2L, processor = testSpanProcessor)
+
+        span1.previous = span2
+
+        val filteredChain = span1.filter { it.id != 1L }
+
+        assertSame(span2, filteredChain)
+        assertNull(filteredChain!!.previous)
+    }
+
+    @Test
+    fun filterItems() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.id % 2 == 0L }!!.toList()
+        assertEquals(5, filtered.size)
+        // SpanFactory starts counting at 1
+        assertSame(spans[1], filtered[0]) // id == 2
+        assertSame(spans[3], filtered[1]) // id == 4
+        assertSame(spans[5], filtered[2]) // id == 6
+        assertSame(spans[7], filtered[3]) // id == 8
+        assertSame(spans[9], filtered[4]) // id == 10
+    }
+
+    @Test
+    fun filterAllItems() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.id == -1L }
+        assertNull(filtered)
+    }
+
+    @Test
+    fun filterNothing() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.id != -1L }!!.toList()
+        assertEquals(spans, filtered)
+    }
+
+    @Test
+    fun size() {
+        val spanList = spanFactory.newSpans(25, testSpanProcessor)
+        var chain: Span? = spanList.toSpanChain()
+
+        // assert the chain size is the same for each link in the chain
+        repeat(spanList.size) { index ->
+            assertEquals(spanList.size - index, chain?.size)
+            chain = chain?.previous
+        }
+    }
+
+    @Test
+    fun emptyChecks() {
+        val nullSpan: Span? = null
+        val notNull: Span? = spanFactory.newSpan(processor = testSpanProcessor)
+
+        assertTrue(nullSpan.isEmpty())
+        assertTrue(notNull.isNotEmpty())
+
+        assertFalse(nullSpan.isNotEmpty())
+        assertFalse(notNull.isEmpty())
+    }
+
+    @Test
+    fun concatChains() {
+        val spanList1 = spanFactory.newSpans(6, testSpanProcessor)
+        val spanList2 = spanFactory.newSpans(6, testSpanProcessor)
+
+        val chain = spanList1.toSpanChain() + spanList2.toSpanChain()
+
+        assertSame(chain, spanList1[0])
+        assertEquals(12, chain.size)
+
+        val joinedChains = chain.toList()
+        assertEquals((spanList1 + spanList2).toList(), joinedChains)
+    }
+
+    private fun List<Span>.toSpanChain(): Span {
+        reduce { acc, span -> span.also { acc.previous = span } }
+        return first()
+    }
+}


### PR DESCRIPTION
## Goal
Make it easier to work with chains of `Span` objects by adding extension functions for common `Collections`-like functionality.

## Changelog

Introduced extensions for:

- size
- find
- filter
- forEach
- toList
- isNotEmpty
- isEmpty

## Testing
New unit tests will complete coverage of the new code.