### PR TITLE
Use the latest Maze Runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/performance'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.6.0'
 
 # Or follow master:
 # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 5d9e01124670823aab9c6212d014c62bf335e714
-  branch: integration/performance
+  revision: 8c9505902d81959ceeab926d9a18359934458fb6
+  tag: v7.6.0
   specs:
-    bugsnag-maze-runner (7.2.0)
+    bugsnag-maze-runner (7.6.0)
       appium_lib (~> 12.0)
+      appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -81,11 +82,11 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     multi_test (0.1.2)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (2.0.1)
+    power_assert (2.0.2)
     racc (1.6.0)
     rake (12.3.3)
     rexml (3.2.5)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:integration-performance-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
     environment:
       DEBUG:
       BUILDKITE:


### PR DESCRIPTION
## Goal

Use the latest, formal, release of Maze Runner v7 rather than the integration branch.

## Testing

Covered by CI.