### PR TITLE
[PLAT-9195] Retry queued spans on network establishment

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>EmptyFunctionBlock:BugsnagPerformance.kt$BugsnagPerformance${}</ID>
+    <ID>EmptyFunctionBlock:Connectivity.kt$UnknownConnectivity${}</ID>
     <ID>EmptyFunctionBlock:Tracer.kt$Tracer.&lt;no name provided>${}</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>
     <ID>MagicNumber:Encodings.kt$16</ID>
@@ -19,6 +20,10 @@
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$24L</ID>
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$30000L</ID>
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$60</ID>
+    <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
+    <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
+    <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Tracer.kt$Tracer$e: Exception</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
   </CurrentIssues>

--- a/bugsnag-android-performance/src/main/AndroidManifest.xml
+++ b/bugsnag-android-performance/src/main/AndroidManifest.xml
@@ -2,5 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bugsnag.android.performance">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -5,6 +5,8 @@ import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.SystemClock
+import com.bugsnag.android.performance.internal.Connectivity
+import com.bugsnag.android.performance.internal.ConnectivityCompat
 import com.bugsnag.android.performance.internal.HttpDelivery
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.android.performance.internal.PerformancePlatformCallbacks
@@ -25,6 +27,8 @@ object BugsnagPerformance: ComponentCallbacks2 {
 
     private var isStarted = false
 
+    private var connectivity: Connectivity? = null
+
     @JvmStatic
     fun start(configuration: PerformanceConfiguration) {
         if (!isStarted) {
@@ -35,6 +39,13 @@ object BugsnagPerformance: ComponentCallbacks2 {
                 }
             }
             configuration.context.registerComponentCallbacks(this)
+            connectivity = ConnectivityCompat(configuration.context, {
+                hasConnection, metering ->
+                if (hasConnection) {
+                    tracer.sendNextBatch()
+                }
+            })
+            connectivity!!.registerForNetworkChanges()
         } else {
             logAlreadyStarted()
         }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -1,0 +1,199 @@
+package com.bugsnag.android.performance.internal
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal typealias NetworkChangeCallback = (hasConnection: Boolean, metering: ConnectionMetering) -> Unit
+
+internal enum class ConnectionMetering {
+    DISCONNECTED,
+    UNMETERED,
+    POTENTIALLY_METERED,
+}
+
+internal interface Connectivity {
+    fun registerForNetworkChanges()
+    fun unregisterForNetworkChanges()
+    fun hasNetworkConnection(): Boolean
+    fun metering(): ConnectionMetering
+}
+
+internal class ConnectivityCompat(
+    context: Context,
+    callback: NetworkChangeCallback?
+) : Connectivity {
+
+    private val cm = context.getConnectivityManager()
+
+    private val connectivity: Connectivity =
+        when {
+            cm == null -> UnknownConnectivity
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> ConnectivityApi31(cm, callback)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> ConnectivityApi24(cm, callback)
+            else -> ConnectivityLegacy(context, cm, callback)
+        }
+
+    override fun registerForNetworkChanges() {
+        runCatching { connectivity.registerForNetworkChanges() }
+    }
+
+    override fun hasNetworkConnection(): Boolean {
+        val result = runCatching { connectivity.hasNetworkConnection() }
+        return result.getOrElse { true } // allow network requests to be made if state unknown
+    }
+
+    override fun unregisterForNetworkChanges() {
+        runCatching { connectivity.unregisterForNetworkChanges() }
+    }
+
+    override fun metering(): ConnectionMetering {
+        val result = runCatching { connectivity.metering() }
+        return result.getOrElse { ConnectionMetering.DISCONNECTED }
+    }
+}
+
+@Suppress("DEPRECATION")
+internal class ConnectivityLegacy(
+    private val context: Context,
+    private val cm: ConnectivityManager,
+    callback: NetworkChangeCallback?
+) : Connectivity {
+
+    private val changeReceiver = ConnectivityChangeReceiver(callback)
+
+    private val activeNetworkInfo: android.net.NetworkInfo?
+        get() = try {
+            cm.activeNetworkInfo
+        } catch (e: NullPointerException) {
+            // in some rare cases we get a remote NullPointerException via Parcel.readException
+            null
+        }
+
+    override fun registerForNetworkChanges() {
+        val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+        context.registerReceiverSafe(changeReceiver, intentFilter)
+    }
+
+    override fun unregisterForNetworkChanges() = context.unregisterReceiverSafe(changeReceiver)
+
+    override fun hasNetworkConnection(): Boolean {
+        return activeNetworkInfo?.isConnectedOrConnecting ?: false
+    }
+
+    override fun metering(): ConnectionMetering {
+        return when (activeNetworkInfo?.type) {
+            null -> ConnectionMetering.DISCONNECTED
+            ConnectivityManager.TYPE_WIFI -> ConnectionMetering.UNMETERED
+            ConnectivityManager.TYPE_ETHERNET -> ConnectionMetering.UNMETERED
+            else -> ConnectionMetering.POTENTIALLY_METERED // all other types are cellular in some form
+        }
+    }
+
+    private inner class ConnectivityChangeReceiver(
+        private val cb: NetworkChangeCallback?
+    ) : BroadcastReceiver() {
+
+        private val receivedFirstCallback = AtomicBoolean(false)
+
+        override fun onReceive(context: Context, intent: Intent) {
+            if (receivedFirstCallback.getAndSet(true)) {
+                cb?.invoke(hasNetworkConnection(), metering())
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.N)
+internal open class ConnectivityApi24(
+    internal val cm: ConnectivityManager,
+    callback: NetworkChangeCallback?
+) : Connectivity {
+
+    private val networkCallback = ConnectivityTrackerCallback(callback)
+
+    override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(networkCallback)
+    override fun unregisterForNetworkChanges() = cm.unregisterNetworkCallback(networkCallback)
+    override fun hasNetworkConnection() = cm.activeNetwork != null
+
+    override fun metering(): ConnectionMetering {
+        val network = cm.activeNetwork
+        val capabilities = if (network != null) cm.getNetworkCapabilities(network) else null
+
+        return when {
+            capabilities == null -> ConnectionMetering.DISCONNECTED
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> ConnectionMetering.UNMETERED
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> ConnectionMetering.UNMETERED
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> ConnectionMetering.POTENTIALLY_METERED
+            else -> ConnectionMetering.DISCONNECTED
+        }
+    }
+
+    @VisibleForTesting
+    internal class ConnectivityTrackerCallback(
+        private val cb: NetworkChangeCallback?
+    ) : ConnectivityManager.NetworkCallback() {
+
+        private val receivedFirstCallback = AtomicBoolean(false)
+
+        override fun onUnavailable() {
+            super.onUnavailable()
+            invokeNetworkCallback(false)
+        }
+
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            invokeNetworkCallback(true)
+        }
+
+        /**
+         * Invokes the network callback, as long as the ConnectivityManager callback has been
+         * triggered at least once before (when setting a NetworkCallback Android always
+         * invokes the callback with the current network state).
+         */
+        private fun invokeNetworkCallback(hasConnection: Boolean) {
+            if (receivedFirstCallback.getAndSet(true)) {
+                cb?.invoke(hasConnection, UnknownConnectivity.metering())
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal class ConnectivityApi31(
+    cm: ConnectivityManager,
+    callback: NetworkChangeCallback?
+) : ConnectivityApi24(cm, callback) {
+
+    override fun metering(): ConnectionMetering {
+        val network = cm.activeNetwork
+        val capabilities = if (network != null) cm.getNetworkCapabilities(network) else null
+
+        return when {
+            capabilities == null -> ConnectionMetering.DISCONNECTED
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) ||
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_TEMPORARILY_NOT_METERED)
+            -> ConnectionMetering.UNMETERED
+            else -> super.metering()
+        }
+    }
+}
+
+/**
+ * Connectivity used in cases where we cannot access the system ConnectivityManager.
+ * We assume that there is some sort of network and do not attempt to report any network changes.
+ */
+internal object UnknownConnectivity : Connectivity {
+    override fun registerForNetworkChanges() = Unit
+    override fun unregisterForNetworkChanges() = Unit
+    override fun hasNetworkConnection(): Boolean = true
+    override fun metering(): ConnectionMetering = ConnectionMetering.DISCONNECTED
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
@@ -1,0 +1,75 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.ActivityManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.location.LocationManager
+import android.net.ConnectivityManager
+import android.os.RemoteException
+import android.os.storage.StorageManager
+import android.util.Log
+import java.lang.RuntimeException
+
+/**
+ * Calls [Context.registerReceiver] but swallows [SecurityException] and [RemoteException]
+ * to avoid terminating the process in rare cases where the registration is unsuccessful.
+ */
+internal fun Context.registerReceiverSafe(
+    receiver: BroadcastReceiver?,
+    filter: IntentFilter?
+): Intent? {
+    try {
+        return registerReceiver(receiver, filter)
+    } catch (exc: SecurityException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    } catch (exc: RemoteException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    } catch (exc: IllegalArgumentException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    }
+    return null
+}
+
+/**
+ * Calls [Context.unregisterReceiver] but swallows [SecurityException] and [RemoteException]
+ * to avoid terminating the process in rare cases where the registration is unsuccessful.
+ */
+internal fun Context.unregisterReceiverSafe(
+    receiver: BroadcastReceiver?
+) {
+    try {
+        unregisterReceiver(receiver)
+    } catch (exc: SecurityException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    } catch (exc: RemoteException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    } catch (exc: IllegalArgumentException) {
+        Log.w("BugsnagPerformance", "Failed to register receiver", exc)
+    }
+}
+
+private inline fun <reified T> Context.safeGetSystemService(name: String): T? {
+    return try {
+        getSystemService(name) as? T
+    } catch (exc: RuntimeException) {
+        null
+    }
+}
+
+@JvmName("getActivityManagerFrom")
+internal fun Context.getActivityManager(): ActivityManager? =
+    safeGetSystemService(Context.ACTIVITY_SERVICE)
+
+@JvmName("getConnectivityManagerFrom")
+internal fun Context.getConnectivityManager(): ConnectivityManager? =
+    safeGetSystemService(Context.CONNECTIVITY_SERVICE)
+
+@JvmName("getStorageManagerFrom")
+internal fun Context.getStorageManager(): StorageManager? =
+    safeGetSystemService(Context.STORAGE_SERVICE)
+
+@JvmName("getLocationManager")
+internal fun Context.getLocationManager(): LocationManager? =
+    safeGetSystemService(Context.LOCATION_SERVICE)


### PR DESCRIPTION
## Goal

Code copied from bugsnag-android to retry queued spans when network connectivity is re-established.

I preserved the network connection type code in a slightly modified form since we'll need it in a later phase.

## Testing

Tested manually.
