### PR TITLE
Make `Span.end` thread safe

### DIFF
--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanThreadingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanThreadingTest.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.test.CollectingSpanProcessor
+import com.bugsnag.android.performance.test.TestSpanFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+
+class SpanThreadingTest {
+    private lateinit var spanFactory: TestSpanFactory
+    private lateinit var spanProcessor: CollectingSpanProcessor
+
+    @Before
+    fun newSpanFactory() {
+        spanFactory = TestSpanFactory()
+        spanProcessor = CollectingSpanProcessor()
+    }
+
+    @Test
+    fun threadSafeEnd() {
+        val spans = (0..100).map { spanFactory.newSpan(endTime = null, processor = spanProcessor) }
+        val latch = CountDownLatch(1)
+        val threads = (0..Runtime.getRuntime().availableProcessors()).map { index ->
+            thread(name = "Span-ender $index") {
+                latch.await()
+                spans.forEach { it.end(index + 100L) }
+            }
+        }
+
+        // release the threads
+        latch.countDown()
+
+        // wait for all of the threads to complete processing
+        threads.forEach { it.join() }
+
+        val collectedSpans = spanProcessor.toList()
+        assertEquals(spans.size, collectedSpans.size)
+        assertTrue(collectedSpans.containsAll(spans))
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/CollectingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/CollectingSpanProcessor.kt
@@ -2,9 +2,10 @@ package com.bugsnag.android.performance.test
 
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanProcessor
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class CollectingSpanProcessor : SpanProcessor {
-    private val spans = ArrayList<Span>()
+    private val spans = ConcurrentLinkedQueue<Span>()
 
     fun toList(): List<Span> = spans.sortedBy { it.startTime }
 


### PR DESCRIPTION
## Goal
Make `Span.end` thread safe to ensure that a `Span` cannot be processed twice.

## Changeset
Made `Span.endTime` volatile and used an `AtomicLongFieldUpdater` to CAS the value when `end()` is called, only sending the `Span` for processing if the CAS succeeds.

## Testing
A new unit test using multiple threads to concurrently close a collection of Spans