### PR TITLE
Network type/subtype attributes

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
@@ -16,6 +16,10 @@ class Attributes : Collection<Pair<String, Any>> {
         content[key] = value
     }
 
+    operator fun set(key: String, value: Int) {
+        content[key] = value.toLong()
+    }
+
     operator fun set(key: String, value: Double) {
         content[key] = value
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
@@ -11,6 +11,10 @@ interface HasAttributes {
         attributes[key] = value
     }
 
+    fun setAttribute(key: String, value: Int) {
+        attributes[key] = value
+    }
+
     fun setAttribute(key: String, value: Double) {
         attributes[key] = value
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkType.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkType.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.android.performance
+
+enum class NetworkType(
+    @JvmField
+    internal val otelName: String
+) {
+    WIFI("wifi"),
+    WIRED("wired"),
+    CELL("cell"),
+    UNAVAILABLE("unavailable"),
+    UNKNOWN("unknown"),
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -1,16 +1,28 @@
 package com.bugsnag.android.performance.internal
 
+import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.ConnectivityManager
 import android.net.Network
-import android.net.NetworkCapabilities
+import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
+import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_METERED
+import android.net.NetworkCapabilities.NET_CAPABILITY_TEMPORARILY_NOT_METERED
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_ETHERNET
+import android.net.NetworkCapabilities.TRANSPORT_USB
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build
+import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
-import androidx.annotation.VisibleForTesting
+import com.bugsnag.android.performance.NetworkType
 import java.util.concurrent.atomic.AtomicBoolean
+
+private const val READ_BASIC_PHONE_STATE = "android.permission.READ_BASIC_PHONE_STATE"
+private const val READ_PHONE_STATE = android.Manifest.permission.READ_PHONE_STATE
 
 internal typealias NetworkChangeCallback = (hasConnection: Boolean, metering: ConnectionMetering) -> Unit
 
@@ -21,6 +33,9 @@ internal enum class ConnectionMetering {
 }
 
 internal interface Connectivity {
+    val networkType: NetworkType
+    val networkSubType: String?
+
     fun registerForNetworkChanges()
     fun unregisterForNetworkChanges()
     fun hasNetworkConnection(): Boolean
@@ -37,10 +52,18 @@ internal class ConnectivityCompat(
     private val connectivity: Connectivity =
         when {
             cm == null -> UnknownConnectivity
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> ConnectivityApi31(cm, callback)
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> ConnectivityApi24(cm, callback)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+                ConnectivityApi31(context, cm, callback)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ->
+                ConnectivityApi24(context, cm, callback)
             else -> ConnectivityLegacy(context, cm, callback)
         }
+
+    override val networkType: NetworkType
+        get() = connectivity.networkType
+
+    override val networkSubType: String?
+        get() = connectivity.networkSubType
 
     override fun registerForNetworkChanges() {
         runCatching { connectivity.registerForNetworkChanges() }
@@ -65,10 +88,10 @@ internal class ConnectivityCompat(
 internal class ConnectivityLegacy(
     private val context: Context,
     private val cm: ConnectivityManager,
-    callback: NetworkChangeCallback?
-) : Connectivity {
+    private val callback: NetworkChangeCallback?
+) : BroadcastReceiver(), Connectivity {
 
-    private val changeReceiver = ConnectivityChangeReceiver(callback)
+    private val receivedFirstCallback = AtomicBoolean(false)
 
     private val activeNetworkInfo: android.net.NetworkInfo?
         get() = try {
@@ -78,12 +101,24 @@ internal class ConnectivityLegacy(
             null
         }
 
+    override val networkType: NetworkType
+        get() = when (activeNetworkInfo?.type) {
+            null -> NetworkType.UNAVAILABLE
+            ConnectivityManager.TYPE_WIFI -> NetworkType.WIFI
+            ConnectivityManager.TYPE_MOBILE -> NetworkType.CELL
+            ConnectivityManager.TYPE_ETHERNET -> NetworkType.WIRED
+            else -> NetworkType.UNKNOWN
+        }
+
+    override val networkSubType: String?
+        get() = activeNetworkInfo?.subtypeName
+
     override fun registerForNetworkChanges() {
         val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-        context.registerReceiverSafe(changeReceiver, intentFilter)
+        context.registerReceiverSafe(this, intentFilter)
     }
 
-    override fun unregisterForNetworkChanges() = context.unregisterReceiverSafe(changeReceiver)
+    override fun unregisterForNetworkChanges() = context.unregisterReceiverSafe(this)
 
     override fun hasNetworkConnection(): Boolean {
         return activeNetworkInfo?.isConnectedOrConnecting ?: false
@@ -98,30 +133,73 @@ internal class ConnectivityLegacy(
         }
     }
 
-    private inner class ConnectivityChangeReceiver(
-        private val cb: NetworkChangeCallback?
-    ) : BroadcastReceiver() {
-
-        private val receivedFirstCallback = AtomicBoolean(false)
-
-        override fun onReceive(context: Context, intent: Intent) {
-            if (receivedFirstCallback.getAndSet(true)) {
-                cb?.invoke(hasNetworkConnection(), metering())
-            }
+    override fun onReceive(context: Context, intent: Intent) {
+        // don't send a callback for the first state-update event
+        if (receivedFirstCallback.getAndSet(true)) {
+            callback?.invoke(hasNetworkConnection(), metering())
         }
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.N)
 internal open class ConnectivityApi24(
+    private val context: Context,
     internal val cm: ConnectivityManager,
-    callback: NetworkChangeCallback?
-) : Connectivity {
+    private val callback: NetworkChangeCallback?
+) : ConnectivityManager.NetworkCallback(), Connectivity {
 
-    private val networkCallback = ConnectivityTrackerCallback(callback)
+    private val receivedFirstCallback = AtomicBoolean(false)
+    private val tm: TelephonyManager? = context.getTelephonyManager()
 
-    override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(networkCallback)
-    override fun unregisterForNetworkChanges() = cm.unregisterNetworkCallback(networkCallback)
+    override val networkType: NetworkType
+        get() {
+            val capabilities = cm.getNetworkCapabilities(cm.activeNetwork)
+            return when {
+                capabilities == null -> NetworkType.UNAVAILABLE
+                capabilities.hasTransport(TRANSPORT_ETHERNET) ||
+                    capabilities.hasTransport(TRANSPORT_USB) -> NetworkType.WIRED
+                capabilities.hasTransport(TRANSPORT_WIFI) -> NetworkType.WIFI
+                capabilities.hasTransport(TRANSPORT_CELLULAR) -> NetworkType.CELL
+                else -> NetworkType.UNKNOWN
+            }
+        }
+
+    override val networkSubType: String?
+        @SuppressLint("MissingPermission")
+        get() {
+            if (networkType != NetworkType.CELL || tm == null) {
+                return null
+            }
+
+            if (context.checkCallingPermission(READ_BASIC_PHONE_STATE) == PERMISSION_GRANTED
+                || context.checkCallingPermission(READ_PHONE_STATE) == PERMISSION_GRANTED
+            ) {
+                return when (tm.dataNetworkType) {
+                    TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
+                    TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
+                    TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+                    TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
+                    TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
+                    TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+                    TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
+                    TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
+                    TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
+                    TelephonyManager.NETWORK_TYPE_EVDO_B -> "EVDO_B"
+                    TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
+                    TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
+                    TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
+                    TelephonyManager.NETWORK_TYPE_EHRPD -> "EHRPD"
+                    TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPAP"
+                    TelephonyManager.NETWORK_TYPE_NR -> "NR"
+                    else -> "UNKNOWN"
+                }
+            }
+
+            return null
+        }
+
+    override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(this)
+    override fun unregisterForNetworkChanges() = cm.unregisterNetworkCallback(this)
     override fun hasNetworkConnection() = cm.activeNetwork != null
 
     override fun metering(): ConnectionMetering {
@@ -130,48 +208,45 @@ internal open class ConnectivityApi24(
 
         return when {
             capabilities == null -> ConnectionMetering.DISCONNECTED
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> ConnectionMetering.UNMETERED
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> ConnectionMetering.UNMETERED
-            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> ConnectionMetering.POTENTIALLY_METERED
+            capabilities.hasTransport(TRANSPORT_WIFI) -> ConnectionMetering.UNMETERED
+            capabilities.hasTransport(TRANSPORT_ETHERNET) ||
+                capabilities.hasTransport(TRANSPORT_USB) -> ConnectionMetering.UNMETERED
+            capabilities.hasTransport(TRANSPORT_CELLULAR) -> ConnectionMetering.POTENTIALLY_METERED
             else -> ConnectionMetering.DISCONNECTED
         }
     }
 
-    @VisibleForTesting
-    internal class ConnectivityTrackerCallback(
-        private val cb: NetworkChangeCallback?
-    ) : ConnectivityManager.NetworkCallback() {
+    override fun onUnavailable() {
+        super.onUnavailable()
+        invokeNetworkCallback(false)
+    }
 
-        private val receivedFirstCallback = AtomicBoolean(false)
-
-        override fun onUnavailable() {
-            super.onUnavailable()
-            invokeNetworkCallback(false)
-        }
-
-        override fun onAvailable(network: Network) {
-            super.onAvailable(network)
+    override fun onAvailable(network: Network) {
+        super.onAvailable(network)
+        val capabilities = cm.getNetworkCapabilities(network) ?: return
+        if (capabilities.hasCapability(NET_CAPABILITY_INTERNET)) {
             invokeNetworkCallback(true)
         }
+    }
 
-        /**
-         * Invokes the network callback, as long as the ConnectivityManager callback has been
-         * triggered at least once before (when setting a NetworkCallback Android always
-         * invokes the callback with the current network state).
-         */
-        private fun invokeNetworkCallback(hasConnection: Boolean) {
-            if (receivedFirstCallback.getAndSet(true)) {
-                cb?.invoke(hasConnection, UnknownConnectivity.metering())
-            }
+    /**
+     * Invokes the network callback, as long as the ConnectivityManager callback has been
+     * triggered at least once before (when setting a NetworkCallback Android always
+     * invokes the callback with the current network state).
+     */
+    private fun invokeNetworkCallback(hasConnection: Boolean) {
+        if (receivedFirstCallback.getAndSet(true)) {
+            callback?.invoke(hasConnection, UnknownConnectivity.metering())
         }
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
 internal class ConnectivityApi31(
+    context: Context,
     cm: ConnectivityManager,
     callback: NetworkChangeCallback?
-) : ConnectivityApi24(cm, callback) {
+) : ConnectivityApi24(context, cm, callback) {
 
     override fun metering(): ConnectionMetering {
         val network = cm.activeNetwork
@@ -179,9 +254,9 @@ internal class ConnectivityApi31(
 
         return when {
             capabilities == null -> ConnectionMetering.DISCONNECTED
-            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) ||
-                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_TEMPORARILY_NOT_METERED)
-            -> ConnectionMetering.UNMETERED
+            capabilities.hasCapability(NET_CAPABILITY_NOT_METERED) ||
+                capabilities.hasCapability(NET_CAPABILITY_TEMPORARILY_NOT_METERED) ->
+                ConnectionMetering.UNMETERED
             else -> super.metering()
         }
     }
@@ -192,6 +267,9 @@ internal class ConnectivityApi31(
  * We assume that there is some sort of network and do not attempt to report any network changes.
  */
 internal object UnknownConnectivity : Connectivity {
+    override val networkType: NetworkType get() = NetworkType.UNKNOWN
+    override val networkSubType: String? get() = null
+
     override fun registerForNetworkChanges() = Unit
     override fun unregisterForNetworkChanges() = Unit
     override fun hasNetworkConnection(): Boolean = true

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
@@ -9,8 +9,8 @@ import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.os.RemoteException
 import android.os.storage.StorageManager
+import android.telephony.TelephonyManager
 import android.util.Log
-import java.lang.RuntimeException
 
 /**
  * Calls [Context.registerReceiver] but swallows [SecurityException] and [RemoteException]
@@ -65,6 +65,10 @@ internal fun Context.getActivityManager(): ActivityManager? =
 @JvmName("getConnectivityManagerFrom")
 internal fun Context.getConnectivityManager(): ConnectivityManager? =
     safeGetSystemService(Context.CONNECTIVITY_SERVICE)
+
+@JvmName("getTelephonyManagerFrom")
+internal fun Context.getTelephonyManager(): TelephonyManager? =
+    safeGetSystemService(Context.TELEPHONY_SERVICE)
 
 @JvmName("getStorageManagerFrom")
 internal fun Context.getStorageManager(): StorageManager? =

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
@@ -1,0 +1,15 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.HasAttributes
+
+internal class DefaultAttributeSource(
+    private val connectivity: Connectivity,
+) : AttributeSource {
+    override fun invoke(target: HasAttributes) {
+        target.setAttribute("net.host.connection.type", connectivity.networkType.otelName)
+
+        connectivity.networkSubType?.let { networkSubtype ->
+            target.setAttribute("net.host.connection.subtype", networkSubtype)
+        }
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceComponentCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceComponentCallbacks.kt
@@ -1,0 +1,16 @@
+package com.bugsnag.android.performance.internal
+
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+
+internal class PerformanceComponentCallbacks(private val tracer: Tracer) : ComponentCallbacks2 {
+    override fun onConfigurationChanged(newConfig: Configuration) = Unit
+    override fun onLowMemory() = Unit
+
+    override fun onTrimMemory(level: Int) {
+        if (level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
+            // App has been backgrounded
+            tracer.sendNextBatch()
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.android.performance.internal
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.bugsnag.android.performance.NetworkType
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class Api24NetworkTypeTest {
+    @Test
+    fun wired() {
+        testTransportTye(NetworkCapabilities.TRANSPORT_ETHERNET, NetworkType.WIRED)
+        testTransportTye(NetworkCapabilities.TRANSPORT_USB, NetworkType.WIRED)
+    }
+
+    @Test
+    fun wifi() {
+        testTransportTye(NetworkCapabilities.TRANSPORT_WIFI, NetworkType.WIFI)
+    }
+
+    @Test
+    fun cell() {
+        testTransportTye(NetworkCapabilities.TRANSPORT_CELLULAR, NetworkType.CELL)
+    }
+
+    private fun testTransportTye(transportType: Int, networkType: NetworkType) {
+        val context = mock<Context>()
+        val connectivityManager = mock<ConnectivityManager>()
+
+        val connectivity = ConnectivityApi24(context, connectivityManager) { _, _ -> }
+
+        val networkCapabilities = mock<NetworkCapabilities>()
+        whenever(networkCapabilities.hasTransport(eq(transportType)))
+            .thenReturn(true)
+
+        whenever(connectivityManager.getNetworkCapabilities(isNull()))
+            .thenReturn(networkCapabilities)
+
+        Assert.assertEquals(networkType, connectivity.networkType)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.performance.internal
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import com.bugsnag.android.performance.NetworkType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class LegacyNetworkTypeTest {
+    @Test
+    fun legacyNetworkType() {
+        val context = mock<Context>()
+        val connectivityManager = mock<ConnectivityManager>()
+
+        whenever(connectivityManager.activeNetworkInfo)
+            .thenReturn(newNetworkInfo(ConnectivityManager.TYPE_WIFI))
+            .thenReturn(newNetworkInfo(ConnectivityManager.TYPE_MOBILE))
+            .thenReturn(newNetworkInfo(ConnectivityManager.TYPE_ETHERNET))
+            .thenReturn(newNetworkInfo(ConnectivityManager.TYPE_BLUETOOTH))
+            .thenReturn(null)
+
+        val connectivity = ConnectivityLegacy(context, connectivityManager) { _, _ -> }
+
+        assertEquals(NetworkType.WIFI, connectivity.networkType)
+        assertEquals(NetworkType.CELL, connectivity.networkType)
+        assertEquals(NetworkType.WIRED, connectivity.networkType)
+        assertEquals(NetworkType.UNKNOWN, connectivity.networkType)
+        assertEquals(NetworkType.UNAVAILABLE, connectivity.networkType)
+    }
+
+    private fun newNetworkInfo(type: Int): NetworkInfo = object : NetworkInfo(type, 0, null, null) {
+        override fun getType(): Int = type
+    }
+}

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -2,7 +2,8 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$10</ID>
+    <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
+    <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$90_000L</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$100</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$30</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.mazeracer.scenarios
 
-import android.content.ComponentCallbacks2
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.android.performance.measureSpan
 import com.bugsnag.mazeracer.Scenario
 
@@ -10,19 +10,17 @@ class AppBackgroundedScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String
 ) : Scenario(config, scenarioMetadata) {
+    init {
+        InternalDebug.spanBatchSizeSendTriggerPoint = 100
+        // this should be longer than the Mazerunner timeout
+        InternalDebug.spanBatchTimeoutMs = 90_000L
+    }
+
     override fun startScenario() {
         BugsnagPerformance.start(config)
 
         measureSpan("Span 1") {
             Thread.sleep(1)
         }
-
-        BugsnagPerformance.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
-
-        measureSpan("Span 2") {
-            Thread.sleep(1)
-        }
-
-        Thread.sleep(10)
     }
 }

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -12,6 +12,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" attribute "service.name" equals "com.bugsnag.mazeracer"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.android"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0.0"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "net.host.connection.type" exists
 
   Scenario: Spans can be logged before start
     Given I run "PreStartSpansScenario"
@@ -27,8 +28,8 @@ Feature: Manual creation of spans
     Then a span name equals "Custom/Span 1"
     * a span name equals "Custom/Span 2"
 
-
   Scenario: App backgrounded
     Given I run "AppBackgroundedScenario"
+    And I send the app to the background for 5 seconds
     And I wait to receive 1 traces
     Then a span name equals "Custom/Span 1"


### PR DESCRIPTION
## Goal
Log the active network type & subtype (if available) for every `Span` opened.

## Design
Introduced an `AttributeSource` variable to the `SpanFactory` which is used to populate every new `Span` with an undefined set of attributes.

The `AttributeSource` before `start` is called currently adds no attributes to the `Span`s. `start` replaces the `AttributeSource` with a `DefaultAttributeSource` which contains the logic needed to extract the standard attributes for every `Span` and populate it.

## Testing
Modified end-to-end tests.