### PR TITLE
Added `bugsnag.app.in_foreground` as a Span attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: install test-fixture
+.PHONY: install test-fixture check
+
+check:
+	@./gradlew --continue detekt lint ktlintCheck test
+	@cd features/fixtures/mazeracer && ./gradlew ktlintCheck detekt
 
 install:
 	@./gradlew -PVERSION_NAME=9.9.9 clean publishToMavenLocal

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -2,8 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>EmptyFunctionBlock:BugsnagPerformance.kt$BugsnagPerformance${}</ID>
-    <ID>EmptyFunctionBlock:Connectivity.kt$UnknownConnectivity${}</ID>
     <ID>EmptyFunctionBlock:Tracer.kt$Tracer.&lt;no name provided>${}</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>
     <ID>MagicNumber:Encodings.kt$16</ID>
@@ -22,9 +20,10 @@
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$60</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>SwallowedException:ForegroundTracker.kt$ForegroundTracker$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:ForegroundTracker.kt$ForegroundTracker$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Tracer.kt$Tracer$e: Exception</ID>
-    <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
@@ -11,5 +11,9 @@ internal class DefaultAttributeSource(
         connectivity.networkSubType?.let { networkSubtype ->
             target.setAttribute("net.host.connection.subtype", networkSubtype)
         }
+
+        ForegroundTracker.isInForeground?.let { inForeground ->
+            target.setAttribute("bugsnag.app.in_foreground", inForeground)
+        }
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ForegroundTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ForegroundTracker.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo
+
+private const val IMPORTANCE_FOREGROUND_SERVICE = 125
+
+internal object ForegroundTracker {
+    /**
+     * Determines whether or not the application is in the foreground, by using the process'
+     * importance as a proxy.
+     *
+     * In the unlikely event that information about the process cannot be retrieved, this method
+     * will return null, and the 'bugsnag.app.in_foreground' attribute will not be added to
+     * new `Span`s.
+     *
+     * @return whether the application is in the foreground or not
+     */
+    val isInForeground: Boolean?
+        get() = try {
+            processInfo.importance <= IMPORTANCE_FOREGROUND_SERVICE
+        } catch (exc: RuntimeException) {
+            null
+        }
+
+    private val processInfo: RunningAppProcessInfo
+        get() {
+            val info = RunningAppProcessInfo()
+            ActivityManager.getMyMemoryState(info)
+            return info
+        }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ForegroundTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ForegroundTrackerTest.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED
+import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+import com.bugsnag.android.performance.test.withStaticMock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+
+internal class ForegroundTrackerTest {
+    @Test
+    fun testInForeground() = withStaticMock<ActivityManager> { activityManager ->
+        activityManager.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+            .then { answer ->
+                val runningInfo = answer.arguments[0] as ActivityManager.RunningAppProcessInfo
+                runningInfo.importance = IMPORTANCE_FOREGROUND
+
+                Unit
+            }
+
+        assertEquals(true, ForegroundTracker.isInForeground)
+    }
+
+    @Test
+    fun testInBackground() = withStaticMock<ActivityManager> { activityManager ->
+        activityManager.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+            .then { answer ->
+                val runningInfo = answer.arguments[0] as ActivityManager.RunningAppProcessInfo
+                runningInfo.importance = IMPORTANCE_CACHED
+
+                Unit
+            }
+
+        assertEquals(false, ForegroundTracker.isInForeground)
+    }
+
+    @Test
+    fun testFailure() = withStaticMock<ActivityManager> { activityManager ->
+        activityManager.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+            .thenThrow(RuntimeException())
+
+        assertNull(ForegroundTracker.isInForeground)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@Suppress("DEPRECATION")
 class LegacyNetworkTypeTest {
     @Test
     fun legacyNetworkType() {

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -13,6 +13,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.android"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0.0"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "net.host.connection.type" exists
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.app.in_foreground" is true
 
   Scenario: Spans can be logged before start
     Given I run "PreStartSpansScenario"


### PR DESCRIPTION
## Goal
Add a new "bugsnag.app.in_foreground" attribute to `Span`s that are opened after `start` has been called.

## Testing
Check for the new attribute in an end to end test