### PR TITLE
Add Gradle config for Sonatype publishing

### DIFF
--- a/bugsnag-android-performance/build.gradle
+++ b/bugsnag-android-performance/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'maven-publish'
 }
 
+apply from: '../gradle/release.gradle'
+
 version = "${project.VERSION_NAME}"
 group = "${project.GROUP}"
 
@@ -24,6 +26,12 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
         }
     }
     testOptions {
@@ -53,19 +61,6 @@ dependencies {
     testImplementation 'net.jimblackler.jsonschemafriend:core:0.11.4'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-}
-
-project.afterEvaluate {
-    publishing {
-        publications {
-            SDK(MavenPublication) {
-                from components.release
-                groupId = "com.bugsnag"
-                artifactId = archivesBaseName
-                version = version
-            }
-        }
-    }
 }
 
 detekt {

--- a/bugsnag-android-performance/gradle.properties
+++ b/bugsnag-android-performance/gradle.properties
@@ -1,0 +1,2 @@
+pomName=Bugsnag Android Performance
+artefactId=bugsnag-android-performance

--- a/bugsnag-plugin-android-performance-okhttp/build.gradle
+++ b/bugsnag-plugin-android-performance-okhttp/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'maven-publish'
 }
 
+apply from: '../gradle/release.gradle'
+
 version = "${project.VERSION_NAME}"
 group = "${project.GROUP}"
 
@@ -24,6 +26,12 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
         }
     }
     testOptions {
@@ -56,19 +64,6 @@ dependencies {
     implementation project(':bugsnag-android-performance')
     compileOnly("com.squareup.okhttp3:okhttp:4.9.1")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
-}
-
-project.afterEvaluate {
-    publishing {
-        publications {
-            SDK(MavenPublication) {
-                from components.release
-                groupId = "com.bugsnag"
-                artifactId = archivesBaseName
-                version = version
-            }
-        }
-    }
 }
 
 detekt {

--- a/bugsnag-plugin-android-performance-okhttp/gradle.properties
+++ b/bugsnag-plugin-android-performance-okhttp/gradle.properties
@@ -1,0 +1,2 @@
+pomName=Bugsnag Android Performance OkHttp
+artefactId=bugsnag-android-performance-okhttp

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,15 @@
 GROUP=com.bugsnag
 VERSION_NAME=0.0.0
 
+POM_SCM_URL=https://github.com/bugsnag/bugsnag-android-performance
+POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android-performance.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android-performance.git
+POM_LICENCE_NAME=MIT
+POM_LICENCE_URL=https://opensource.org/licenses/MIT
+POM_LICENCE_DIST=repo
+POM_DESCRIPTION=Official Bugsnag performance monitoring for Android applications
+POM_URL=https://bugsnag.com
+
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,0 +1,46 @@
+// https://developer.android.com/studio/build/maven-publish-plugin
+project.afterEvaluate {
+    publishing {
+
+        repositories {
+            maven {
+                if (VERSION_NAME.contains("SNAPSHOT")) {
+                    url "https://oss.sonatype.org/content/repositories/snapshots/"
+                } else {
+                    url "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                }
+                credentials {
+                    username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+                    password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
+                }
+            }
+        }
+
+        publications {
+            SDK(MavenPublication) {
+                from components.release
+                groupId = "com.bugsnag"
+                artifactId = archivesBaseName
+                version = version
+
+                pom {
+                    name = pomName
+                    description = project.POM_DESCRIPTION
+                    url = project.POM_URL
+                    licenses {
+                        license {
+                            name = project.POM_LICENCE_NAME
+                            url = project.POM_LICENCE_URL
+                            distribution = project.POM_LICENCE_DIST
+                        }
+                    }
+                    scm {
+                        connection = project.POM_SCM_CONNECTION
+                        developerConnection = project.POM_SCM_DEV_CONNECTION
+                        url = project.POM_SCM_URL
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Allow automated release publishing to Sonatype using Gradle.

## Testing
Tested by publishing to a staging repository on Sonatype, and then dropping the repository.