### PR TITLE
Set the default endpoint

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -7,7 +7,7 @@ class PerformanceConfiguration(val context: Context) {
 
     var apiKey: String? = null
 
-    var endpoint: String = "https://localhost:8888/performance"
+    var endpoint: String = "https://otlp.bugsnag.com/v1/traces"
 
     var autoInstrumentAppStarts = true
 


### PR DESCRIPTION
## Goal
Change the default `endpoint` to `https://otlp.bugsnag.com/v1/traces`