### PR TITLE
Replace Timer & BlockingQueue with timed condition

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -30,7 +30,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
     @FloatRange(from = 0.0, to = 1.0)
     var samplingProbability: Double = 1.0
         set(value) {
-            require(field in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
+            require(value in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
             field = value
         }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.test.StubDelivery
 import com.bugsnag.android.performance.test.endedSpans
 import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
@@ -12,29 +13,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-
-class StubDelivery : Delivery {
-    var nextResult: DeliveryResult = DeliveryResult.SUCCESS
-    var lastAttempt: Collection<Span> = listOf()
-
-    fun reset(nextResult: DeliveryResult) {
-        this.nextResult = nextResult
-        lastAttempt = listOf()
-    }
-
-    override fun deliver(
-        spans: Collection<Span>,
-        resourceAttributes: Attributes,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult {
-        lastAttempt = spans
-        return nextResult
-    }
-
-    override fun fetchCurrentProbability(newPCallback: NewProbabilityCallback) {
-        // Nothing to do
-    }
-}
 
 @RunWith(RobolectricTestRunner::class)
 class RetryDeliveryTest {
@@ -62,7 +40,7 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         // No new probability value
         stub.reset(DeliveryResult.SUCCESS)
@@ -80,7 +58,7 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         // Callback and new probability value
         stub.reset(DeliveryResult.SUCCESS)
@@ -98,7 +76,7 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
     }
 
     @Test
@@ -123,11 +101,11 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         stub.reset(DeliveryResult.FAIL_RETRIABLE)
         retry.deliver(listOf(), attributes, null)
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         stub.reset(DeliveryResult.SUCCESS)
         retry.deliver(
@@ -144,11 +122,11 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(2, stub.lastAttempt.size)
+        assertEquals(2, stub.lastAttempt?.size)
 
         stub.reset(DeliveryResult.SUCCESS)
         retry.deliver(listOf(), attributes, null)
-        assertEquals(0, stub.lastAttempt.size)
+        assertEquals(0, stub.lastAttempt?.size)
     }
 
     @Test
@@ -174,13 +152,13 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         SystemClock.setCurrentTimeMillis(startTime + 1000)
 
         stub.reset(DeliveryResult.FAIL_RETRIABLE)
         retry.deliver(listOf(), attributes, null)
-        assertEquals(0, stub.lastAttempt.size)
+        assertEquals(0, stub.lastAttempt?.size)
 
         stub.reset(DeliveryResult.SUCCESS)
         retry.deliver(
@@ -197,11 +175,11 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         stub.reset(DeliveryResult.SUCCESS)
         retry.deliver(listOf(), attributes, null)
-        assertEquals(0, stub.lastAttempt.size)
+        assertEquals(0, stub.lastAttempt?.size)
     }
 
     @Test
@@ -226,9 +204,9 @@ class RetryDeliveryTest {
             attributes,
             null
         )
-        assertEquals(1, stub.lastAttempt.size)
+        assertEquals(1, stub.lastAttempt?.size)
 
         retry.deliver(listOf(), attributes, null)
-        assertEquals(0, stub.lastAttempt.size)
+        assertEquals(0, stub.lastAttempt?.size)
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.performance.internal
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.test.CollectingSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.withDebugValues
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,12 +21,15 @@ class SamplerTest {
     }
 
     @Test
-    fun testPExpiry() {
+    fun testPExpiry() = InternalDebug.withDebugValues {
         val oldExpiry = InternalDebug.pValueExpireAfterMs
         InternalDebug.pValueExpireAfterMs = 10
         val sampler = Sampler(1.0)
         sampler.probability = 0.2
-        val span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE))
+        val span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
         assertTrue(sampler.probability == 0.2)
         Thread.sleep(100)
@@ -39,35 +43,65 @@ class SamplerTest {
         val sampler = Sampler(1.0)
         var span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0))
         assertTrue(sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+        )
         assertTrue(sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE)
+        )
         assertTrue(sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(1000000000)
+        )
         assertTrue(sampler.shouldKeepSpan(span))
     }
 
     @Test
     fun testSampleSpanProbability0() {
         val sampler = Sampler(0.0)
-        var span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0))
+        var span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(0)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(1000000000)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
     }
 
     @Test
     fun testSampleSpanProbability0_5() {
         val sampler = Sampler(0.5)
-        var span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0))
+        var span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(0)
+        )
         assertTrue(sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+        )
         assertTrue(!sampler.shouldKeepSpan(span))
-        span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE - 10000))
+        span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(Long.MAX_VALUE - 10000)
+        )
         assertTrue(sampler.shouldKeepSpan(span))
     }
 
@@ -76,9 +110,18 @@ class SamplerTest {
         val sampler = Sampler(1.0)
         val batch = listOf<Span>(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            ),
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(Long.MAX_VALUE)
+            ),
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(1000000000)
+            )
         )
         val sampled = sampler.sampled(batch)
         assertTrue(sampled.size == 4)
@@ -89,9 +132,15 @@ class SamplerTest {
         val sampler = Sampler(0.0)
         val batch = listOf<Span>(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1)),
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            ),
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(1000000000)
+            )
         )
         val sampled = sampler.sampled(batch)
         assertTrue(sampled.size == 0)
@@ -102,8 +151,14 @@ class SamplerTest {
         val sampler = Sampler(0.5)
         val batch = listOf<Span>(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE shl 1)),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE - 10000)),
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            ),
+            spanFactory.newSpan(
+                processor = spanProcessor,
+                traceId = uuidWithUpper(Long.MAX_VALUE - 10000)
+            ),
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
         )
         val sampled = sampler.sampled(batch)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
@@ -1,0 +1,98 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.test.StubDelivery
+import com.bugsnag.android.performance.test.withDebugValues
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class TracerTest {
+    private lateinit var stubDelivery: StubDelivery
+    private lateinit var tracer: Tracer
+
+    @Before
+    fun createTracer() {
+        tracer = Tracer()
+        stubDelivery = StubDelivery()
+    }
+
+    @After
+    fun destroyTracer() {
+        tracer.stop()
+    }
+
+    @Test
+    fun testBatchTimeout() = InternalDebug.withDebugValues {
+        InternalDebug.spanBatchTimeoutMs = 50
+
+        val spanFactory = SpanFactory(tracer)
+
+        tracer.start(
+            PerformanceConfiguration(
+                RuntimeEnvironment.getApplication(),
+                "decafbaddecafbaddecafbaddecafbad"
+            )
+        )
+
+        // swap the standard delivery for our stub
+        tracer.delivery = stubDelivery
+
+        spanFactory.createCustomSpan("BatchTimeout", 1L).end(10L)
+
+        // assert it was not delivered immediately (timeout is 50ms)
+        assertNull(stubDelivery.lastAttempt)
+        stubDelivery.awaitDelivery()
+        assertEquals(1, stubDelivery.lastAttempt?.size)
+
+        stubDelivery.reset(DeliveryResult.SUCCESS)
+
+        // we deliver another two to ensure that the loop behaves as expected
+        spanFactory.createCustomSpan("BatchTimeout2", 2L).end(20L)
+        spanFactory.createCustomSpan("BatchTimeout3", 3L).end(30L)
+
+        stubDelivery.awaitDelivery()
+        assertEquals(2, stubDelivery.lastAttempt?.size)
+    }
+
+    @Test
+    fun testBatchSize() = InternalDebug.withDebugValues {
+        InternalDebug.spanBatchSizeSendTriggerPoint = 2
+
+        val spanFactory = SpanFactory(tracer)
+
+        tracer.start(
+            PerformanceConfiguration(
+                RuntimeEnvironment.getApplication(),
+                "decafbaddecafbaddecafbaddecafbad"
+            )
+        )
+
+        // swap the standard delivery for our stub
+        tracer.delivery = stubDelivery
+
+        spanFactory.createCustomSpan("BatchSize1.1", 1L).end(10L)
+
+        // assert it was not delivered immediately (the batch size is 2)
+        assertNull(stubDelivery.lastAttempt)
+        spanFactory.createCustomSpan("BatchSize1.2", 1L).end(10L)
+        // give the delivery thread time to wake up and do it's work
+        stubDelivery.awaitDelivery(500L)
+        assertEquals(2, stubDelivery.lastAttempt?.size)
+
+        stubDelivery.reset(DeliveryResult.SUCCESS)
+
+        // we deliver another two to ensure that the loop behaves as expected
+        spanFactory.createCustomSpan("BatchSize2.1", 2L).end(20L)
+        spanFactory.createCustomSpan("BatchSize2.2", 3L).end(30L)
+
+        stubDelivery.awaitDelivery(500L)
+        assertEquals(2, stubDelivery.lastAttempt?.size)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/InternalDebugExtensions.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/InternalDebugExtensions.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.performance.test
+
+import com.bugsnag.android.performance.internal.InternalDebug
+
+/**
+ * Run the given block and then restore all of the `InternalDebug` values to their previous values.
+ */
+inline fun <R> InternalDebug.withDebugValues(block: () -> R): R {
+    val oldSpanBatchSizeSendTriggerPoint = spanBatchSizeSendTriggerPoint
+    val oldSpanBatchTimeoutMs = spanBatchTimeoutMs
+    val oldDropSpansOlderThanMs = dropSpansOlderThanMs
+    val oldPValueExpireAfterMs = pValueExpireAfterMs
+
+    try {
+        return block()
+    } finally {
+        spanBatchSizeSendTriggerPoint = oldSpanBatchSizeSendTriggerPoint
+        spanBatchTimeoutMs = oldSpanBatchTimeoutMs
+        dropSpansOlderThanMs = oldDropSpansOlderThanMs
+        pValueExpireAfterMs = oldPValueExpireAfterMs
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
@@ -1,0 +1,45 @@
+package com.bugsnag.android.performance.test
+
+import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.internal.Delivery
+import com.bugsnag.android.performance.internal.DeliveryResult
+import com.bugsnag.android.performance.internal.NewProbabilityCallback
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+class StubDelivery : Delivery {
+    var nextResult: DeliveryResult = DeliveryResult.SUCCESS
+    var lastAttempt: Collection<Span>? = null
+
+    private val lock = ReentrantLock(false)
+    private val deliveryCondition = lock.newCondition()
+
+    fun awaitDelivery(timeout: Long = 60_000L) {
+        lock.withLock {
+            if (lastAttempt == null) {
+                deliveryCondition.await(timeout, TimeUnit.MILLISECONDS)
+            }
+        }
+    }
+
+    fun reset(nextResult: DeliveryResult) {
+        this.nextResult = nextResult
+        lastAttempt = null
+    }
+
+    override fun deliver(
+        spans: Collection<Span>,
+        resourceAttributes: Attributes,
+        newProbabilityCallback: NewProbabilityCallback?
+    ): DeliveryResult {
+        lock.withLock {
+            lastAttempt = spans
+            deliveryCondition.signalAll()
+            return nextResult
+        }
+    }
+
+    override fun fetchCurrentProbability(newPCallback: NewProbabilityCallback) = Unit
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -132,6 +132,9 @@ class MainActivity : AppCompatActivity() {
                                 polling = false
                                 runScenario(scenarioName, scenarioMetadata, endpointUrl)
                             }
+                            "load_scenario" -> {
+                                loadScenario(scenarioName, scenarioMetadata, endpointUrl)
+                            }
                             else -> throw IllegalArgumentException("Unknown action: $action")
                         }
                     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryScenario.kt
@@ -4,6 +4,7 @@ import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.Scenario
+import java.util.concurrent.TimeUnit
 
 class RetryScenario(
     config: PerformanceConfiguration,
@@ -11,6 +12,7 @@ class RetryScenario(
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
+        InternalDebug.spanBatchTimeoutMs = TimeUnit.SECONDS.toMillis(1)
     }
 
     override fun startScenario() {

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -28,8 +28,9 @@ Feature: Automatic creation of spans
   Scenario: AppStart instrumentation
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
-    Then I wait to receive 2 traces
-    And I discard the oldest trace
+    * I load scenario "AppStartScenario"
+    * I wait to receive 2 traces
+    * I discard the oldest trace
     * a span name equals "AppStart/Cold"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "app_start"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.app_start.type" equals "cold"

--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -23,6 +23,10 @@ When('I run {string} configured as {string}') do |scenario_name, scenario_metada
   execute_command 'run_scenario', scenario_name, scenario_metadata
 end
 
+When('I load scenario {string}') do |scenario_name|
+  execute_command 'load_scenario', scenario_name
+end
+
 When("I relaunch the app after shutdown") do
   max_attempts = 20
   attempts = 0


### PR DESCRIPTION
## Goal
Replace the use of `Timer` and `BlockingQueue` in `Tracer` with a `ReentrantLock` and timed `await`.

## Design
`Timer` requires an additional thread to process the timer tasks, and our use of it required cancelling and replacing the delivery tasks adding to the overhead.

Using a `ReentrantLock` and `Condition` allows the delivery thread to wait until either our expected timeout or the batch is considered full using a single blocking call, reducing the number of threads and the complexity of our inter-thread signals.

## Testing
A new unit test was added for the `Tracer`