### PR TITLE
Include the Bugsnag-Api-Key HTTP header in traces requests

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -9,7 +9,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
 
-internal class HttpDelivery(private val endpoint: String) : Delivery {
+internal class HttpDelivery(private val endpoint: String, private val apiKey: String) : Delivery {
     override fun deliver(spans: Collection<Span>, resourceAttributes: Attributes): DeliveryResult {
         if (spans.isEmpty()) {
             return DeliveryResult.SUCCESS
@@ -19,7 +19,10 @@ internal class HttpDelivery(private val endpoint: String) : Delivery {
 
         val connection = URL(endpoint).openConnection() as HttpURLConnection
         with(connection) {
+            requestMethod = "POST"
+
             setFixedLengthStreamingMode(payload.size)
+            setRequestProperty("Bugsnag-Api-Key", apiKey)
             setRequestProperty("Content-Encoding", "application/json")
             computeSha1Digest(payload)?.let { digest ->
                 setRequestProperty("Bugsnag-Integrity", digest)
@@ -85,6 +88,8 @@ internal class HttpDelivery(private val endpoint: String) : Delivery {
             }
         }.getOrElse { return null }
     }
+
+    override fun toString(): String = "HttpDelivery(\"$endpoint\")"
 
     companion object {
         private val retriable400Codes = setOf(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
@@ -21,4 +21,6 @@ class RetryDelivery(private val dropOlderThanMs: Long, private val delivery: Del
         }
         return result
     }
+
+    override fun toString(): String = "RetryDelivery($delivery)"
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
@@ -76,6 +76,7 @@ internal class Tracer : SpanProcessor, Runnable {
         while (running) {
             try {
                 val nextBatch = batchSendQueue.take()
+                Logger.d("Sending a batch of ${nextBatch.size} spans to $delivery")
                 delivery.deliver(nextBatch, resourceAttributes)
             } catch (e: Exception) {
                 Logger.e("Unexpected exception", e)
@@ -90,7 +91,12 @@ internal class Tracer : SpanProcessor, Runnable {
 
         val delivery = RetryDelivery(
             InternalDebug.dropSpansOlderThanMs,
-            HttpDelivery(configuration.endpoint)
+            HttpDelivery(
+                configuration.endpoint,
+                requireNotNull(configuration.apiKey) {
+                    "PerformanceConfiguration.apiKey may not be null"
+                }
+            )
         )
 
         this.delivery = delivery

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
@@ -36,7 +36,7 @@ class HttpDeliveryTest {
         span2.end(11L)
         val spans = listOf(span1, span2)
 
-        val delivery = HttpDelivery("")
+        val delivery = HttpDelivery("", "")
         val content = delivery.encodeSpanPayload(
             spans,
             Attributes().also { attrs ->

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -3,7 +3,9 @@ Feature: Manual creation of spans
   Scenario: Manual spans can be logged
     Given I run "ManualSpanScenario"
     And I wait to receive 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
+    Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"


### PR DESCRIPTION
## Goal
Send the configured apiKey in the `Bugsnag-Api-Key` header when sending traces.

## Changelog

This change also includes a small improvement to debugging, logging the number of spans in a batch and the `Delivery` information being used.

## Testing
New checks added to the manual spans end to end test.