### PR TITLE
Updated to an OTEL schema

### DIFF
--- a/bugsnag-android-performance/src/test/resources/otel_trace_schema.json
+++ b/bugsnag-android-performance/src/test/resources/otel_trace_schema.json
@@ -1,169 +1,390 @@
 {
-  "type": "object",
-  "properties": {
-    "resource": {
-      "type": "object",
-      "properties": {
-        "attributes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$def/KeyValue"
-          }
-        }
-      }
-    },
-    "resourceSpans": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/ResourceSpan"
-      }
-    }
-  },
-  "$defs": {
-    "ResourceSpan": {
-      "type": "object",
-      "properties": {
-        "scopeSpans": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ScopeSpan"
-          }
-        },
-        "schemaUrl": {
-          "type": "string"
-        }
-      }
-    },
-    "ScopeSpan": {
-      "type": "object",
-      "properties": {
-        "spans": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Span"
-          }
-        }
-      }
-    },
-    "Span": {
-      "type": "object",
-      "properties": {
-        "traceId": {
-          "type": "string",
-          "format": "hex",
-          "pattern": "^[0-9a-fA-F]{32}$"
-        },
-        "spanId": {
-          "type": "string",
-          "format": "hex",
-          "pattern": "^[0-9a-fA-F]{16}$"
-        },
-        "traceState": {
-          "type": "string"
-        },
-        "parentSpanId": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]{16}$"
-        },
-        "name": {
-          "type": "string"
-        },
-        "kind": {
-          "type": "string",
-          "enum": [
-            "SPAN_KIND_UNSPECIFIED",
-            "SPAN_KIND_INTERNAL",
-            "SPAN_KIND_SERVER",
-            "SPAN_KIND_CLIENT",
-            "SPAN_KIND_PRODUCER",
-            "SPAN_KIND_CONSUMER"
-          ]
-        },
-        "startTimeUnixNano": {
-          "type": "string",
-          "pattern": "^-?[0-9]+$"
-        },
-        "endTimeUnixNano": {
-          "type": "string",
-          "pattern": "^-?[0-9]+$"
-        },
-        "attributes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$def/KeyValue"
-          }
-        },
-        "droppedAttributesCount": {
-          "type": "integer",
-          "minimum": 0
-        }
-      }
-    },
-    "AnyValue": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "stringValue": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "boolValue": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "intValue": {
-              "oneOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "pattern": "^[+-]?[0-9]+$"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/TracesData",
+    "definitions": {
+        "TracesData": {
+            "properties": {
+                "resourceSpans": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.trace.v1.ResourceSpans"
+                    },
+                    "type": "array",
+                    "description": "An array of ResourceSpans. For data coming from a single resource this array will typically contain one element. Intermediary nodes that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements."
                 }
-              ]
-            }
-          }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Traces Data",
+            "description": "TracesData represents the traces data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP traces data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any \"control\" or \"metadata\" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well."
         },
-        {
-          "type": "object",
-          "properties": {
-            "doubleValue": {
-              "type": "number"
-            }
-          }
-        }
-      ]
-    },
-    "KeyValue": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
+        "opentelemetry.proto.common.v1.AnyValue": {
+            "properties": {
+                "stringValue": {
+                    "type": "string"
+                },
+                "boolValue": {
+                    "type": "boolean"
+                },
+                "intValue": {
+                    "type": "string"
+                },
+                "doubleValue": {
+                    "type": "number"
+                },
+                "arrayValue": {
+                    "$ref": "#/definitions/opentelemetry.proto.common.v1.ArrayValue",
+                    "additionalProperties": false
+                },
+                "kvlistValue": {
+                    "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValueList",
+                    "additionalProperties": false
+                },
+                "bytesValue": {
+                    "type": "string",
+                    "format": "binary",
+                    "binaryEncoding": "base64"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Any Value",
+            "description": "AnyValue is used to represent any type of attribute value. AnyValue may contain a primitive value such as a string or integer or it may contain an arbitrary nested object containing arrays, key-value lists and primitives."
         },
-        "value": {
-          "$ref": "#/$defs/AnyValue"
+        "opentelemetry.proto.common.v1.ArrayValue": {
+            "properties": {
+                "values": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.AnyValue"
+                    },
+                    "type": "array",
+                    "description": "Array of values. The array may be empty (contain 0 elements)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Array Value",
+            "description": "ArrayValue is a list of AnyValue messages. We need ArrayValue as a message since oneof in AnyValue does not allow repeated fields."
+        },
+        "opentelemetry.proto.common.v1.InstrumentationScope": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "An empty instrumentation scope name means the name is unknown."
+                },
+                "version": {
+                    "type": "string"
+                },
+                "attributes": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array"
+                },
+                "droppedAttributesCount": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Instrumentation Scope",
+            "description": "InstrumentationScope is a message representing the instrumentation scope information such as the fully qualified name and version."
+        },
+        "opentelemetry.proto.common.v1.KeyValue": {
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/opentelemetry.proto.common.v1.AnyValue",
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Key Value",
+            "description": "KeyValue is a key-value pair that is used to store Span attributes, Link attributes, etc."
+        },
+        "opentelemetry.proto.common.v1.KeyValueList": {
+            "properties": {
+                "values": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array",
+                    "description": "A collection of key/value pairs of key-value pairs. The list may be empty (may contain 0 elements). The keys MUST be unique (it is not allowed to have more than one value with the same key)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Key Value List",
+            "description": "KeyValueList is a list of KeyValue messages. We need KeyValueList as a message since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches are semantically equivalent."
+        },
+        "opentelemetry.proto.resource.v1.Resource": {
+            "properties": {
+                "attributes": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array",
+                    "description": "Set of attributes that describe the resource. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key)."
+                },
+                "droppedAttributesCount": {
+                    "type": "integer",
+                    "description": "dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Resource",
+            "description": "Resource information."
+        },
+        "opentelemetry.proto.trace.v1.ResourceSpans": {
+            "properties": {
+                "resource": {
+                    "$ref": "#/definitions/opentelemetry.proto.resource.v1.Resource",
+                    "additionalProperties": false,
+                    "description": "The resource for the spans in this message. If this field is not set then no resource info is known."
+                },
+                "scopeSpans": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.trace.v1.ScopeSpans"
+                    },
+                    "type": "array",
+                    "description": "A list of ScopeSpans that originate from a resource."
+                },
+                "schemaUrl": {
+                    "type": "string",
+                    "description": "This schema_url applies to the data in the \"resource\" field. It does not apply to the data in the \"scope_spans\" field which have their own schema_url field."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Resource Spans",
+            "description": "A collection of ScopeSpans from a Resource."
+        },
+        "opentelemetry.proto.trace.v1.ScopeSpans": {
+            "properties": {
+                "scope": {
+                    "$ref": "#/definitions/opentelemetry.proto.common.v1.InstrumentationScope",
+                    "additionalProperties": false,
+                    "description": "The instrumentation scope information for the spans in this message. Semantically when InstrumentationScope isn't set, it is equivalent with an empty instrumentation scope name (unknown)."
+                },
+                "spans": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.trace.v1.Span"
+                    },
+                    "type": "array",
+                    "description": "A list of Spans that originate from an instrumentation scope."
+                },
+                "schemaUrl": {
+                    "type": "string",
+                    "description": "This schema_url applies to all spans and span events in the \"spans\" field."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Scope Spans",
+            "description": "A collection of Spans produced by an InstrumentationScope."
+        },
+        "opentelemetry.proto.trace.v1.Span": {
+            "properties": {
+                "traceId": {
+                    "type": "string",
+                    "description": "A unique identifier for a trace. All spans from the same trace share the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes is considered invalid. This field is semantically required. Receiver should generate new random trace_id if empty or invalid trace_id was received. This field is required.",
+                    "format": "hex",
+                    "pattern": "^[0-9a-fA-F]{32}$"
+                },
+                "spanId": {
+                    "type": "string",
+                    "description": "A unique identifier for a span within a trace, assigned when the span is created. The ID is an 8-byte array. An ID with all zeroes is considered invalid. This field is semantically required. Receiver should generate new random span_id if empty or invalid span_id was received. This field is required.",
+                    "format": "hex",
+                    "pattern": "^[0-9a-fA-F]{16}$"
+                },
+                "traceState": {
+                    "type": "string",
+                    "description": "trace_state conveys information about request position in multiple distributed tracing graphs. It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header See also https://github.com/w3c/distributed-tracing for more details about this field."
+                },
+                "parentSpanId": {
+                    "type": "string",
+                    "description": "The `span_id` of this span's parent span. If this is a root span, then this field must be empty. The ID is an 8-byte array.",
+                    "format": "hex",
+                    "pattern": "^[0-9a-fA-F]{16}$"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A description of the span's operation. For example, the name can be a qualified method name or a file name and a line number where the operation is called. A best practice is to use the same display name at the same call point in an application. This makes it easier to correlate spans in different traces. This field is semantically required to be set to non-empty string. Empty value is equivalent to an unknown span name. This field is required."
+                },
+                "kind": {
+                    "enum": [
+                        "SPAN_KIND_UNSPECIFIED",
+                        0,
+                        "SPAN_KIND_INTERNAL",
+                        1,
+                        "SPAN_KIND_SERVER",
+                        2,
+                        "SPAN_KIND_CLIENT",
+                        3,
+                        "SPAN_KIND_PRODUCER",
+                        4,
+                        "SPAN_KIND_CONSUMER",
+                        5
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Span Kind",
+                    "description": "SpanKind is the type of span. Can be used to specify additional relationships between spans in addition to a parent/child relationship."
+                },
+                "startTimeUnixNano": {
+                    "type": "string",
+                    "description": "start_time_unix_nano is the start time of the span. On the client side, this is the time kept by the local machine where the span execution starts. On the server side, this is the time when the server's application handler starts running. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. This field is semantically required and it is expected that end_time \u003e= start_time."
+                },
+                "endTimeUnixNano": {
+                    "type": "string",
+                    "description": "end_time_unix_nano is the end time of the span. On the client side, this is the time kept by the local machine where the span execution ends. On the server side, this is the time when the server application handler stops running. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. This field is semantically required and it is expected that end_time \u003e= start_time."
+                },
+                "attributes": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array",
+                    "description": "attributes is a collection of key/value pairs. Note, global attributes like server name can be set using the resource API. Examples of attributes:     \"/http/user_agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36\"     \"/http/server_latency\": 300     \"abc.com/myattribute\": true     \"abc.com/score\": 10.239 The OpenTelemetry API specification further restricts the allowed value types: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key)."
+                },
+                "droppedAttributesCount": {
+                    "type": "integer",
+                    "description": "dropped_attributes_count is the number of attributes that were discarded. Attributes can be discarded because their keys are too long or because there are too many attributes. If this value is 0, then no attributes were dropped."
+                },
+                "events": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.trace.v1.Span.Event"
+                    },
+                    "type": "array",
+                    "description": "events is a collection of Event items."
+                },
+                "droppedEventsCount": {
+                    "type": "integer",
+                    "description": "dropped_events_count is the number of dropped events. If the value is 0, then no events were dropped."
+                },
+                "links": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.trace.v1.Span.Link"
+                    },
+                    "type": "array",
+                    "description": "links is a collection of Links, which are references from this span to a span in the same or different trace."
+                },
+                "droppedLinksCount": {
+                    "type": "integer",
+                    "description": "dropped_links_count is the number of dropped links after the maximum size was enforced. If this value is 0, then no links were dropped."
+                },
+                "status": {
+                    "$ref": "#/definitions/opentelemetry.proto.trace.v1.Status",
+                    "additionalProperties": false,
+                    "description": "An optional final status for this span. Semantically when Status isn't set, it means span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Span",
+            "description": "A Span represents a single operation performed by a single component of the system. The next available field id is 17."
+        },
+        "opentelemetry.proto.trace.v1.Span.Event": {
+            "properties": {
+                "timeUnixNano": {
+                    "type": "string",
+                    "description": "time_unix_nano is the time the event occurred."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name of the event. This field is semantically required to be set to non-empty string."
+                },
+                "attributes": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array",
+                    "description": "attributes is a collection of attribute key/value pairs on the event. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key)."
+                },
+                "droppedAttributesCount": {
+                    "type": "integer",
+                    "description": "dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Event",
+            "description": "Event is a time-stamped annotation of the span, consisting of user-supplied text description and key-value pairs."
+        },
+        "opentelemetry.proto.trace.v1.Span.Link": {
+            "properties": {
+                "traceId": {
+                    "type": "string",
+                    "description": "A unique identifier of a trace that this linked span is part of. The ID is a 16-byte array.",
+                    "format": "hex",
+                    "pattern": "^[0-9a-fA-F]{32}$"
+                },
+                "spanId": {
+                    "type": "string",
+                    "description": "A unique identifier for the linked span. The ID is an 8-byte array.",
+                    "format": "hex",
+                    "pattern": "^[0-9a-fA-F]{16}$"
+                },
+                "traceState": {
+                    "type": "string",
+                    "description": "The trace_state associated with the link."
+                },
+                "attributes": {
+                    "items": {
+                        "$ref": "#/definitions/opentelemetry.proto.common.v1.KeyValue"
+                    },
+                    "type": "array",
+                    "description": "attributes is a collection of attribute key/value pairs on the link. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key)."
+                },
+                "droppedAttributesCount": {
+                    "type": "integer",
+                    "description": "dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Link",
+            "description": "A pointer from the current span to another span in the same trace or in a different trace. For example, this can be used in batching operations, where a single batch handler processes multiple requests from different traces or when the handler receives a request from a different project."
+        },
+        "opentelemetry.proto.trace.v1.Status": {
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "A developer-facing human readable error message."
+                },
+                "code": {
+                    "enum": [
+                        "STATUS_CODE_UNSET",
+                        0,
+                        "STATUS_CODE_OK",
+                        1,
+                        "STATUS_CODE_ERROR",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Status Code",
+                    "description": "For the semantics of status codes see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Status",
+            "description": "The Status type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs."
         }
-      }
-    },
-    "KeyValueList": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/KeyValue"
-          }
-        }
-      }
     }
-  }
 }


### PR DESCRIPTION
## Goal
Change the Open Telemetry json schema to one generated from the official protocol buffers.

## Design
This schema was generated directly from the protocol buffer definition for traces, and then modified to:
- not allow additional properties, ensuring stricter validation
- use regex checks for the `traceId` and `spanId` properties instead of the Protocol Buffer standard "base64" format (this is inline with the OpenTelemetry spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spancontext )

## Testing
Relied on existing tests