### PR TITLE
Make the BugsnagPerformanceOkhttp thread safe

### DIFF
--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -7,52 +7,56 @@ import okhttp3.EventListener
 import okhttp3.Protocol
 import okhttp3.Response
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
-class BugsnagPerformanceOkhttp: EventListener() {
+class BugsnagPerformanceOkhttp : EventListener() {
     companion object EventListenerFactory : EventListener.Factory {
         override fun create(call: Call): EventListener {
             return BugsnagPerformanceOkhttp()
         }
     }
 
-    var span: Span? = null
+    private val spans = ConcurrentHashMap<Call, Span>()
 
     override fun callStart(call: Call) {
-        span = BugsnagPerformance.startNetworkSpan(call.request().url.toUrl(), call.request().method)
+        val url = call.request().url.toUrl()
+        val span = BugsnagPerformance.startNetworkSpan(url, call.request().method)
         val contentLength = call.request().body?.contentLength()
         if (contentLength != null) {
-            span?.setAttribute("http.request_content_length", contentLength)
+            span.setAttribute("http.request_content_length", contentLength)
         }
+
+        spans[call] = span
     }
 
     override fun responseHeadersEnd(call: Call, response: Response) {
-        span?.setAttribute("http.status_code", response.code.toLong())
+        val span = spans[call] ?: return
+        span.setAttribute("http.status_code", response.code.toLong())
         val contentLength = response.body?.contentLength()
         if (contentLength != null) {
-            span?.setAttribute("http.response_content_length", contentLength)
+            span.setAttribute("http.response_content_length", contentLength)
         }
-        span?.setAttribute("http.flavor",
-        when (response.protocol) {
-            Protocol.HTTP_1_0 -> "1.0"
-            Protocol.HTTP_1_1 -> "1.1"
-            Protocol.HTTP_2 -> "2.0"
-            Protocol.QUIC -> "QUIC"
-            else -> "unknown"
-        })
+        span.setAttribute(
+            "http.flavor",
+            when (response.protocol) {
+                Protocol.HTTP_1_0 -> "1.0"
+                Protocol.HTTP_1_1 -> "1.1"
+                Protocol.HTTP_2 -> "2.0"
+                Protocol.QUIC -> "QUIC"
+                else -> "unknown"
+            }
+        )
     }
 
     override fun callEnd(call: Call) {
-        span?.end()
-        span = null
+        spans.remove(call)?.end()
     }
 
     override fun callFailed(call: Call, ioe: IOException) {
-        span?.end()
-        span = null
+        spans.remove(call)?.end()
     }
 
     override fun canceled(call: Call) {
-        span?.end()
-        span = null
+        spans.remove(call)?.end()
     }
 }


### PR DESCRIPTION
## Goal
Allow `BugsnagPerformanceOkhttp` to be used as a pure `EventListener` by making it thread-safe.

## Design
`Span`s related to a `Call` are now tracked in a `ConcurrentHashMap` allowing more than one to be in-flight at the same time.

## Testing
Manually tested in the example app