### PR TITLE
Various fixes to align Spans with design

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.performance.internal
 import android.util.JsonWriter
 import androidx.annotation.VisibleForTesting
 import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.Span
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
@@ -34,6 +35,11 @@ internal class HttpDelivery(private val endpoint: String, private val apiKey: St
         }
 
         val result = getDeliveryResult(connection)
+        if (result != DeliveryResult.SUCCESS) {
+            val errorMessage = connection.errorStream.reader().readText()
+            Logger.w("Could not deliver payload to $endpoint. Response: $errorMessage")
+        }
+
         connection.disconnect()
         return result
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -81,7 +81,7 @@ internal class PerformanceLifecycleCallbacks(
     }
 
     override fun onActivityResumed(activity: Activity) {
-        maybeEndAppLoad()
+        maybeEndAppLoad(activity)
 
         // we may have an appStartupSpan from before the configuration was in-place
         appStartupSpan = null
@@ -146,8 +146,16 @@ internal class PerformanceLifecycleCallbacks(
         }
     }
 
-    private fun maybeEndAppLoad() {
+    private fun maybeEndAppLoad(activity: Activity?) {
         if (instrumentAppStart) {
+            appStartupSpan?.apply {
+                if (activity != null) {
+                    val activityName = activity::class.java.simpleName
+                    setAttribute("bugsnag.view.type", "Activity")
+                    setAttribute("bugsnag.first_view", activityName)
+                }
+            }
+
             appStartupSpan?.end()
         }
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
@@ -27,7 +27,7 @@ internal fun createResourceAttributes(configuration: PerformanceConfiguration): 
         configuration.releaseStage ?: context.releaseStage
 
     configuration.versionCodeFor(context)?.let { versionCode ->
-        resourceAttributes["bugsnag.app.version_code"] = versionCode
+        resourceAttributes["bugsnag.app.version_code"] = versionCode.toString()
     }
 
     resourceAttributes["service.name"] = configuration.context.packageName

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -21,8 +21,9 @@ class SpanFactory(
     fun createNetworkSpan(url: URL, verb: String, startTime: Long): Span {
         val verbUpper = verb.uppercase()
         val span = createSpan("HTTP/$verbUpper", SpanKind.CLIENT, startTime)
-        span.attributes["http.url"] = url.toString()
-        span.attributes["http.method"] = verbUpper
+        span.setAttribute("bugsnag.span_category", "network")
+        span.setAttribute("http.url", url.toString())
+        span.setAttribute("http.method", verbUpper)
         return span
     }
 
@@ -33,19 +34,22 @@ class SpanFactory(
 
     fun createViewLoadSpan(viewType: ViewType, viewName: String, startTime: Long): Span {
         val span = createSpan(
-            "ViewLoad/${viewType.spanName}/$viewName",
+            "ViewLoaded/${viewType.spanName}/$viewName",
             SpanKind.INTERNAL,
             startTime
         )
 
-        span.attributes["bugsnag.span_category"] = "view_load"
-        span.attributes["bugsnag.view.type"] = viewType.typeName
-        span.attributes["bugsnag.view.name"] = viewName
+        span.setAttribute("bugsnag.span_category", "view_load")
+        span.setAttribute("bugsnag.view.type", viewType.typeName)
+        span.setAttribute("bugsnag.view.name", viewName)
         return span
     }
 
     fun createAppStartSpan(startType: String): Span =
-        createSpan("AppStart/$startType", SpanKind.INTERNAL, SystemClock.elapsedRealtimeNanos())
+        createSpan("AppStart/$startType", SpanKind.INTERNAL, SystemClock.elapsedRealtimeNanos()).apply {
+            setAttribute("bugsnag.span_category", "app_start")
+            setAttribute("bugsnag.app_start.type", startType.lowercase())
+        }
 
     private fun createSpan(name: String, kind: SpanKind, startTime: Long): Span {
         val span = Span(name, kind, startTime, UUID.randomUUID(), processor = spanProcessor)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -63,7 +63,7 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals(1, spans.size)
 
         val span = spans.first()
-        assertEquals("ViewLoad/Activity/Activity", span.name)
+        assertEquals("ViewLoaded/Activity/Activity", span.name)
         // start and end time are in nanoseconds, not milliseconds
         assertEquals(100_000_000L, span.startTime)
         assertEquals(200_000_000L, span.endTime)
@@ -104,7 +104,7 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals(1, spans.size)
 
         val span = spans.first()
-        assertEquals("ViewLoad/Activity/Activity", span.name)
+        assertEquals("ViewLoaded/Activity/Activity", span.name)
         assertEquals(100_000_000L, span.startTime)
         assertEquals(200_000_000L, span.endTime)
         assertEquals(SpanKind.INTERNAL, span.kind)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -31,7 +31,7 @@ class ResourceAttributesTest {
         assertEquals("TEST-1234", attributes["device.model.identifier"])
         assertEquals("Bugsnag", attributes["device.manufacturer"])
         assertEquals("development", attributes["deployment.environment"])
-        assertEquals(321L, attributes["bugsnag.app.version_code"])
+        assertEquals("321", attributes["bugsnag.app.version_code"])
         assertEquals(application.packageName, attributes["service.name"])
         assertEquals("bugsnag.performance.android", attributes["telemetry.sdk.name"])
     }
@@ -56,7 +56,7 @@ class ResourceAttributesTest {
         assertEquals("TEST-1234", attributes["device.model.identifier"])
         assertEquals("Bugsnag", attributes["device.manufacturer"])
         assertEquals("production", attributes["deployment.environment"]) // overridden
-        assertEquals(123L, attributes["bugsnag.app.version_code"]) // overridden
+        assertEquals("123", attributes["bugsnag.app.version_code"]) // overridden
         assertEquals(application.packageName, attributes["service.name"])
         assertEquals("bugsnag.performance.android", attributes["telemetry.sdk.name"])
     }

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$90_000L</ID>
+    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$100</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$30</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
@@ -20,6 +20,7 @@ class AppStartScenario(
         config.autoInstrumentActivities = AutoInstrument.OFF
         context.saveStartupConfig(config)
 
+        Thread.sleep(500L)
         // quit the app
         exitProcess(0)
     }

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -3,7 +3,7 @@ Feature: Automatic creation of spans
   Scenario: Activity with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
+    Then a span name equals "ViewLoaded/Activity/ActivityViewLoadActivity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.type" equals "activity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
@@ -11,7 +11,7 @@ Feature: Automatic creation of spans
   Scenario: Activity with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
+    Then a span name equals "ViewLoaded/Activity/ActivityViewLoadActivity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.type" equals "activity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
@@ -19,7 +19,7 @@ Feature: Automatic creation of spans
   Scenario: Activity with no automatic ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "OFF"
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
+    Then a span name equals "ViewLoaded/Activity/ActivityViewLoadActivity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "view_load"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.type" equals "activity"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
@@ -30,3 +30,5 @@ Feature: Automatic creation of spans
     Then I relaunch the app after shutdown
     Then I wait to receive 1 traces
     * a span name equals "AppStart/Cold"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "app_start"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.app_start.type" equals "cold"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -27,7 +27,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" attribute "deployment.environment" is one of:
       | development |
       | production  |
-    * the trace payload field "resourceSpans.0.resource" attribute "bugsnag.app.version_code" is 1
+    * the trace payload field "resourceSpans.0.resource" attribute "bugsnag.app.version_code" equals "1"
     * the trace payload field "resourceSpans.0.resource" attribute "service.name" equals "com.bugsnag.mazeracer"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.name" equals "bugsnag.performance.android"
     * the trace payload field "resourceSpans.0.resource" attribute "telemetry.sdk.version" equals "0.0.0"

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -9,6 +9,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_CLIENT"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.span_category" equals "network"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "http.url" equals "https://google.com/?test=true"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "http.flavor" exists


### PR DESCRIPTION
## Goal
Align the span generation with the expectations of the Bugsnag server side and dashboard.

## Changeset
- `bugsnag.view.type` is now correctly reported
- `bugsnag.first_view` is reported as the activity name where available
- network spans have the expected `bugsnag.span_category`
- `ViewLoad` spans report as `ViewLoaded`
- `bugsnag.app_start.type` reports the actual app start type (cold, warm, hot)

## Testing
Manually tested with the production pipeline and dashboard