### PR TITLE
Add Worker & Task

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -3,7 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexMethod:Connectivity.kt$ConnectivityApi24$private fun nameForDataNetworkType(dataNetworkType: Int): String</ID>
-    <ID>EmptyFunctionBlock:Tracer.kt$Tracer.&lt;no name provided>${}</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>
     <ID>MagicNumber:Encodings.kt$16</ID>
     <ID>MagicNumber:Encodings.kt$24</ID>
@@ -30,6 +29,7 @@
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:ResourceAttributes.kt$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Tracer.kt$Tracer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
     <ID>TooManyFunctions:PerformanceLifecycleCallbacks.kt$PerformanceLifecycleCallbacks : ActivityLifecycleCallbacksCallback</ID>
   </CurrentIssues>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
@@ -1,0 +1,114 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Logger
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+internal interface Task {
+    fun onAttach(worker: Worker) = Unit
+
+    fun onDetach(worker: Worker) = Unit
+
+    /**
+     * Run the task and return `true` if any work was done (and more work is likely to be available
+     * on the next call to `execute`).
+     */
+    fun execute(): Boolean
+}
+
+internal class Worker(
+    private val tasks: List<Task>
+) : Runnable {
+
+    constructor(vararg tasks: Task) : this(tasks.toList())
+
+    private val lock = ReentrantLock(false)
+    private val workerWaitCondition = lock.newCondition()
+
+    private var runner: Thread? = null
+
+    @Volatile
+    private var running = false
+
+    @Synchronized
+    fun start() {
+        if (running) return
+
+        running = true
+
+        runner = Thread(this, "Bugsnag Performance").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    @Synchronized
+    fun stop(waitForTermination: Boolean = true) {
+        if (!running) return
+
+        running = false
+        runner?.interrupt()
+
+        if (waitForTermination) {
+            runner?.join()
+        }
+
+        runner = null
+    }
+
+    override fun run() {
+        attachTasks()
+        try {
+            while (running) {
+                val shouldWaitForWork = runTasks()
+
+                if (shouldWaitForWork) {
+                    waitForWorkOrWakeup()
+                }
+            }
+        } finally {
+            detachWorkers()
+        }
+    }
+
+    private fun attachTasks() {
+        tasks.forEach { it.onAttach(this) }
+    }
+
+    private fun detachWorkers() {
+        tasks.forEach { it.onDetach(this) }
+    }
+
+    fun wake() {
+        if (!running) return
+        // wake up with worker
+        lock.withLock { workerWaitCondition.signalAll() }
+    }
+
+    private fun runTasks(): Boolean {
+        var shouldWaitForWork = true
+
+        for (task in tasks) {
+            try {
+                if (task.execute()) {
+                    shouldWaitForWork = false
+                }
+            } catch (ex: Exception) {
+                // failures are treated as a Task returning false
+                Logger.w("unhandled exception in a worker task: $task", ex)
+            }
+        }
+
+        return shouldWaitForWork
+    }
+
+    private fun waitForWorkOrWakeup() {
+        lock.withLock {
+            workerWaitCondition.await(
+                InternalDebug.spanBatchTimeoutMs,
+                TimeUnit.MILLISECONDS
+            )
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
@@ -1,0 +1,121 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Logger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+class WorkerTest {
+    @Before
+    fun stubLogger() {
+        Logger.delegate = NoopLogger
+    }
+
+    @After
+    fun unStubLogger() {
+        Logger.delegate = DebugLogger
+    }
+
+    @Test(timeout = 1000)
+    fun testWaitAndWake() {
+        val count1 = CountingTask(1)
+        val count2 = CountingTask(5)
+        val worker = Worker(count1, count2)
+
+        worker.start()
+        try {
+            count1.await()
+            count2.await()
+        } finally {
+            worker.stop()
+        }
+
+        assertEquals(1, count1.currentCount)
+        assertEquals(5, count2.currentCount)
+    }
+
+    @Test
+    fun testWaitAndAwake() {
+        val count1 = CountingTask(1)
+        val count2 = CountingTask(5)
+        val worker = Worker(count1, count2)
+
+        worker.start()
+        try {
+            count1.await()
+            count2.await()
+
+            assertEquals(1, count1.currentCount)
+            assertEquals(5, count2.currentCount)
+
+            count2.reset()
+
+            // a short delay to ensure the worker has not woken up
+            Thread.sleep(5L)
+
+            // assert that the work was not done again
+            assertEquals(0, count2.currentCount)
+
+            worker.wake()
+            count2.await()
+            assertEquals(5, count2.currentCount)
+        } finally {
+            worker.stop()
+        }
+    }
+
+    @Test
+    fun testExceptionHandling() {
+        val latch = CountDownLatch(1)
+        val worker = Worker(
+            object : Task {
+                override fun execute(): Boolean {
+                    throw NullPointerException()
+                }
+            },
+            object : Task {
+                override fun execute(): Boolean {
+                    latch.countDown()
+                    return false
+                }
+            },
+        )
+
+        // this test succeeds if the latch releases, as it means that the exception in the first
+        // task was correctly handled without blocking the second task
+        worker.start()
+        try {
+            latch.await()
+        } finally {
+            worker.stop()
+        }
+    }
+
+    private class CountingTask(
+        private val maximum: Int
+    ) : Task {
+        private var latch = CountDownLatch(maximum)
+
+        var currentCount = 0
+            private set
+
+        fun await() = latch.await()
+
+        fun reset() {
+            currentCount = 0
+            latch = CountDownLatch(maximum)
+        }
+
+        override fun execute(): Boolean {
+            if (currentCount < maximum) {
+                currentCount++
+                latch.countDown()
+                return true
+            }
+
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Implement the `Worker` class and `Task` interface to provide a clean mechanism to implement the various actions the performance library needs to take away from the app main-thread.

## Design
Tasks are attached & detached to a `Worker` when the `Worker` is started or stopped, providing the `Task` implementors with a clear inter-communication mechanism without having tricky reference ordering when the `Worker` is constructed.

## Changeset
None of the actually `Task` classes have yet been implemented. The existing `Tracer`, and delivery systems will both be refactored to take advantage of the `Worker` at a later date.

## Testing
A new unit test was added to assert all of the functionality the `Worker` provides