### PR TITLE
Changed the retry mechanism to persist the queue on disk

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -19,6 +19,8 @@
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$24L</ID>
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$30000L</ID>
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$60</ID>
+    <ID>MagicNumber:Persistence.kt$RetryQueue$19</ID>
+    <ID>MagicNumber:Persistence.kt$TraceFileDecoder$1024</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
@@ -28,7 +30,6 @@
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:ResourceAttributes.kt$ex: RuntimeException</ID>
-    <ID>TooGenericExceptionCaught:Tracer.kt$Tracer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
     <ID>TooManyFunctions:PerformanceLifecycleCallbacks.kt$PerformanceLifecycleCallbacks : ActivityLifecycleCallbacksCallback</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
@@ -20,4 +20,9 @@ internal object BugsnagClock {
      * precision.
      */
     fun elapsedNanosToUnixTime(elapsedRealtimeNanos: Long) = elapsedRealtimeNanos + bootTimeNano
+
+    /**
+     * `System.currentTimeMillis` but as nanosecond precision time.
+     */
+    fun currentUnixNanoTime(): Long = elapsedNanosToUnixTime(SystemClock.elapsedRealtimeNanos())
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
@@ -3,10 +3,13 @@ package com.bugsnag.android.performance.internal
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Span
 
-enum class DeliveryResult {
-    SUCCESS,
-    FAIL_RETRIABLE,
-    FAIL_PERMANENT
+sealed class DeliveryResult {
+    object Success : DeliveryResult()
+
+    data class Failed(
+        val payload: TracePayload,
+        val canRetry: Boolean
+    ) : DeliveryResult()
 }
 
 fun interface NewProbabilityCallback {
@@ -17,6 +20,11 @@ interface Delivery {
     fun deliver(
         spans: Collection<Span>,
         resourceAttributes: Attributes,
+        newProbabilityCallback: NewProbabilityCallback?
+    ): DeliveryResult
+
+    fun deliver(
+        tracePayload: TracePayload,
         newProbabilityCallback: NewProbabilityCallback?
     ): DeliveryResult
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Persistence.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Persistence.kt
@@ -1,0 +1,196 @@
+package com.bugsnag.android.performance.internal
+
+import android.content.Context
+import com.bugsnag.android.performance.Logger
+import com.bugsnag.android.performance.internal.TraceFileDecoder.FILENAME_PREFIX
+import com.bugsnag.android.performance.internal.TraceFileDecoder.FILENAME_SUFFIX
+import java.io.ByteArrayOutputStream
+import java.io.EOFException
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+
+internal class Persistence(val context: Context) {
+    val topLevelDirectory = File(context.cacheDir, "bugsnag-performance/v1").apply { mkdirs() }
+
+    val retryQueue = RetryQueue(File(topLevelDirectory, "retry-queue"))
+
+    fun clear() {
+        // delete the contents of the directory, but not the directory itself
+        topLevelDirectory.listFiles()?.forEach {
+            it.deleteRecursively()
+        }
+    }
+}
+
+internal object TraceFileDecoder {
+    private const val CR = '\r'.code // 13
+    private const val LF = '\n'.code // 10
+
+    internal const val FILENAME_PREFIX = "retry-"
+    internal const val FILENAME_SUFFIX = ".json"
+
+    fun decodeTracePayload(file: File): TracePayload {
+        val timestamp = parseTimestamp(file.name)
+            ?: throw IOException("not a valid trace payload filename: '${file.name}'")
+
+        return file.inputStream().buffered().use { istream ->
+            // parse the HTTP headers from the start of the file
+            val headers = readHeaders(istream)
+
+            // read the remaining bytes as the body of the file
+            val body = istream.readBytes()
+            TracePayload(timestamp, body, headers)
+        }
+    }
+
+    private fun readHeaders(inputStream: InputStream): Map<String, String> {
+        val headers = LinkedHashMap<String, String>()
+        val buffer = ByteArrayOutputStream(1024)
+
+        while (true) {
+            if (inputStream.readUntilCRLF(buffer)) {
+                if (buffer.size() != 0) {
+                    parseHeaderLine(buffer.toString(), headers)
+                } else {
+                    // an empty line indicates the end of the headers
+                    break
+                }
+            } else {
+                // we hit an unexpected EOF before the headers were finished
+                // that indicates that the file is invalid
+                throw EOFException("unexpected EOF in headers")
+            }
+
+            // reuse the buffer without having to re-allocate it
+            buffer.reset()
+        }
+
+        return headers
+    }
+
+    private fun parseHeaderLine(headerLine: String, output: MutableMap<String, String>) {
+        val separator = headerLine.indexOf(':')
+        if (separator == -1) {
+            throw IOException("Not a valid HTTP header line: '$headerLine'")
+        }
+
+        val name = headerLine.substring(0, separator)
+        val value = headerLine.substring(separator + 1).trimStart()
+
+        output[name] = value
+    }
+
+    internal fun parseTimestamp(filename: String): Long? {
+        if (filename.startsWith(FILENAME_PREFIX) && filename.endsWith(FILENAME_SUFFIX)) {
+            return filename.substring(FILENAME_PREFIX.length).substringBefore('.').toLongOrNull()
+        }
+
+        return null
+    }
+
+    /**
+     * Due to all the nice `readLine` implementations being on `Reader`s (which includes a
+     * read-ahead) we need to implement our own strict CRLF based line reader which only
+     * consumes a single byte at a time, leaving binary payloads intact.
+     */
+    private fun InputStream.readUntilCRLF(output: ByteArrayOutputStream): Boolean {
+        while (true) {
+            when (val b = read()) {
+                CR -> {
+                    // checkpoint in case the next byte != LF
+                    mark(1)
+                    val next = read()
+
+                    if (next == LF) {
+                        // end of line, return happy
+                        return true
+                    } else {
+                        // oops this is not a strict CRLF we passthrough the CR and rewind
+                        // to our checkpoint
+                        output.write(CR)
+                        reset()
+                    }
+                }
+                -1 -> return false
+                else -> output.write(b)
+            }
+        }
+    }
+}
+
+/**
+ * Implements the on-storage retry file storage. Slightly misnamed as the `RetryQueue` is actually
+ * a stack (LIFO instead of FIFO) since more recently stored data is considered more important
+ * than the older content (and older content may be discarded as being "stale").
+ */
+internal class RetryQueue(
+    private val queueDirectory: File,
+    private val maxPayloadAgeNanos: Long = TimeUnit.MILLISECONDS.toNanos(InternalDebug.dropSpansOlderThanMs)
+) {
+    private fun ensureQueueDirectory(): File {
+        if (!queueDirectory.exists()) queueDirectory.mkdirs()
+        return queueDirectory
+    }
+
+    private fun createRetryFile(timestamp: Long): File {
+        // make sure the timestamp is the actual Unix timestamp so that it doesn't reset on reboot
+        val unixNanoTimestamp = BugsnagClock.elapsedNanosToUnixTime(timestamp)
+        return fileForNanoTimestamp(unixNanoTimestamp)
+    }
+
+    private fun fileForNanoTimestamp(timestamp: Long): File {
+        val timestampString = timestamp.toString().padStart(19, '0')
+        return File(ensureQueueDirectory(), "$FILENAME_PREFIX$timestampString$FILENAME_SUFFIX")
+    }
+
+    private fun writeHeaders(headers: Map<String, String>, out: OutputStream) {
+        val headerBytes = headers.entries
+            .joinToString(
+                separator = "\r\n",
+                postfix = "\r\n\r\n",
+                transform = { (key, value) -> "$key: $value" }
+            )
+            .toByteArray()
+
+        out.write(headerBytes)
+    }
+
+    /**
+     * Delete any payloads older than [maxPayloadAgeNanos]
+     */
+    fun sweep() {
+        val minExpectedTimestamp = BugsnagClock.currentUnixNanoTime() - maxPayloadAgeNanos
+        queueDirectory.listFiles()
+            ?.filter { (TraceFileDecoder.parseTimestamp(it.name) ?: 0) < minExpectedTimestamp }
+            ?.forEach { it.deleteRecursively() }
+    }
+
+    fun next(): TracePayload? {
+        sweep()
+
+        val nextFile = queueDirectory.listFiles()?.maxByOrNull { it.name } ?: return null
+
+        return try {
+            TraceFileDecoder.decodeTracePayload(nextFile)
+        } catch (ioe: IOException) {
+            Logger.w("Discarding trace file: $nextFile", ioe)
+            nextFile.delete()
+            null
+        }
+    }
+
+    fun remove(timestamp: Long) {
+        fileForNanoTimestamp(timestamp).delete()
+    }
+
+    fun add(tracePayload: TracePayload) {
+        val (timestamp, trace, headers) = tracePayload
+        createRetryFile(timestamp).outputStream().buffered().use { out ->
+            writeHeaders(headers, out)
+            out.write(trace)
+        }
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.performance.internal
+
+internal class RetryDeliveryTask(
+    private val retryQueue: RetryQueue,
+    private val delivery: Delivery
+) : AbstractTask() {
+    override fun execute(): Boolean {
+        val nextPayload = retryQueue.next() ?: return false
+        val result = delivery.deliver(nextPayload, null)
+
+        // if it was delivered, or can never be delivered - delete it
+        if (result is DeliveryResult.Success ||
+            (result is DeliveryResult.Failed && !result.canRetry)
+        ) {
+            retryQueue.remove(nextPayload.timestamp)
+        }
+        return true
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
@@ -1,0 +1,116 @@
+package com.bugsnag.android.performance.internal
+
+import android.os.SystemClock
+import android.util.JsonWriter
+import androidx.annotation.VisibleForTesting
+import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Span
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+
+data class TracePayload(
+    val timestamp: Long,
+    val body: ByteArray,
+    val headers: Map<String, String>
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TracePayload
+
+        if (timestamp != other.timestamp) return false
+        if (!body.contentEquals(other.body)) return false
+        if (headers != other.headers) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = timestamp.hashCode()
+        result = 31 * result + body.contentHashCode()
+        result = 31 * result + headers.hashCode()
+        return result
+    }
+
+    companion object Encoder {
+        @JvmStatic
+        fun createTracePayload(
+            apiKey: String,
+            spans: Collection<Span>,
+            resourceAttributes: Attributes
+        ): TracePayload {
+            val payloadBytes = encodeSpanPayload(spans, resourceAttributes)
+            val timestamp = spans.maxOf { it.endTime }
+
+            return createTracePayload(apiKey, payloadBytes, timestamp)
+        }
+
+        @JvmStatic
+        fun createTracePayload(
+            apiKey: String,
+            payloadBytes: ByteArray,
+            timestamp: Long = SystemClock.elapsedRealtimeNanos()
+        ): TracePayload {
+            val headers = mutableMapOf(
+                "Bugsnag-Api-Key" to apiKey,
+                "Content-Encoding" to "application/json",
+                "Content-Length" to payloadBytes.size.toString()
+            )
+
+            computeSha1Digest(payloadBytes)?.let { digest ->
+                headers["Bugsnag-Integrity"] = digest
+            }
+
+            return TracePayload(
+                timestamp,
+                payloadBytes,
+                headers
+            )
+        }
+
+        @VisibleForTesting
+        internal fun encodeSpanPayload(
+            spans: Collection<Span>,
+            resourceAttributes: Attributes
+        ): ByteArray {
+            val buffer = ByteArrayOutputStream()
+            JsonWriter(buffer.writer()).use { json ->
+                json.beginObject()
+                    .name("resourceSpans").beginArray()
+                    .beginObject()
+
+                json.name("resource").beginObject()
+                    .name("attributes").value(resourceAttributes)
+                    .endObject()
+
+                json.name("scopeSpans").beginArray()
+                    .beginObject()
+                    .name("spans").beginArray()
+
+                spans.forEach { it.toJson(json) }
+
+                json.endArray() // spans
+                    .endObject()
+                    .endArray() // scopeSpans
+                    .endObject()
+                    .endArray() // resourceSpans
+                    .endObject()
+            }
+
+            return buffer.toByteArray()
+        }
+
+        private fun computeSha1Digest(payload: ByteArray): String? {
+            runCatching {
+                val shaDigest = MessageDigest.getInstance("SHA-1")
+                shaDigest.update(payload)
+
+                return buildString {
+                    append("sha1 ")
+                    appendHexString(shaDigest.digest())
+                }
+            }.getOrElse { return null }
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryQueueTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryQueueTest.kt
@@ -1,0 +1,66 @@
+package com.bugsnag.android.performance.internal
+
+import android.os.SystemClock
+import com.bugsnag.android.performance.test.withStaticMock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class RetryQueueTest {
+    private lateinit var dir: File
+    private lateinit var retryQueue: RetryQueue
+
+    @Before
+    fun createQueueDir() {
+        dir = File(
+            System.getProperty("java.io.tmpdir"),
+            "retry-queue-test-${System.currentTimeMillis()}"
+        )
+
+        retryQueue = RetryQueue(dir)
+    }
+
+    @After
+    fun deleteQueueDir() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun addPayloads() = withStaticMock<SystemClock> { mockedClock ->
+        mockedClock.`when`<Long>(SystemClock::elapsedRealtimeNanos)
+            .thenReturn(0L)
+
+        val tracePayload1 = TracePayload(
+            1L,
+            byteArrayOf(1, 2, 3),
+            mapOf(
+                "Header1" to "one",
+                "Header2" to "two"
+            )
+        )
+
+        val tracePayload2 = TracePayload(
+            2L,
+            byteArrayOf(3, 2, 1),
+            mapOf(
+                "One" to "1",
+                "Two" to "2",
+                "Three" to "3"
+            )
+        )
+
+        retryQueue.add(tracePayload2)
+        retryQueue.add(tracePayload1)
+
+        val expectedPayload1 =
+            tracePayload1.copy(timestamp = tracePayload1.timestamp + BugsnagClock.bootTimeNano)
+        val expectedPayload2 =
+            tracePayload2.copy(timestamp = tracePayload2.timestamp + BugsnagClock.bootTimeNano)
+
+        assertEquals(expectedPayload2, retryQueue.next())
+        retryQueue.remove(expectedPayload2.timestamp)
+        assertEquals(expectedPayload1, retryQueue.next())
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -12,7 +12,7 @@ import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
-class HttpDeliveryTest {
+class SpanPayloadEncodingTest {
     @Test
     @Suppress("LongMethod")
     fun testDeliver() {
@@ -36,8 +36,7 @@ class HttpDeliveryTest {
         span2.end(11L)
         val spans = listOf(span1, span2)
 
-        val delivery = HttpDelivery("", "")
-        val content = delivery.encodeSpanPayload(
+        val content = TracePayload.encodeSpanPayload(
             spans,
             Attributes().also { attrs ->
                 attrs["service.name"] = "Test app"

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
@@ -5,20 +5,21 @@ import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.internal.Delivery
 import com.bugsnag.android.performance.internal.DeliveryResult
 import com.bugsnag.android.performance.internal.NewProbabilityCallback
+import com.bugsnag.android.performance.internal.TracePayload
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 class StubDelivery : Delivery {
-    var nextResult: DeliveryResult = DeliveryResult.SUCCESS
-    var lastAttempt: Collection<Span>? = null
+    var nextResult: DeliveryResult = DeliveryResult.Success
+    var lastSpanDelivery: Collection<Span>? = null
 
     private val lock = ReentrantLock(false)
     private val deliveryCondition = lock.newCondition()
 
     fun awaitDelivery(timeout: Long = 60_000L) {
         lock.withLock {
-            if (lastAttempt == null) {
+            if (lastSpanDelivery == null) {
                 deliveryCondition.await(timeout, TimeUnit.MILLISECONDS)
             }
         }
@@ -26,7 +27,7 @@ class StubDelivery : Delivery {
 
     fun reset(nextResult: DeliveryResult) {
         this.nextResult = nextResult
-        lastAttempt = null
+        lastSpanDelivery = null
     }
 
     override fun deliver(
@@ -35,11 +36,16 @@ class StubDelivery : Delivery {
         newProbabilityCallback: NewProbabilityCallback?
     ): DeliveryResult {
         lock.withLock {
-            lastAttempt = spans
+            lastSpanDelivery = spans
             deliveryCondition.signalAll()
             return nextResult
         }
     }
+
+    override fun deliver(
+        tracePayload: TracePayload,
+        newProbabilityCallback: NewProbabilityCallback?
+    ): DeliveryResult = nextResult
 
     override fun fetchCurrentProbability(newPCallback: NewProbabilityCallback) = Unit
 }

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -7,8 +7,9 @@
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$100</ID>
+    <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$250</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$30</ID>
-    <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$5</ID>
+    <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$50</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$1000L</ID>
@@ -20,6 +21,7 @@
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$50</ID>
     <ID>MagicNumber:RetryScenario.kt$RetryScenario$100</ID>
     <ID>MagicNumber:RetryTimeoutScenario.kt$RetryTimeoutScenario$100</ID>
+    <ID>MagicNumber:RetryTimeoutScenario.kt$RetryTimeoutScenario$105</ID>
     <ID>MagicNumber:SamplingProbabilityZeroScenario.kt$SamplingProbabilityZeroScenario$100</ID>
     <ID>MagicNumber:ThreeSpansScenario.kt$ThreeSpansScenario$300</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BatchTimeoutScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BatchTimeoutScenario.kt
@@ -12,14 +12,14 @@ class BatchTimeoutScenario(
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 100
-        InternalDebug.workerSleepMs = 100
+        InternalDebug.workerSleepMs = 250
     }
 
     override fun startScenario() {
         BugsnagPerformance.start(config)
 
         // a short sleep to allow the worker to finish a single pass before continuing
-        Thread.sleep(5)
+        Thread.sleep(50)
 
         measureSpan("Span 1") {
             Thread.sleep(30)
@@ -29,7 +29,7 @@ class BatchTimeoutScenario(
             Thread.sleep(30)
         }
 
-        Thread.sleep(100)
+        Thread.sleep(InternalDebug.workerSleepMs)
 
         measureSpan("Span 3") {
             Thread.sleep(30)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryTimeoutScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryTimeoutScenario.kt
@@ -16,7 +16,7 @@ class RetryTimeoutScenario(
 
     override fun startScenario() {
         BugsnagPerformance.start(config)
-        Thread.sleep(100)
+        Thread.sleep(105)
         BugsnagPerformance.startSpan("span 1").end()
         Thread.sleep(100)
         BugsnagPerformance.startSpan("span 2").end()

--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -5,7 +5,7 @@ Feature: Server responses
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I should receive no traces
 
-  Scenario: No P update: success, fail-permament, fail-retriable
+  Scenario: No P update: success, fail-permanent, fail-retriable
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
@@ -15,98 +15,112 @@ Feature: Server responses
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
 
-  Scenario: No P update: success, fail-retriable, fail-permament
+  Scenario: No P update: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
+    # 200 - Payload accepted
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # 500 - Server error (retry) but still recorded by MazeRunner
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
     And I discard the oldest trace
+    # Retry of the previous request
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 3"
 
-  Scenario: No P update: fail-retriable, fail-permament, success
+  Scenario: No P update: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
+    # 500 - Server error (retry) but still recorded by MazeRunner
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # 400 - Retry, payload rejected (no retry)
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 2"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    # 200 - Payload accepted
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
 
-  Scenario: No P update: fail-retriable, success, fail-permament
+  Scenario: No P update: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
+    # 500 - Server error (retry) but still recorded by MazeRunner
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # 200 - Payload accepted
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 2"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    # 400 - Payload rejected
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
 
-  Scenario: No P update: fail-permament, fail-retriable, success
+  Scenario: No P update: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
+    # 400 - Payload rejected, no retry
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # 500 - Server error (retry) but still recorded by MazeRunner
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
     And I discard the oldest trace
+    # Retry of the previous request
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 3"
 
-  Scenario: No P update: fail-permament, success, fail-retriable
+  Scenario: No P update: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 3 traces
+    And I wait to receive 4 traces
+    # 400 - Payload rejected, no retry
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # 200 - Payload accepted
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
     And I discard the oldest trace
+    # 500 - Payload rejected (retry)
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    And I discard the oldest trace
+    # Retry of the previous request
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
 
   # P=0 on first response
 
-  Scenario: Update P to 0 on first response: success, fail-permament, fail-retriable
+  Scenario: Update P to 0 on first response: success, fail-permanent, fail-retriable
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
-  Scenario: Update P to 0 on first response: success, fail-retriable, fail-permament
+  Scenario: Update P to 0 on first response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
-  Scenario: Update P to 0 on first response: fail-retriable, fail-permament, success
+  Scenario: Update P to 0 on first response: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
-  Scenario: Update P to 0 on first response: fail-retriable, success, fail-permament
+  Scenario: Update P to 0 on first response: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
-  Scenario: Update P to 0 on first response: fail-permament, fail-retriable, success
+  Scenario: Update P to 0 on first response: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
-  Scenario: Update P to 0 on first response: fail-permament, success, fail-retriable
+  Scenario: Update P to 0 on first response: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
@@ -115,7 +129,7 @@ Feature: Server responses
 
   # P=0 on second response
 
-  Scenario: Update P to 0 on second response: success, fail-permament, fail-retriable
+  Scenario: Update P to 0 on second response: success, fail-permanent, fail-retriable
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
@@ -124,7 +138,7 @@ Feature: Server responses
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
 
-  Scenario: Update P to 0 on second response: success, fail-retriable, fail-permament
+  Scenario: Update P to 0 on second response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
@@ -133,27 +147,29 @@ Feature: Server responses
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
 
-  Scenario: Update P to 0 on second response: fail-retriable, fail-permament, success
+  Scenario: Update P to 0 on second response: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 2 traces
+    # 500 - Payload rejected (retry)
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # Retry of previously rejected trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 2"
 
-  Scenario: Update P to 0 on second response: fail-retriable, success, fail-permament
+  Scenario: Update P to 0 on second response: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 2 traces
+    # 500 - Payload rejected (retry)
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
+    # Retry of previously rejected trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Custom/span 2"
 
-  Scenario: Update P to 0 on second response: fail-permament, fail-retriable, success
+  Scenario: Update P to 0 on second response: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
@@ -162,9 +178,9 @@ Feature: Server responses
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
 
-  Scenario: Update P to 0 on second response: fail-permament, success, fail-retriable
+  Scenario: Update P to 0 on second response: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
-    Given I set the sampling probability for the next traces to "null,null,0"
+    Given I set the sampling probability for the next traces to "null,null ,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 2 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"


### PR DESCRIPTION
## Goal
Ensure that payloads recorded when there is no connectivity can be delivered later by persisting them.

## Design
The `RetryDelivery` now stores failed payloads in a persistent `RetryQueue`. The `RetryDeliveryTask` is then called from the `Worker` to attempt delivery (starting at the oldest still-valid payload), if the retry-delivery is successful (or cannot be retried) then the payload is deleted from storage.

## Changeset
- Introduced `RetryQueue` and `RetryDeliveryTask` which work together with `RetryDelivery` to persist and later re-deliver traces
- The `DeliveryStatus` is now a `sealed class` instead of an enum, so that failures can encapsulate the `TracePayload` that was being delivered. This allows the `RetryQueue` to store the payload without needing to re-encode it.
- The retry status is now a flag on `Failed` deliveries instead of being a deliver result in its own right

## Testing
New unit tests, and modified the end to end scenarios to expect the new trace structures, where retried payloads are still discrete (instead of being bundled together).