### PR TITLE
Persist pValue and its expiry to a JSON file

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -125,11 +125,17 @@ object BugsnagPerformance {
         )
 
         val persistence = Persistence(application)
+        tracer.sampler.loadConfiguration(persistence.persistentState)
 
         val delivery = RetryDelivery(persistence.retryQueue, httpDelivery)
 
         val bsgWorker = Worker(
-            SendBatchTask(delivery, tracer, createResourceAttributes(configuration)),
+            SendBatchTask(
+                delivery,
+                tracer,
+                persistence.persistentState,
+                createResourceAttributes(configuration)
+            ),
             RetryDeliveryTask(persistence.retryQueue, httpDelivery)
         )
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
@@ -2,15 +2,14 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Span
 
-class Sampler(fallbackProbability: Double) {
+internal class Sampler(fallbackProbability: Double) {
     var fallbackProbability = fallbackProbability
         set(value) {
             field = value
             currentProbability = value
             expiryTime = newExpiryTime()
         }
-    private var expiryTime = newExpiryTime()
-    private var currentProbability = fallbackProbability
+
     var probability: Double
         get() {
             return when {
@@ -22,6 +21,14 @@ class Sampler(fallbackProbability: Double) {
             currentProbability = value
             expiryTime = newExpiryTime()
         }
+
+    var expiryTime = newExpiryTime()
+    private var currentProbability = fallbackProbability
+
+    fun loadConfiguration(persistentState: PersistentState) {
+        this.currentProbability = persistentState.pValue
+        this.expiryTime = persistentState.pValueExpiryTime
+    }
 
     fun sampled(spans: Collection<Span>): Collection<Span> {
         return spans.filter { shouldKeepSpan(it) }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -8,6 +8,7 @@ internal class SendBatchTask(
     @get:VisibleForTesting
     val delivery: Delivery,
     private val tracer: Tracer,
+    private val persistentState: PersistentState,
     private val resourceAttributes: Attributes
 ) : AbstractTask(), NewProbabilityCallback {
 
@@ -27,5 +28,9 @@ internal class SendBatchTask(
 
     override fun onNewProbability(newP: Double) {
         sampler.probability = newP
+        persistentState.update {
+            pValue = newP
+            pValueExpiryTime = sampler.expiryTime
+        }
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PersistentStateTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PersistentStateTest.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.performance.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class PersistentStateTest {
+    lateinit var stateFile: File
+
+    @Before
+    fun createStateFile() {
+        stateFile = File.createTempFile("persistent-state", ".json")
+    }
+
+    @After
+    fun deleteStateFile() {
+        stateFile.delete()
+    }
+
+    @Test
+    fun updateAndSave() {
+        val persistentState = PersistentState(stateFile)
+        persistentState.update {
+            pValue = 0.01234
+            pValueExpiryTime = Long.MAX_VALUE
+        }
+
+        val newPersistentState = PersistentState(stateFile)
+        assertEquals(persistentState.pValue, newPersistentState.pValue, 0.000001)
+        assertEquals(persistentState.pValueExpiryTime, newPersistentState.pValueExpiryTime)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
@@ -39,9 +39,10 @@ class SendBatchTaskTest {
         }
 
         val delivery = mock<Delivery>()
+        val persistentState = mock<PersistentState>()
 
         val resourceAttributes = Attributes()
-        val sendBatchTask = SendBatchTask(delivery, tracer, resourceAttributes)
+        val sendBatchTask = SendBatchTask(delivery, tracer, persistentState, resourceAttributes)
         val workDone = sendBatchTask.execute()
 
         assertTrue("SendBatchTask should have delivered a batch", workDone)
@@ -55,8 +56,9 @@ class SendBatchTaskTest {
         }
 
         val deliver = mock<Delivery>()
+        val persistentState = mock<PersistentState>()
 
-        val sendBatchTask = SendBatchTask(deliver, tracer, Attributes())
+        val sendBatchTask = SendBatchTask(deliver, tracer, persistentState, Attributes())
         val workDone = sendBatchTask.execute()
 
         assertFalse("SendBatchTask should not have done any work", workDone)
@@ -70,9 +72,10 @@ class SendBatchTaskTest {
         }
 
         val delivery = mock<Delivery>()
+        val persistentState = mock<PersistentState>()
 
         val resourceAttributes = Attributes()
-        val sendBatchTask = SendBatchTask(delivery, tracer, resourceAttributes)
+        val sendBatchTask = SendBatchTask(delivery, tracer, persistentState, resourceAttributes)
         val workDone = sendBatchTask.execute()
 
         assertFalse("SendBatchTask should not have done any work", workDone)


### PR DESCRIPTION
 ## Goal
Ensure that the `pValue` is persisted and can be loaded on startup.

## Design
Introduced `PersistentState` to contain values that can change at runtime, but should last through a process restart. The `PersistentState` deliberately swallows any IO related errors, and uses simple non-atomic IO operations as these values are still technically ephemeral, and an IO error simply results in a return to the defaults.

## Testing
A new unit test was introduced for the `PersistentState` class