### PR TITLE
Add a "wait for" check based on the total number spans

### DIFF
--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -44,19 +44,19 @@ Feature: Manual creation of spans
   @skip
   Scenario: Span batch times out
     Given I run "BatchTimeoutScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait for 2 spans
     Then a span name equals "Custom/Span 1"
     * a span name equals "Custom/Span 2"
 
   Scenario: Send on App backgrounded
     Given I run "AppBackgroundedScenario" and discard the initial p-value request
     And I send the app to the background for 5 seconds
-    And I wait to receive 1 traces
+    And I wait for 1 span
     Then a span name equals "Custom/Span 1"
 
   Scenario: Spans logged in the background
     Given I run "BackgroundSpanScenario" and discard the initial p-value request
     And I send the app to the background for 5 seconds
-    And I wait to receive 1 traces
+    And I wait for 1 span
     Then a span name equals "Custom/BackgroundSpan"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" attribute "bugsnag.app.in_foreground" is false

--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -8,7 +8,7 @@ Feature: Server responses
   Scenario: No P update: success, fail-permanent, fail-retriable
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 3 traces
+    And I wait to receive at least 3 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
@@ -110,7 +110,7 @@ Feature: Server responses
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   Scenario: Update P to 0 on first response: fail-permanent, fail-retriable, success
@@ -173,7 +173,7 @@ Feature: Server responses
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "null,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 2 traces
+    And I wait to receive at least 2 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     And I discard the oldest trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"


### PR DESCRIPTION
## Goal
Avoid problems with span delivery ordering and batching where it's not always strict by allowing scenarios to wait for a set number of spans across any number of traces.

## Testing
Modified the `manual_spans` scenario to use the next step