### PR TITLE
Additional error handling in Worker

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -30,6 +30,7 @@
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:ResourceAttributes.kt$ex: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:Worker.kt$Worker$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
     <ID>TooManyFunctions:PerformanceLifecycleCallbacks.kt$PerformanceLifecycleCallbacks : ActivityLifecycleCallbacksCallback</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -16,4 +16,6 @@ internal class RetryDeliveryTask(
         }
         return true
     }
+
+    override fun toString(): String = "RetryDeliveryTask"
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -33,4 +33,6 @@ internal class SendBatchTask(
             pValueExpiryTime = sampler.expiryTime
         }
     }
+
+    override fun toString(): String = "SendBatch[$delivery]"
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
@@ -96,11 +96,23 @@ internal class Worker(
     }
 
     private fun attachTasks() {
-        tasks.forEach { it.onAttach(this) }
+        tasks.forEach { task ->
+            try {
+                task.onAttach(this)
+            } catch (e: Exception) {
+                Logger.w("unhandled exception while attempting to attach worker $task", e)
+            }
+        }
     }
 
     private fun detachWorkers() {
-        tasks.forEach { it.onDetach(this) }
+        tasks.forEach { task ->
+            try {
+                task.onDetach(this)
+            } catch (e: Exception) {
+                Logger.w("unhandled exception while attempting to detach worker $task", e)
+            }
+        }
     }
 
     fun wake() {


### PR DESCRIPTION
## Goal
Avoid crashing the client app when attaching / detaching tasks.

## Design
Added error handling and logging to the `Worker` when it attaches / detaches tasks, which avoids crashing the client app when starting / stopping the worker.

The most commonly visible issue was when attempting to retrieve the initial p-value from the server when there is no network, the `UnkownHostException` propagated through the worker and crashed the app.

## Testing
Manually tested using the example app.