### PR TITLE
Change the e2e tests to use "receive at least"

### DIFF
--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -2,7 +2,7 @@ Feature: Manual creation of spans
 
   Scenario: Manual spans can be logged
     Given I run "ManualSpanScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace Bugsnag-Integrity header is valid
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
@@ -44,7 +44,7 @@ Feature: Manual creation of spans
   @skip
   Scenario: Span batch times out
     Given I run "BatchTimeoutScenario" and discard the initial p-value request
-    And I wait for 2 spans
+    And I wait to receive at least 2 spans
     Then a span name equals "Custom/Span 1"
     * a span name equals "Custom/Span 2"
 

--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -89,21 +89,21 @@ Feature: Server responses
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   Scenario: Update P to 0 on first response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   Scenario: Update P to 0 on first response: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   Scenario: Update P to 0 on first response: fail-retriable, success, fail-permanent
@@ -117,14 +117,14 @@ Feature: Server responses
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   Scenario: Update P to 0 on first response: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     Given I set the sampling probability for the next traces to "null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive 1 traces
+    And I wait to receive at least 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
 
   # P=0 on second response


### PR DESCRIPTION
## Goal
Reduce the flakiness of the end-to-end tests by not requiring exact matches for most spans & traces.

## Testing
Re-ran the entire build pipeline several times without failure.