### PR TITLE
Add the Bugsnag-Span-Sampling header to the trace payloads

### DIFF
--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -88,7 +88,8 @@ class RetryDeliveryTest {
         val retryQueue = mock<RetryQueue>()
         val retry = RetryDelivery(retryQueue, stub)
 
-        val tracePayload = TracePayload.createTracePayload("fake-api-key", byteArrayOf(), 0L)
+        val tracePayload =
+            TracePayload.createTracePayload("fake-api-key", byteArrayOf(), timestamp = 0L)
 
         stub.reset(DeliveryResult.Failed(tracePayload, true))
         retry.deliver(
@@ -116,7 +117,8 @@ class RetryDeliveryTest {
         val retryQueue = mock<RetryQueue>()
         val retry = RetryDelivery(retryQueue, stub)
 
-        val tracePayload = TracePayload.createTracePayload("fake-api-key", byteArrayOf(), 0L)
+        val tracePayload =
+            TracePayload.createTracePayload("fake-api-key", byteArrayOf(), timestamp = 0L)
 
         stub.reset(DeliveryResult.Failed(tracePayload, false))
         retry.deliver(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
@@ -1,0 +1,44 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.testSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class TracePayloadTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun createSpanFactory() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun testSamplerHeader() {
+        val spans = listOf(
+            createSpan(0.3),
+            createSpan(0.1),
+            createSpan(0.5),
+            createSpan(0.3),
+            createSpan(0.5),
+            createSpan(0.3),
+        )
+
+        val tracePayload = TracePayload.createTracePayload("abc123", spans, Attributes())
+        assertEquals(
+            "0.1:1;0.3:3;0.5:2",
+            tracePayload.headers["Bugsnag-Span-Sampling"]
+        )
+    }
+
+    private fun createSpan(pValue: Double): Span =
+        spanFactory.newSpan(processor = testSpanProcessor).apply {
+            samplingProbability = pValue
+        }
+}

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -4,6 +4,7 @@ Feature: Manual creation of spans
     Given I run "ManualSpanScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
     Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"


### PR DESCRIPTION
## Goal
Send a count of the spans with each discrete pValue to the server in the `Bugsnag-Span-Sampling` header.

## Testing
A new unit test and check on the `manual-spans` end-to-end test