### PR TITLE
Changed the `NewProbabilityCallback` to be a property

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
@@ -20,16 +20,9 @@ internal fun interface NewProbabilityCallback {
 }
 
 internal interface Delivery {
-    fun deliver(
-        spans: Collection<SpanImpl>,
-        resourceAttributes: Attributes,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult
+    var newProbabilityCallback: NewProbabilityCallback?
 
-    fun deliver(
-        tracePayload: TracePayload,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult
-
-    fun fetchCurrentProbability(newPCallback: NewProbabilityCallback)
+    fun deliver(spans: Collection<SpanImpl>, resourceAttributes: Attributes): DeliveryResult
+    fun deliver(tracePayload: TracePayload): DeliveryResult
+    fun fetchCurrentProbability()
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
@@ -5,33 +5,21 @@ import com.bugsnag.android.performance.Attributes
 internal class RetryDelivery(
     private val retryQueue: RetryQueue,
     private val delivery: Delivery
-) : Delivery {
+) : Delivery by delivery {
     override fun deliver(
         spans: Collection<SpanImpl>,
-        resourceAttributes: Attributes,
-        newProbabilityCallback: NewProbabilityCallback?
+        resourceAttributes: Attributes
     ): DeliveryResult {
         if (spans.isEmpty()) {
             return DeliveryResult.Success
         }
 
-        val result = delivery.deliver(spans, resourceAttributes, newProbabilityCallback)
+        val result = delivery.deliver(spans, resourceAttributes)
         if (result is DeliveryResult.Failed && result.canRetry) {
             retryQueue.add(result.payload)
         }
         return result
     }
 
-    override fun deliver(
-        tracePayload: TracePayload,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult {
-        return delivery.deliver(tracePayload, newProbabilityCallback)
-    }
-
     override fun toString(): String = "RetryDelivery($delivery)"
-
-    override fun fetchCurrentProbability(newPCallback: NewProbabilityCallback) {
-        delivery.fetchCurrentProbability(newPCallback)
-    }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -6,7 +6,7 @@ internal class RetryDeliveryTask(
 ) : AbstractTask() {
     override fun execute(): Boolean {
         val nextPayload = retryQueue.next() ?: return false
-        val result = delivery.deliver(nextPayload, null)
+        val result = delivery.deliver(nextPayload)
 
         // if it was delivered, or can never be delivered - delete it
         if (result is DeliveryResult.Success ||

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
@@ -1,42 +1,36 @@
 package com.bugsnag.android.performance.internal
 
-internal class Sampler(fallbackProbability: Double) {
-    var fallbackProbability = fallbackProbability
-        set(value) {
-            field = value
-            currentProbability = value
-            expiryTime = newExpiryTime()
-        }
+import androidx.annotation.FloatRange
+import com.bugsnag.android.performance.internal.SpanImpl
 
-    var probability: Double
-        get() {
-            return when {
-                System.currentTimeMillis() > expiryTime -> fallbackProbability
-                else -> currentProbability
-            }
-        }
-        set(value) {
-            currentProbability = value
-            expiryTime = newExpiryTime()
-        }
-
-    var expiryTime = newExpiryTime()
-    private var currentProbability = fallbackProbability
-
-    fun loadConfiguration(persistentState: PersistentState) {
-        this.currentProbability = persistentState.pValue
-        this.expiryTime = persistentState.pValueExpiryTime
-    }
-
+internal class Sampler(
+    /**
+     * The probability that any given [Span] is retained during sampling as a value between 0 and 1.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    var sampleProbability: Double,
+    private val persistentState: PersistentState?
+) : NewProbabilityCallback {
     fun sampled(spans: Collection<SpanImpl>): Collection<SpanImpl> {
         return spans.filter { shouldKeepSpan(it) }
     }
 
     // Side effect: Sets span.samplingProbability to the current probability
     fun shouldKeepSpan(span: SpanImpl): Boolean {
-        val upperBound = probability
+        val upperBound = sampleProbability
         span.samplingProbability = upperBound
         return upperBound > 0.0 && span.samplingValue <= upperBound
+    }
+
+    fun isProbabilityValid() =
+        persistentState?.let { System.currentTimeMillis() < it.pValueExpiryTime } ?: true
+
+    override fun onNewProbability(newP: Double) {
+        sampleProbability = newP
+        persistentState?.update {
+            pValue = newP
+            pValueExpiryTime = newExpiryTime()
+        }
     }
 
     private fun newExpiryTime() = System.currentTimeMillis() + InternalDebug.pValueExpireAfterMs

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
@@ -55,12 +55,12 @@ internal data class TracePayload(
             return createTracePayload(apiKey, payloadBytes, headers, timestamp)
         }
 
-        private fun calculateSpanSamplingHeader(spans: Collection<Span>): String =
+        private fun calculateSpanSamplingHeader(spans: Collection<SpanImpl>): String =
             calculateProbabilityCounts(spans).entries.joinToString(";") { (pValue, count) ->
                 "$pValue:$count"
             }
 
-        private fun calculateProbabilityCounts(spans: Collection<Span>): Map<Double, Int> {
+        private fun calculateProbabilityCounts(spans: Collection<SpanImpl>): Map<Double, Int> {
             // using a TreeMap gives us a natural ascending order here
             val pValueCounts = TreeMap<Double, Int>()
             spans.forEach { span ->

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
@@ -5,12 +5,12 @@ import com.bugsnag.android.performance.Span
 
 internal class Tracer : SpanProcessor {
 
-    internal val sampler = Sampler(1.0)
-
     @Suppress("DoubleMutabilityForCollection") // we swap out this ArrayList when we flush batches
     private var batch = ArrayList<SpanImpl>()
 
     private var lastBatchSendTime = SystemClock.elapsedRealtime()
+
+    internal var sampler = Sampler(1.0, null)
 
     internal var worker: Worker? = null
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -39,7 +39,6 @@ class RetryDeliveryTest {
                 )
             ),
             attributes,
-            null
         )
         assertEquals(1, stub.lastSpanDelivery?.size)
 
@@ -57,7 +56,6 @@ class RetryDeliveryTest {
                 )
             ),
             attributes,
-            null
         )
         assertEquals(1, stub.lastSpanDelivery?.size)
 
@@ -75,7 +73,6 @@ class RetryDeliveryTest {
                 )
             ),
             attributes,
-            null
         )
         assertEquals(1, stub.lastSpanDelivery?.size)
     }
@@ -103,7 +100,6 @@ class RetryDeliveryTest {
                 )
             ),
             attributes,
-            null
         )
         assertEquals(1, stub.lastSpanDelivery?.size)
         verify(retryQueue).add(same(tracePayload))
@@ -132,7 +128,6 @@ class RetryDeliveryTest {
                 )
             ),
             attributes,
-            null
         )
         assertEquals(1, stub.lastSpanDelivery?.size)
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.test.CollectingSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import com.bugsnag.android.performance.test.withDebugValues
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,26 +20,8 @@ class SamplerTest {
     }
 
     @Test
-    fun testPExpiry() = InternalDebug.withDebugValues {
-        val oldExpiry = InternalDebug.pValueExpireAfterMs
-        InternalDebug.pValueExpireAfterMs = 10
-        val sampler = Sampler(1.0)
-        sampler.probability = 0.2
-        val span = spanFactory.newSpan(
-            processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE)
-        )
-        assertTrue(!sampler.shouldKeepSpan(span))
-        assertTrue(sampler.probability == 0.2)
-        Thread.sleep(100)
-        assertTrue(sampler.shouldKeepSpan(span))
-        assertTrue(sampler.probability == 1.0)
-        InternalDebug.pValueExpireAfterMs = oldExpiry
-    }
-
-    @Test
     fun testSampleSpanProbability1() {
-        val sampler = Sampler(1.0)
+        val sampler = Sampler(1.0, null)
         var span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0))
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
@@ -62,7 +43,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanProbability0() {
-        val sampler = Sampler(0.0)
+        val sampler = Sampler(0.0, null)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
             traceId = uuidWithUpper(0)
@@ -87,7 +68,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanProbability0_5() {
-        val sampler = Sampler(0.5)
+        val sampler = Sampler(0.5, null)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
             traceId = uuidWithUpper(0)
@@ -107,7 +88,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability1() {
-        val sampler = Sampler(1.0)
+        val sampler = Sampler(1.0, null)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
@@ -129,7 +110,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability0() {
-        val sampler = Sampler(0.0)
+        val sampler = Sampler(0.0, null)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
@@ -148,7 +129,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability0_5() {
-        val sampler = Sampler(0.5)
+        val sampler = Sampler(0.5, null)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
@@ -10,7 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -38,14 +37,13 @@ class SendBatchTaskTest {
         }
 
         val delivery = mock<Delivery>()
-        val persistentState = mock<PersistentState>()
 
         val resourceAttributes = Attributes()
-        val sendBatchTask = SendBatchTask(delivery, tracer, persistentState, resourceAttributes)
+        val sendBatchTask = SendBatchTask(delivery, tracer, resourceAttributes)
         val workDone = sendBatchTask.execute()
 
         assertTrue("SendBatchTask should have delivered a batch", workDone)
-        verify(delivery).deliver(argWhere { it.size == 10 }, eq(resourceAttributes), anyOrNull())
+        verify(delivery).deliver(argWhere { it.size == 10 }, eq(resourceAttributes))
     }
 
     @Test
@@ -55,9 +53,8 @@ class SendBatchTaskTest {
         }
 
         val deliver = mock<Delivery>()
-        val persistentState = mock<PersistentState>()
 
-        val sendBatchTask = SendBatchTask(deliver, tracer, persistentState, Attributes())
+        val sendBatchTask = SendBatchTask(deliver, tracer, Attributes())
         val workDone = sendBatchTask.execute()
 
         assertFalse("SendBatchTask should not have done any work", workDone)
@@ -71,13 +68,12 @@ class SendBatchTaskTest {
         }
 
         val delivery = mock<Delivery>()
-        val persistentState = mock<PersistentState>()
 
         val resourceAttributes = Attributes()
-        val sendBatchTask = SendBatchTask(delivery, tracer, persistentState, resourceAttributes)
+        val sendBatchTask = SendBatchTask(delivery, tracer, resourceAttributes)
         val workDone = sendBatchTask.execute()
 
         assertFalse("SendBatchTask should not have done any work", workDone)
-        verify(delivery).deliver(any<List<SpanImpl>>(), eq(resourceAttributes), anyOrNull())
+        verify(delivery).deliver(any<List<SpanImpl>>(), eq(resourceAttributes))
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
-import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.test.TestSpanFactory
 import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
@@ -37,7 +36,7 @@ internal class TracePayloadTest {
         )
     }
 
-    private fun createSpan(pValue: Double): Span =
+    private fun createSpan(pValue: Double): SpanImpl =
         spanFactory.newSpan(processor = testSpanProcessor).apply {
             samplingProbability = pValue
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
@@ -16,6 +16,9 @@ internal class StubDelivery : Delivery {
 
     private val lock = ReentrantLock(false)
     private val deliveryCondition = lock.newCondition()
+    override var newProbabilityCallback: NewProbabilityCallback?
+        set(_) = Unit
+        get() = null
 
     fun awaitDelivery(timeout: Long = 60_000L) {
         lock.withLock {
@@ -30,11 +33,7 @@ internal class StubDelivery : Delivery {
         lastSpanDelivery = null
     }
 
-    override fun deliver(
-        spans: Collection<SpanImpl>,
-        resourceAttributes: Attributes,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult {
+    override fun deliver(spans: Collection<SpanImpl>, resourceAttributes: Attributes): DeliveryResult {
         lock.withLock {
             lastSpanDelivery = spans
             deliveryCondition.signalAll()
@@ -42,10 +41,7 @@ internal class StubDelivery : Delivery {
         }
     }
 
-    override fun deliver(
-        tracePayload: TracePayload,
-        newProbabilityCallback: NewProbabilityCallback?
-    ): DeliveryResult = nextResult
+    override fun deliver(tracePayload: TracePayload): DeliveryResult = nextResult
 
-    override fun fetchCurrentProbability(newPCallback: NewProbabilityCallback) = Unit
+    override fun fetchCurrentProbability() = Unit
 }


### PR DESCRIPTION
## Goal
Allow for more complex communication by separating the `NewProbabilityCallback` flow from the `deliver` process.

## Design

Instead of passing an optional `NewProbabilityCallback` to each `deliver` call, the callback can be set once on the `Delivery` object. This keeps the `deliver` wrapper implementations simpler and unaware of the possible "back flow" of data.

This PR also moves much of the logic for probability expiry out of `Sampler` - this will be re-introduced as a new worker task in the next PR.

## Testing
Relied on existing tests.