### PR TITLE
Add `SpanOptions` and associated tests

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexMethod:Connectivity.kt$ConnectivityApi24$private fun nameForDataNetworkType(dataNetworkType: Int): String</ID>
+    <ID>ComplexMethod:SpanOptions.kt$SpanOptions$override fun equals(other: Any?): Boolean</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>
     <ID>MagicNumber:Encodings.kt$16</ID>
     <ID>MagicNumber:Encodings.kt$24</ID>

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -3,7 +3,9 @@ package com.bugsnag.android.performance
 import android.os.SystemClock
 import com.bugsnag.android.performance.test.withStaticMock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 
@@ -23,6 +25,11 @@ class SpanOptionsTest {
 
         assertNotEquals(
             SpanOptions.defaults.makeCurrentContext(false),
+            SpanOptions.defaults
+        )
+
+        assertNotEquals(
+            SpanOptions.defaults.setFirstClass(true),
             SpanOptions.defaults
         )
 
@@ -46,6 +53,11 @@ class SpanOptionsTest {
             SpanOptions.defaults.within(SpanContext.invalid)
         )
 
+        assertEquals(
+            SpanOptions.defaults.setFirstClass(true),
+            SpanOptions.defaults.setFirstClass(true),
+        )
+
         assertNotEquals(
             SpanOptions.defaults.within(SpanContext.invalid),
             SpanOptions.defaults
@@ -56,7 +68,6 @@ class SpanOptionsTest {
     fun defaultStartTime() = withStaticMock<SystemClock> { clock ->
         val expectedTime = 192837465L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
-
         assertEquals(expectedTime, SpanOptions.defaults.startTime)
     }
 
@@ -66,5 +77,12 @@ class SpanOptionsTest {
         assertEquals(time, SpanOptions.defaults.startTime(time).startTime)
         // test multi overrides of the same value
         assertEquals(time, SpanOptions.defaults.startTime(0L).startTime(time).startTime)
+    }
+
+    @Test
+    fun overrideIsFirstClass() {
+        assertFalse(SpanOptions.defaults.setFirstClass(false).isFirstClass)
+        // test multi overrides of the same value
+        assertTrue(SpanOptions.defaults.setFirstClass(false).setFirstClass(true).isFirstClass)
     }
 }


### PR DESCRIPTION
## Goal
Add `SpanOptions` implementation which will replace the current set of optional arguments in the `startSpan` functions.

## Testing
New unit test added.