### PR TITLE
[PLAT-9554] Don't attempt to send requests when there's no connectivity

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -22,6 +22,7 @@
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$60</ID>
     <ID>MagicNumber:Persistence.kt$RetryQueue$19</ID>
     <ID>MagicNumber:Persistence.kt$TraceFileDecoder$1024</ID>
+    <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -114,6 +114,7 @@ object BugsnagPerformance {
             requireNotNull(configuration.apiKey) {
                 "PerformanceConfiguration.apiKey may not be null"
             },
+            connectivity,
         )
 
         val persistence = Persistence(application)
@@ -129,7 +130,7 @@ object BugsnagPerformance {
         val bsgWorker = Worker(
             samplerTask,
             SendBatchTask(delivery, tracer, createResourceAttributes(configuration)),
-            RetryDeliveryTask(persistence.retryQueue, httpDelivery),
+            RetryDeliveryTask(persistence.retryQueue, httpDelivery, connectivity),
         )
 
         delivery.newProbabilityCallback = samplerTask

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -170,21 +170,13 @@ internal open class ConnectivityApi24(
 ) : ConnectivityManager.NetworkCallback(), Connectivity {
 
     override val hasConnection: Boolean
-        get() {
-            return connectedFor(capabilities)
-        }
+        get() = connectedFor(capabilities)
     override val metering: ConnectionMetering
-        get() {
-            return meteringFor(capabilities)
-        }
+        get() = meteringFor(capabilities)
     override val networkType: NetworkType
-        get() {
-            return networkTypeFor(capabilities)
-        }
+        get() = networkTypeFor(capabilities)
     override val networkSubType: String?
-        get() {
-            return networkSubTypeFor(capabilities)
-        }
+        get() = networkSubTypeFor(capabilities)
 
     private var capabilities: NetworkCapabilities? =
         cm.getNetworkCapabilities(cm.boundNetworkForProcess)
@@ -271,6 +263,7 @@ internal open class ConnectivityApi24(
     override fun onAvailable(network: Network) {
         capabilities = cm.getNetworkCapabilities(network)
         if (capabilities?.hasCapability(NET_CAPABILITY_INTERNET) == true &&
+            capabilities?.hasCapability(NET_CAPABILITY_VALIDATED) == true &&
             receivedFirstCallback.getAndSet(true)
         ) {
             callback?.invoke(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -12,6 +12,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_METERED
 import android.net.NetworkCapabilities.NET_CAPABILITY_TEMPORARILY_NOT_METERED
+import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_ETHERNET
 import android.net.NetworkCapabilities.TRANSPORT_USB
@@ -96,13 +97,21 @@ internal class ConnectivityLegacy(
 ) : BroadcastReceiver(), Connectivity {
 
     override val hasConnection: Boolean
-        get() { return activeNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION }
+        get() {
+            return activeNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION
+        }
     override val metering: ConnectionMetering
-        get() { return activeNetworkInfo?.metering ?: UnknownNetwork.METERING }
+        get() {
+            return activeNetworkInfo?.metering ?: UnknownNetwork.METERING
+        }
     override val networkType: NetworkType
-        get() { return activeNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE }
+        get() {
+            return activeNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE
+        }
     override val networkSubType: String?
-        get() { return activeNetworkInfo?.subtypeName }
+        get() {
+            return activeNetworkInfo?.subtypeName
+        }
 
     private val receivedFirstCallback = AtomicBoolean(false)
 
@@ -161,15 +170,24 @@ internal open class ConnectivityApi24(
 ) : ConnectivityManager.NetworkCallback(), Connectivity {
 
     override val hasConnection: Boolean
-        get() { return connectedFor(capabilities) }
+        get() {
+            return connectedFor(capabilities)
+        }
     override val metering: ConnectionMetering
-        get() { return meteringFor(capabilities) }
+        get() {
+            return meteringFor(capabilities)
+        }
     override val networkType: NetworkType
-        get() { return networkTypeFor(capabilities) }
+        get() {
+            return networkTypeFor(capabilities)
+        }
     override val networkSubType: String?
-        get() { return networkSubTypeFor(capabilities) }
+        get() {
+            return networkSubTypeFor(capabilities)
+        }
 
-    private var capabilities: NetworkCapabilities? = cm.getNetworkCapabilities(cm.boundNetworkForProcess)
+    private var capabilities: NetworkCapabilities? =
+        cm.getNetworkCapabilities(cm.boundNetworkForProcess)
     private val receivedFirstCallback = AtomicBoolean(false)
     private val tm: TelephonyManager? = context.getTelephonyManager()
 
@@ -229,8 +247,11 @@ internal open class ConnectivityApi24(
     }
 
     protected open fun connectedFor(capabilities: NetworkCapabilities?): Boolean {
-        return capabilities?.hasCapability(NET_CAPABILITY_INTERNET) == true &&
-                receivedFirstCallback.get();
+        if (capabilities == null) return false
+
+        return capabilities.hasCapability(NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NET_CAPABILITY_VALIDATED) &&
+            receivedFirstCallback.get()
     }
 
     override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(this)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -39,12 +39,12 @@ internal enum class ConnectionMetering {
 }
 
 internal interface Connectivity {
-    fun registerForNetworkChanges()
-    fun unregisterForNetworkChanges()
     val hasConnection: Boolean
     val metering: ConnectionMetering
     val networkType: NetworkType
     val networkSubType: String?
+    fun registerForNetworkChanges()
+    fun unregisterForNetworkChanges()
 }
 
 private object UnknownNetwork {
@@ -306,3 +306,6 @@ internal object UnknownConnectivity : Connectivity {
     override val networkType = NetworkType.UNKNOWN
     override val networkSubType = null
 }
+
+internal fun Connectivity.shouldAttemptDelivery(): Boolean =
+    networkType == NetworkType.UNKNOWN || hasConnection

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -29,7 +29,7 @@ internal typealias NetworkChangeCallback = (
     hasConnection: Boolean,
     metering: ConnectionMetering,
     networkType: NetworkType,
-    networkSubType: String?
+    networkSubType: String?,
 ) -> Unit
 
 internal enum class ConnectionMetering {
@@ -56,7 +56,7 @@ private object UnknownNetwork {
 
 internal class ConnectivityCompat(
     context: Context,
-    callback: NetworkChangeCallback?
+    callback: NetworkChangeCallback?,
 ) : Connectivity {
 
     private val cm = context.getConnectivityManager()
@@ -93,7 +93,7 @@ internal class ConnectivityCompat(
 internal class ConnectivityLegacy(
     private val context: Context,
     private val cm: ConnectivityManager,
-    private val callback: NetworkChangeCallback?
+    private val callback: NetworkChangeCallback?,
 ) : BroadcastReceiver(), Connectivity {
 
     override val hasConnection: Boolean
@@ -156,7 +156,7 @@ internal class ConnectivityLegacy(
                 newNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION,
                 newNetworkInfo?.metering ?: UnknownNetwork.METERING,
                 newNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE,
-                newNetworkInfo?.subtypeName
+                newNetworkInfo?.subtypeName,
             )
         }
     }
@@ -166,7 +166,7 @@ internal class ConnectivityLegacy(
 internal open class ConnectivityApi24(
     private val context: Context,
     internal val cm: ConnectivityManager,
-    private val callback: NetworkChangeCallback?
+    private val callback: NetworkChangeCallback?,
 ) : ConnectivityManager.NetworkCallback(), Connectivity {
 
     override val hasConnection: Boolean
@@ -255,7 +255,7 @@ internal open class ConnectivityApi24(
                 UnknownNetwork.HAS_CONNECTION,
                 UnknownNetwork.METERING,
                 UnknownNetwork.NETWORK_TYPE,
-                UnknownNetwork.NETWORK_SUBTYPE
+                UnknownNetwork.NETWORK_SUBTYPE,
             )
         }
     }
@@ -270,7 +270,7 @@ internal open class ConnectivityApi24(
                 true,
                 meteringFor(capabilities),
                 networkTypeFor(capabilities),
-                networkSubTypeFor(capabilities)
+                networkSubTypeFor(capabilities),
             )
         }
     }
@@ -280,7 +280,7 @@ internal open class ConnectivityApi24(
 internal class ConnectivityApi31(
     context: Context,
     cm: ConnectivityManager,
-    callback: NetworkChangeCallback?
+    callback: NetworkChangeCallback?,
 ) : ConnectivityApi24(context, cm, callback) {
 
     override fun meteringFor(capabilities: NetworkCapabilities?): ConnectionMetering {
@@ -307,5 +307,10 @@ internal object UnknownConnectivity : Connectivity {
     override val networkSubType = null
 }
 
+/**
+ * Should we attempt to deliver a payload based on the current status of the `Connectivity`. Returns
+ * `true` if the `Connectivity` [hasConnection] *or* is an unknown network (handling edge cases
+ * where the network status has not been set yet, or the app might not have appropriate permissions).
+ */
 internal fun Connectivity.shouldAttemptDelivery(): Boolean =
     networkType == NetworkType.UNKNOWN || hasConnection

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -19,10 +19,10 @@ internal class HttpDelivery(
     }
 
     override fun deliver(tracePayload: TracePayload): DeliveryResult {
-//        if (!connectivity.hasConnection) {
-//            // We can't deliver now but can retry later.
-//            return DeliveryResult.Failed(tracePayload, true)
-//        }
+        if (!connectivity.hasConnection) {
+            // We can't deliver now but can retry later.
+            return DeliveryResult.Failed(tracePayload, true)
+        }
 
         val connection = URL(endpoint).openConnection() as HttpURLConnection
         with(connection) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -7,6 +7,7 @@ import java.net.URL
 internal class HttpDelivery(
     private val endpoint: String,
     private val apiKey: String,
+    private val connectivity: Connectivity,
 ) : Delivery {
     override var newProbabilityCallback: NewProbabilityCallback? = null
 
@@ -18,6 +19,11 @@ internal class HttpDelivery(
     }
 
     override fun deliver(tracePayload: TracePayload): DeliveryResult {
+        if (!connectivity.hasConnection) {
+            // We can't deliver now but can retry later.
+            return DeliveryResult.Failed(tracePayload, true)
+        }
+
         val connection = URL(endpoint).openConnection() as HttpURLConnection
         with(connection) {
             requestMethod = "POST"

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Logger
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -20,6 +21,7 @@ internal class HttpDelivery(
 
     override fun deliver(tracePayload: TracePayload): DeliveryResult {
         if (!connectivity.hasConnection) {
+            Logger.d("HttpDelivery refusing to delivery payload - no connectivity.")
             // We can't deliver now but can retry later.
             return DeliveryResult.Failed(tracePayload, true)
         }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -19,10 +19,10 @@ internal class HttpDelivery(
     }
 
     override fun deliver(tracePayload: TracePayload): DeliveryResult {
-        if (!connectivity.hasConnection) {
-            // We can't deliver now but can retry later.
-            return DeliveryResult.Failed(tracePayload, true)
-        }
+//        if (!connectivity.hasConnection) {
+//            // We can't deliver now but can retry later.
+//            return DeliveryResult.Failed(tracePayload, true)
+//        }
 
         val connection = URL(endpoint).openConnection() as HttpURLConnection
         with(connection) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -20,7 +20,7 @@ internal class HttpDelivery(
     }
 
     override fun deliver(tracePayload: TracePayload): DeliveryResult {
-        if (!connectivity.hasConnection) {
+        if (!connectivity.shouldAttemptDelivery()) {
             Logger.d("HttpDelivery refusing to delivery payload - no connectivity.")
             // We can't deliver now but can retry later.
             return DeliveryResult.Failed(tracePayload, true)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Logger
 
 internal class RetryDelivery(
     private val retryQueue: RetryQueue,
@@ -16,6 +17,7 @@ internal class RetryDelivery(
 
         val result = delivery.deliver(spans, resourceAttributes)
         if (result is DeliveryResult.Failed && result.canRetry) {
+            Logger.d("Delivery failed - will schedule for retry")
             retryQueue.add(result.payload)
         }
         return result

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -2,9 +2,14 @@ package com.bugsnag.android.performance.internal
 
 internal class RetryDeliveryTask(
     private val retryQueue: RetryQueue,
-    private val delivery: Delivery
+    private val delivery: Delivery,
+    private val connectivity: Connectivity
 ) : AbstractTask() {
     override fun execute(): Boolean {
+        if (!connectivity.hasConnection) {
+            return false;
+        }
+
         val nextPayload = retryQueue.next() ?: return false
         val result = delivery.deliver(nextPayload)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -8,7 +8,7 @@ internal class RetryDeliveryTask(
     private val connectivity: Connectivity
 ) : AbstractTask() {
     override fun execute(): Boolean {
-        if (!connectivity.hasConnection) {
+        if (!connectivity.shouldAttemptDelivery()) {
             Logger.d("Skipping RetryDeliveryTask - no connectivity.")
             return false;
         }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -6,9 +6,9 @@ internal class RetryDeliveryTask(
     private val connectivity: Connectivity
 ) : AbstractTask() {
     override fun execute(): Boolean {
-        if (!connectivity.hasConnection) {
-            return false;
-        }
+//        if (!connectivity.hasConnection) {
+//            return false;
+//        }
 
         val nextPayload = retryQueue.next() ?: return false
         val result = delivery.deliver(nextPayload)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android.performance.internal
 
+import com.bugsnag.android.performance.Logger
+
 internal class RetryDeliveryTask(
     private val retryQueue: RetryQueue,
     private val delivery: Delivery,
@@ -7,6 +9,7 @@ internal class RetryDeliveryTask(
 ) : AbstractTask() {
     override fun execute(): Boolean {
         if (!connectivity.hasConnection) {
+            Logger.d("Skipping RetryDeliveryTask - no connectivity.")
             return false;
         }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -6,9 +6,9 @@ internal class RetryDeliveryTask(
     private val connectivity: Connectivity
 ) : AbstractTask() {
     override fun execute(): Boolean {
-//        if (!connectivity.hasConnection) {
-//            return false;
-//        }
+        if (!connectivity.hasConnection) {
+            return false;
+        }
 
         val nextPayload = retryQueue.next() ?: return false
         val result = delivery.deliver(nextPayload)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -39,9 +38,11 @@ class Api24NetworkTypeTest {
         }
 
         val networkCapabilities = mock<NetworkCapabilities>()
-        whenever(networkCapabilities.hasTransport(eq(transportType)))
+        whenever(networkCapabilities.hasTransport(transportType))
             .thenReturn(true)
-        whenever(networkCapabilities.hasCapability(eq(NetworkCapabilities.NET_CAPABILITY_INTERNET)))
+        whenever(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET))
+            .thenReturn(true)
+        whenever(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
             .thenReturn(true)
 
         whenever(connectivityManager.getNetworkCapabilities(any()))

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.test.CollectingSpanProcessor
+import com.bugsnag.android.performance.test.TestSpanFactory
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HttpDeliveryTest {
+    val spanFactory = TestSpanFactory()
+    val spanProcessor = CollectingSpanProcessor()
+
+    @Test
+    fun noConnectivity() {
+        val connectivity = mock<Connectivity> {
+            on { hasConnection } doReturn false
+        }
+        val delivery = HttpDelivery("http://localhost", "0123456789abcdef0123456789abcdef", connectivity)
+
+        val spans = spanFactory.newSpans(5, spanProcessor)
+        val result = delivery.deliver(spans, Attributes())
+
+        Assert.assertTrue(result is DeliveryResult.Failed)
+        val failed = (result as DeliveryResult.Failed)
+        Assert.assertTrue(failed.canRetry)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
@@ -1,12 +1,20 @@
 package com.bugsnag.android.performance.internal
 
+import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.test.StubDelivery
-import org.junit.Assert
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class RetryDeliveryTaskTest {
+
+    @Before
+    fun configureLogging() {
+        Logger.delegate = NoopLogger
+    }
 
     @Test
     fun testNoConnectivity() {
@@ -14,7 +22,7 @@ class RetryDeliveryTaskTest {
             TracePayload.createTracePayload("fake-api-key", byteArrayOf(), timestamp = 0L)
 
         val delivery = StubDelivery()
-        val retryQueue = mock<RetryQueue>() {
+        val retryQueue = mock<RetryQueue> {
             on { next() } doReturn tracePayload
         }
         val connectivity = mock<Connectivity> {
@@ -22,7 +30,7 @@ class RetryDeliveryTaskTest {
         }
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
 
-        Assert.assertFalse(retryDeliveryTask.execute())
-        Assert.assertNull(delivery.lastSpanDelivery)
+        assertFalse(retryDeliveryTask.execute())
+        assertNull(delivery.lastSpanDelivery)
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
@@ -1,0 +1,28 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.test.StubDelivery
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class RetryDeliveryTaskTest {
+
+    @Test
+    fun testNoConnectivity() {
+        val tracePayload =
+            TracePayload.createTracePayload("fake-api-key", byteArrayOf(), timestamp = 0L)
+
+        val delivery = StubDelivery()
+        val retryQueue = mock<RetryQueue>() {
+            on { next() } doReturn tracePayload
+        }
+        val connectivity = mock<Connectivity> {
+            on { hasConnection } doReturn false
+        }
+        val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
+
+        Assert.assertFalse(retryDeliveryTask.execute())
+        Assert.assertNull(delivery.lastSpanDelivery)
+    }
+}

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
-    <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$90_000L</ID>
+    <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$100</ID>
@@ -20,8 +20,10 @@
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$4</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$50</ID>
     <ID>MagicNumber:RetryScenario.kt$RetryScenario$100</ID>
+    <ID>MagicNumber:RetryScenario.kt$RetryScenario$50L</ID>
     <ID>MagicNumber:RetryTimeoutScenario.kt$RetryTimeoutScenario$100</ID>
     <ID>MagicNumber:RetryTimeoutScenario.kt$RetryTimeoutScenario$105</ID>
+    <ID>MagicNumber:RetryTimeoutScenario.kt$RetryTimeoutScenario$50L</ID>
     <ID>MagicNumber:SamplingProbabilityZeroScenario.kt$SamplingProbabilityZeroScenario$100</ID>
     <ID>MagicNumber:ThreeSpansScenario.kt$ThreeSpansScenario$300</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
@@ -1,5 +1,8 @@
 package com.bugsnag.mazeracer.scenarios
 
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
@@ -10,6 +13,9 @@ class AppBackgroundedScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String
 ) : Scenario(config, scenarioMetadata) {
+
+    private val handler = Handler(Looper.getMainLooper())
+
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 100
         // this should be longer than the Mazerunner timeout
@@ -21,6 +27,16 @@ class AppBackgroundedScenario(
 
         measureSpan("Span 1") {
             Thread.sleep(1)
+        }
+
+        // we send ourselves to the background, since the Appium action isn't very reliable
+        handler.post {
+            context.startActivity(
+                Intent().apply {
+                    setAction(Intent.ACTION_MAIN)
+                    addCategory(Intent.CATEGORY_HOME)
+                },
+            )
         }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
@@ -19,7 +19,7 @@ class AppBackgroundedScenario(
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 100
         // this should be longer than the Mazerunner timeout
-        InternalDebug.workerSleepMs = 90_000L
+        InternalDebug.workerSleepMs = 120_000L
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundSpanScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundSpanScenario.kt
@@ -2,9 +2,11 @@ package com.bugsnag.mazeracer.scenarios
 
 import android.app.Activity
 import android.app.Application
+import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
@@ -14,8 +16,11 @@ import java.util.concurrent.TimeUnit
 
 class BackgroundSpanScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
+
+    private val handler = Handler(Looper.getMainLooper())
+
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
     }
@@ -26,26 +31,55 @@ class BackgroundSpanScenario(
         val application = context.applicationContext as Application
 
         // we wait until the app is in the background before starting this span
-        application.registerActivityLifecycleCallbacks(object :
+        application.registerActivityLifecycleCallbacks(
+            object :
                 Application.ActivityLifecycleCallbacks {
-                private val handler = Handler(Looper.getMainLooper())
                 override fun onActivityStopped(activity: Activity) {
+                    Log.i("BackgroundSpan", "onActivityStopped($activity)")
                     handler.postDelayed(
                         {
                             measureSpan("BackgroundSpan") {
                                 Thread.sleep(1)
                             }
                         },
-                        TimeUnit.SECONDS.toMillis(1)
+                        TimeUnit.SECONDS.toMillis(1),
                     )
                 }
 
-                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
-                override fun onActivityStarted(activity: Activity) = Unit
-                override fun onActivityResumed(activity: Activity) = Unit
-                override fun onActivityPaused(activity: Activity) = Unit
-                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
-                override fun onActivityDestroyed(activity: Activity) = Unit
-            })
+                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                    Log.i("BackgroundSpan", "onActivityCreated($activity)")
+                }
+
+                override fun onActivityStarted(activity: Activity) {
+                    Log.i("BackgroundSpan", "onActivityStarted($activity)")
+                }
+
+                override fun onActivityResumed(activity: Activity) {
+                    Log.i("BackgroundSpan", "onActivityResumed($activity)")
+                }
+
+                override fun onActivityPaused(activity: Activity) {
+                    Log.i("BackgroundSpan", "onActivityPaused($activity)")
+                }
+
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+                    Log.i("BackgroundSpan", "onActivitySaveInstanceState($activity)")
+                }
+
+                override fun onActivityDestroyed(activity: Activity) {
+                    Log.i("BackgroundSpan", "onActivityDestroyed($activity)")
+                }
+            },
+        )
+
+        // we send ourselves to the background, since the Appium action isn't very reliable
+        handler.post {
+            context.startActivity(
+                Intent().apply {
+                    setAction(Intent.ACTION_MAIN)
+                    addCategory(Intent.CATEGORY_HOME)
+                },
+            )
+        }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryScenario.kt
@@ -4,7 +4,6 @@ import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.Scenario
-import java.util.concurrent.TimeUnit
 
 class RetryScenario(
     config: PerformanceConfiguration,
@@ -12,7 +11,7 @@ class RetryScenario(
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
-        InternalDebug.workerSleepMs = TimeUnit.SECONDS.toMillis(1)
+        InternalDebug.workerSleepMs = 50L
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryTimeoutScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/RetryTimeoutScenario.kt
@@ -11,6 +11,7 @@ class RetryTimeoutScenario(
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
+        InternalDebug.workerSleepMs = 50L
         InternalDebug.dropSpansOlderThanMs = 100
     }
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,8 @@
+BeforeAll do
+  Maze.config.receive_no_requests_wait = 10
+  Maze.config.receive_requests_wait = 60
+end
+
 Before('@skip') do |scenario|
   skip_this_scenario("Skipping scenario")
 end


### PR DESCRIPTION
## Goal

If there's no connectivity, we shouldn't do a bunch of futile work like loading retries from disk or sending requests.

## Design

`Connectivity` has been enhanced to allow ad-hoc queries of the data that was only available in "network status changed" callbacks before.

`HttpDelivery` and `RetryDeliveryTask` use this to short-circuit when no connectivity is available.

## Testing

Added some no-connectivity unit tests.
