### PR TITLE
Allow internal access to `contextStack`

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
@@ -13,8 +13,9 @@ interface SpanContext {
             override fun initialValue(): Deque<SpanContext> = ArrayDeque()
         }
 
-        private val contextStack: Deque<SpanContext> =
-            threadLocalStorage.get() as Deque<SpanContext>
+        @get:JvmSynthetic
+        internal val contextStack: Deque<SpanContext>
+            get() = threadLocalStorage.get() as Deque<SpanContext>
 
         /**
          * Retrieve the current [SpanContext] for this thread (or [invalid] if not available).
@@ -23,10 +24,12 @@ interface SpanContext {
         val current: SpanContext
             get() = contextStack.peekFirst() ?: invalid
 
+        @JvmSynthetic
         internal fun attach(toAttach: SpanContext) {
             contextStack.push(toAttach)
         }
 
+        @JvmSynthetic
         internal fun detach(spanContext: SpanContext) {
             val stack = contextStack
             // assume that the top of the stack is 'spanContext' and 'poll' it off

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestUtils.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestUtils.kt
@@ -6,6 +6,8 @@ import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.mockito.MockedStatic
 import org.mockito.Mockito
+import java.util.concurrent.Future
+import java.util.concurrent.FutureTask
 
 val testSpanProcessor = SpanProcessor { }
 
@@ -31,4 +33,13 @@ inline fun <reified S> withStaticMock(block: (MockedStatic<S>) -> Unit) {
 fun endedSpans(vararg spans: SpanImpl): Collection<SpanImpl> {
     spans.forEach { it.end() }
     return spans.asList()
+}
+
+/**
+ * Run [block] on a background thread and return a `Future` handle to access its result (or exception)
+ */
+fun <V> task(block: () -> V): Future<V> {
+    val task = FutureTask { block() }
+    Thread(task).start()
+    return task
 }


### PR DESCRIPTION
## Goal
Change `contextStack` access to internal, enabling context stack-aware logic (such as "are any view_load spans on the stack").

This PR also fixes a thread-local access bug, and improves the unit testing.

## Testing
Updated unit test