### PR TITLE
Add `ContextAwareThreadPoolExecutor`

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareThreadPoolExecutor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareThreadPoolExecutor.kt
@@ -50,6 +50,6 @@ class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
     ) : super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler)
 
     override fun execute(command: Runnable?) {
-        super.execute(if (command != null) SpanContext.current.wrap(command) else command)
+        super.execute(command?.let { SpanContext.current.wrap(it) })
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareThreadPoolExecutorTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareThreadPoolExecutorTest.kt
@@ -27,22 +27,18 @@ class ContextAwareThreadPoolExecutorTest {
         spanFactory.createCustomSpan("root").use { rootSpan ->
             val executor = ContextAwareThreadPoolExecutor(1, 1, 1L, TimeUnit.MILLISECONDS, LinkedBlockingQueue())
             // submit a task while the root span is active
-            executor.submit(
-                Runnable {
-                    spanFactory.createCustomSpan("task 1").use { taskSpan ->
-                        assertEquals(rootSpan.spanId, taskSpan.parentSpanId)
-                    }
+            executor.submit {
+                spanFactory.createCustomSpan("task 1").use { taskSpan ->
+                    assertEquals(rootSpan.spanId, taskSpan.parentSpanId)
                 }
-            ).get()
+            }.get()
             // submit a task while the child span is active
             spanFactory.createCustomSpan("child").use { childSpan ->
-                executor.submit(
-                    Runnable {
-                        spanFactory.createCustomSpan("task 2").use { taskSpan ->
-                            assertEquals(childSpan.spanId, taskSpan.parentSpanId)
-                        }
+                executor.submit {
+                    spanFactory.createCustomSpan("task 2").use { taskSpan ->
+                        assertEquals(childSpan.spanId, taskSpan.parentSpanId)
                     }
-                ).get()
+                }.get()
             }
         }
     }
@@ -51,13 +47,11 @@ class ContextAwareThreadPoolExecutorTest {
     fun closedContext() {
         val executor = ContextAwareThreadPoolExecutor(1, 1, 1L, TimeUnit.MILLISECONDS, LinkedBlockingQueue())
         spanFactory.createCustomSpan("parent").use {
-            executor.submit(
-                Runnable {
-                    // allow the parent span to close before starting a span within the task
-                    sleep(10L)
-                    spanFactory.createCustomSpan("child").end(10L)
-                }
-            )
+            executor.submit {
+                // allow the parent span to close before starting a span within the task
+                sleep(10L)
+                spanFactory.createCustomSpan("child").end(10L)
+            }
         }
 
         // wait for the task to complete

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
@@ -112,11 +112,9 @@ internal class SpanContextTest {
         spanFactory.createCustomSpan("parent thread").use {
             val executorService = Executors.newSingleThreadExecutor()
             executorService.submit(
-                SpanContext.current.wrap(
-                    Runnable {
-                        spanFactory.createCustomSpan("worker thread").end(1L)
-                    }
-                )
+                SpanContext.current.wrap {
+                    spanFactory.createCustomSpan("worker thread").end(1L)
+                }
             ).get()
         }
 


### PR DESCRIPTION
## Goal

Adds a new `ContextAwareThreadPoolExecutor` to the SDK. 

This extends the standard `java.util.concurrent.ThreadPoolExecutor` and acts a drop-in replacement. Initialises the 'current' `SpanContext` within a task with the span that was active when the task was submitted (provided it is still open and valid)

## Design

The class simply overrides `ThreadPoolExecutor.execute(command: Runnable)` and uses `SpanContext.current.wrap` to initialise the supplied task using the current context.

This approach was taken since `ThreadPoolExecutor.execute` runs in the executor thread, whereas `beforeExecute` and `afterExecute` are invoked by the thread that will execute the task.

## Testing

New unit tests added