### PR TITLE
[PLAT-9593] Add `ContextAwareScheduledThreadPoolExecutor`

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutor.kt
@@ -1,0 +1,62 @@
+package com.bugsnag.android.performance
+
+import java.util.concurrent.Callable
+import java.util.concurrent.RejectedExecutionHandler
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * A [SpanContext] aware drop-in replacement for [ScheduledThreadPoolExecutor].
+ * Sets the current [SpanContext] within a task to the [SpanContext] that was active
+ * when the task was scheduled.
+ */
+class ContextAwareScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor {
+    constructor(corePoolSize: Int) : super(corePoolSize)
+    constructor(corePoolSize: Int, threadFactory: ThreadFactory?) : super(
+        corePoolSize,
+        threadFactory
+    )
+
+    constructor(corePoolSize: Int, handler: RejectedExecutionHandler?) : super(
+        corePoolSize,
+        handler
+    )
+
+    constructor(
+        corePoolSize: Int,
+        threadFactory: ThreadFactory?,
+        handler: RejectedExecutionHandler?
+    ) : super(corePoolSize, threadFactory, handler)
+
+    override fun schedule(command: Runnable?, delay: Long, unit: TimeUnit?): ScheduledFuture<*> {
+        return super.schedule(command?.let { SpanContext.current.wrap(it) }, delay, unit)
+    }
+
+    override fun <V : Any?> schedule(
+        callable: Callable<V>?,
+        delay: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<V> {
+        return super.schedule(callable?.let { SpanContext.current.wrap(it) }, delay, unit)
+    }
+
+    override fun scheduleWithFixedDelay(
+        command: Runnable?,
+        initialDelay: Long,
+        delay: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<*> {
+        return super.scheduleWithFixedDelay(command?.let { SpanContext.current.wrap(it) }, initialDelay, delay, unit)
+    }
+
+    override fun scheduleAtFixedRate(
+        command: Runnable?,
+        initialDelay: Long,
+        period: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<*> {
+        return super.scheduleAtFixedRate(command?.let { SpanContext.current.wrap(it) }, initialDelay, period, unit)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutorTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutorTest.kt
@@ -1,0 +1,137 @@
+package com.bugsnag.android.performance
+
+import android.os.SystemClock
+import com.bugsnag.android.performance.internal.SpanFactory
+import com.bugsnag.android.performance.test.CollectingSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPausedSystemClock
+import java.lang.Thread.sleep
+import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowPausedSystemClock::class])
+class ContextAwareScheduledThreadPoolExecutorTest {
+    private lateinit var spanFactory: SpanFactory
+    private lateinit var spanProcessor: CollectingSpanProcessor
+
+    @Before
+    fun newSpanFactory() {
+        spanProcessor = CollectingSpanProcessor()
+        spanFactory = SpanFactory(spanProcessor)
+    }
+
+    @Test
+    fun execute() {
+        val scheduledExecutor = ContextAwareScheduledThreadPoolExecutor(1)
+        spanFactory.createCustomSpan("parent").use {
+            scheduledExecutor.execute {
+                spanFactory.createCustomSpan("child").end(1L)
+            }
+            scheduledExecutor.shutdown()
+            scheduledExecutor.awaitTermination(50L, TimeUnit.MILLISECONDS)
+        }
+
+        val collectedSpans = spanProcessor.toList()
+        assertSame(2, collectedSpans.size)
+        assertEquals(collectedSpans[1].spanId, collectedSpans[0].parentSpanId)
+    }
+
+    @Test
+    fun scheduleRunnable() {
+        val scheduledExecutor = ContextAwareScheduledThreadPoolExecutor(1)
+        spanFactory.createCustomSpan("parent").use { rootSpan ->
+            scheduledExecutor.schedule(
+                {
+                    spanFactory.createCustomSpan("child").use { taskSpan ->
+                        assertEquals(rootSpan.spanId, taskSpan.parentSpanId)
+                    }
+                },
+                0L,
+                TimeUnit.MILLISECONDS
+            ).get()
+        }
+    }
+
+    @Test
+    fun scheduleCallable() {
+        val scheduledExecutor = ContextAwareScheduledThreadPoolExecutor(1)
+        spanFactory.createCustomSpan("parent").use { rootSpan ->
+            scheduledExecutor.schedule(
+                Callable {
+                    spanFactory.createCustomSpan("child").use { taskSpan ->
+                        assertEquals(rootSpan.spanId, taskSpan.parentSpanId)
+                    }
+                },
+                0L,
+                TimeUnit.MILLISECONDS
+            ).get()
+        }
+    }
+
+    @Test
+    fun scheduleWithFixedDelay() {
+        val scheduledExecutor = ContextAwareScheduledThreadPoolExecutor(1)
+        var startTime = SystemClock.elapsedRealtime()
+        spanFactory.createCustomSpan("parent").use {
+            scheduledExecutor.scheduleWithFixedDelay(
+                {
+                    startTime += 100L
+                    SystemClock.setCurrentTimeMillis(startTime)
+                    spanFactory.createCustomSpan("child").end()
+                },
+                0L,
+                100L,
+                TimeUnit.MILLISECONDS
+            )
+
+            // end the parent span after one task execution
+            sleep(75L)
+        }
+
+        // allow task to run once more
+        sleep(75L)
+        scheduledExecutor.shutdownNow()
+
+        val collectedSpans = spanProcessor.toList()
+        assertSame(3, collectedSpans.size)
+        assertEquals(collectedSpans[0].spanId, collectedSpans[1].parentSpanId)
+        assertEquals(0, collectedSpans[2].parentSpanId)
+    }
+
+    @Test
+    fun scheduleAtFixedRate() {
+        val scheduledExecutor = ContextAwareScheduledThreadPoolExecutor(1)
+        var startTime = SystemClock.elapsedRealtime()
+        spanFactory.createCustomSpan("parent").use {
+            scheduledExecutor.scheduleAtFixedRate(
+                {
+                    startTime += 100L
+                    SystemClock.setCurrentTimeMillis(startTime)
+                    spanFactory.createCustomSpan("child").end()
+                },
+                0L,
+                100L,
+                TimeUnit.MILLISECONDS
+            )
+
+            // end the parent span after one task execution
+            sleep(75L)
+        }
+
+        // allow task to run once more
+        sleep(75L)
+        scheduledExecutor.shutdownNow()
+
+        val collectedSpans = spanProcessor.toList()
+        assertSame(3, collectedSpans.size)
+        assertEquals(collectedSpans[0].spanId, collectedSpans[1].parentSpanId)
+        assertEquals(0, collectedSpans[2].parentSpanId)
+    }
+}


### PR DESCRIPTION
## Goal

Adds a new `ContextAwareScheduledThreadPoolExecutor` to the SDK.

This extends the standard `java.util.concurrent.ScheduledThreadPoolExecutor` and acts a drop-in replacement. Initialises the 'current' `SpanContext` within a task with the span that was active when the task was scheduled (provided it is still open and valid).

Note that this means for tasks that are scheduled to run periodically, each task execution will be wrapped in the same initial `SpanContext` that was active at the time the task was scheduled and not the `SpanContext` that was active at the point of execution.

## Design

Extends `ScheduledThreadPoolExecutor` and overrrides the `schedule`, `scheduleWithFixedDelay` and `scheduleAtFixedRate` methods and uses `SpanContext.current.wrap` to initialise the context stack for the supplied task.

## Testing

New unit tests added