### PR TITLE
Added trailing-comma rule and formatted

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma = true

--- a/bugsnag-android-performance/build.gradle.kts
+++ b/bugsnag-android-performance/build.gradle.kts
@@ -76,3 +76,7 @@ detekt {
     source.from(files("src/main/kotlin"))
     baseline = file("detekt-baseline.xml")
 }
+
+configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+    enableExperimentalRules.set(true)
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutorTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutorTest.kt
@@ -54,7 +54,7 @@ class ContextAwareScheduledThreadPoolExecutorTest {
                     }
                 },
                 0L,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             ).get()
         }
     }
@@ -70,7 +70,7 @@ class ContextAwareScheduledThreadPoolExecutorTest {
                     }
                 },
                 0L,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             ).get()
         }
     }
@@ -88,7 +88,7 @@ class ContextAwareScheduledThreadPoolExecutorTest {
                 },
                 0L,
                 100L,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
 
             // end the parent span after one task execution
@@ -118,7 +118,7 @@ class ContextAwareScheduledThreadPoolExecutorTest {
                 },
                 0L,
                 100L,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
 
             // end the parent span after one task execution

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
@@ -114,7 +114,7 @@ internal class SpanContextTest {
             executorService.submit(
                 SpanContext.current.wrap {
                     spanFactory.createCustomSpan("worker thread").end(1L)
-                }
+                },
             ).get()
         }
 
@@ -131,8 +131,8 @@ internal class SpanContextTest {
                 SpanContext.current.wrap(
                     Callable {
                         spanFactory.createCustomSpan("child").end()
-                    }
-                )
+                    },
+                ),
             ).get()
         }
 
@@ -147,7 +147,7 @@ internal class SpanContextTest {
     private data class TestSpanContext(
         override val spanId: Long,
         override val traceId: UUID,
-        val threadId: Long
+        val threadId: Long,
     ) : SpanContext {
         override fun wrap(runnable: Runnable) = runnable
         override fun <T> wrap(callable: Callable<T>) = callable

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -25,7 +25,7 @@ class SpanJsonTest {
             0xdecafbad,
             123L,
             testSpanProcessor,
-            false
+            false,
         )
 
         span.setAttribute("fps.average", 61.9)
@@ -69,7 +69,7 @@ class SpanJsonTest {
                     ]
                 }
             """.trimIndent(),
-            json
+            json,
         )
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -28,47 +28,47 @@ class SpanOptionsTest {
         assertEquals(
             // doesn't actually change the output
             SpanOptions.defaults.makeCurrentContext(SpanOptions.defaults.makeContext),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertEquals(
             SpanOptions.defaults.makeCurrentContext(true),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertNotEquals(
             SpanOptions.defaults.makeCurrentContext(false),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertEquals(
             SpanOptions.defaults.setFirstClass(true),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertNotEquals(
             SpanOptions.defaults.setFirstClass(false),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertEquals(
             SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults.startTime(12345L)
+            SpanOptions.defaults.startTime(12345L),
         )
 
         assertNotEquals(
             SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertNotEquals(
             SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults.startTime(54321L)
+            SpanOptions.defaults.startTime(54321L),
         )
 
         assertEquals(
             SpanOptions.defaults.within(SpanContext.invalid),
-            SpanOptions.defaults.within(SpanContext.invalid)
+            SpanOptions.defaults.within(SpanContext.invalid),
         )
 
         assertEquals(
@@ -78,12 +78,12 @@ class SpanOptionsTest {
 
         assertEquals(
             SpanOptions.defaults.within(SpanContext.current),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
 
         assertEquals(
             SpanOptions.defaults.within(SpanOptions.defaults.parentContext),
-            SpanOptions.defaults
+            SpanOptions.defaults,
         )
     }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
@@ -17,29 +17,29 @@ class LegacyNetworkTypeTest {
         testTransportTye(
             ConnectivityManager.TYPE_WIFI,
             NetworkType.WIFI,
-            ConnectionMetering.UNMETERED
+            ConnectionMetering.UNMETERED,
         )
         testTransportTye(
             ConnectivityManager.TYPE_MOBILE,
             NetworkType.CELL,
-            ConnectionMetering.POTENTIALLY_METERED
+            ConnectionMetering.POTENTIALLY_METERED,
         )
         testTransportTye(
             ConnectivityManager.TYPE_ETHERNET,
             NetworkType.WIRED,
-            ConnectionMetering.UNMETERED
+            ConnectionMetering.UNMETERED,
         )
         testTransportTye(
             ConnectivityManager.TYPE_BLUETOOTH,
             NetworkType.UNKNOWN,
-            ConnectionMetering.POTENTIALLY_METERED
+            ConnectionMetering.POTENTIALLY_METERED,
         )
     }
 
     private fun testTransportTye(
         transportType: Int,
         expectedNetworkType: NetworkType,
-        expectedMetering: ConnectionMetering
+        expectedMetering: ConnectionMetering,
     ) {
         val context = mock<Context>()
         var callbackInvoked = false

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -46,7 +46,7 @@ class PerformanceLifecycleCallbacksTest {
         val callbacks = PerformanceLifecycleCallbacks(
             activityLoadSpans = spanTracker,
             spanFactory = spanFactory,
-            inForegroundCallback = {}
+            inForegroundCallback = {},
         ).apply {
             openLoadSpans = true
             closeLoadSpans = true
@@ -80,7 +80,7 @@ class PerformanceLifecycleCallbacksTest {
         val callbacks = PerformanceLifecycleCallbacks(
             activityLoadSpans = spanTracker,
             spanFactory = spanFactory,
-            inForegroundCallback = {}
+            inForegroundCallback = {},
         ).apply {
             openLoadSpans = true
             closeLoadSpans = false
@@ -120,7 +120,7 @@ class PerformanceLifecycleCallbacksTest {
         val callbacks = PerformanceLifecycleCallbacks(
             activityLoadSpans = spanTracker,
             spanFactory = spanFactory,
-            inForegroundCallback = {}
+            inForegroundCallback = {},
         ).apply {
             openLoadSpans = false
             closeLoadSpans = false

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -37,8 +37,8 @@ class RetryDeliveryTest {
                     0xdecafbad,
                     0L,
                     testSpanProcessor,
-                    false
-                )
+                    false,
+                ),
             ),
             attributes,
         )
@@ -56,8 +56,8 @@ class RetryDeliveryTest {
                     0xdecafbad,
                     0L,
                     testSpanProcessor,
-                    false
-                )
+                    false,
+                ),
             ),
             attributes,
         )
@@ -75,8 +75,8 @@ class RetryDeliveryTest {
                     0xdecafbad,
                     0L,
                     testSpanProcessor,
-                    false
-                )
+                    false,
+                ),
             ),
             attributes,
         )
@@ -104,8 +104,8 @@ class RetryDeliveryTest {
                     0xdecafbad,
                     0L,
                     testSpanProcessor,
-                    false
-                )
+                    false,
+                ),
             ),
             attributes,
         )
@@ -134,8 +134,8 @@ class RetryDeliveryTest {
                     0xdecafbad,
                     0L,
                     testSpanProcessor,
-                    false
-                )
+                    false,
+                ),
             ),
             attributes,
         )

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryQueueTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryQueueTest.kt
@@ -16,7 +16,7 @@ class RetryQueueTest {
     fun createQueueDir() {
         dir = File(
             System.getProperty("java.io.tmpdir"),
-            "retry-queue-test-${System.currentTimeMillis()}"
+            "retry-queue-test-${System.currentTimeMillis()}",
         )
 
         retryQueue = RetryQueue(dir)
@@ -37,8 +37,8 @@ class RetryQueueTest {
             byteArrayOf(1, 2, 3),
             mapOf(
                 "Header1" to "one",
-                "Header2" to "two"
-            )
+                "Header2" to "two",
+            ),
         )
 
         val tracePayload2 = TracePayload(
@@ -47,8 +47,8 @@ class RetryQueueTest {
             mapOf(
                 "One" to "1",
                 "Two" to "2",
-                "Three" to "3"
-            )
+                "Three" to "3",
+            ),
         )
 
         retryQueue.add(tracePayload2)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTest.kt
@@ -26,17 +26,17 @@ class SamplerTest {
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
         )
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE)
+            traceId = uuidWithUpper(Long.MAX_VALUE),
         )
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(1000000000)
+            traceId = uuidWithUpper(1000000000),
         )
         assertTrue(sampler.shouldKeepSpan(span))
     }
@@ -46,22 +46,22 @@ class SamplerTest {
         val sampler = Sampler(0.0)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(0)
+            traceId = uuidWithUpper(0),
         )
         assertTrue(!sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
         )
         assertTrue(!sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE)
+            traceId = uuidWithUpper(Long.MAX_VALUE),
         )
         assertTrue(!sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(1000000000)
+            traceId = uuidWithUpper(1000000000),
         )
         assertTrue(!sampler.shouldKeepSpan(span))
     }
@@ -71,17 +71,17 @@ class SamplerTest {
         val sampler = Sampler(0.5)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(0)
+            traceId = uuidWithUpper(0),
         )
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+            traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
         )
         assertTrue(!sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
             processor = spanProcessor,
-            traceId = uuidWithUpper(Long.MAX_VALUE - 10000)
+            traceId = uuidWithUpper(Long.MAX_VALUE - 10000),
         )
         assertTrue(sampler.shouldKeepSpan(span))
     }
@@ -93,16 +93,16 @@ class SamplerTest {
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
             ),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(Long.MAX_VALUE)
+                traceId = uuidWithUpper(Long.MAX_VALUE),
             ),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(1000000000)
-            )
+                traceId = uuidWithUpper(1000000000),
+            ),
         )
         val sampled = sampler.sampled(batch)
         assertTrue(sampled.size == 4)
@@ -115,13 +115,13 @@ class SamplerTest {
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
             ),
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(Long.MAX_VALUE)),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(1000000000)
-            )
+                traceId = uuidWithUpper(1000000000),
+            ),
         )
         val sampled = sampler.sampled(batch)
         assertEquals("expected all spans to be sampled", 0, sampled.size)
@@ -134,13 +134,13 @@ class SamplerTest {
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(Long.MAX_VALUE shl 1)
+                traceId = uuidWithUpper(Long.MAX_VALUE shl 1),
             ),
             spanFactory.newSpan(
                 processor = spanProcessor,
-                traceId = uuidWithUpper(Long.MAX_VALUE - 10000)
+                traceId = uuidWithUpper(Long.MAX_VALUE - 10000),
             ),
-            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000))
+            spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(1000000000)),
         )
         val sampled = sampler.sampled(batch)
         assertEquals(3, sampled.size)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -23,7 +23,7 @@ class SpanPayloadEncodingTest {
             0xdecafbad,
             0L,
             testSpanProcessor,
-            false
+            false,
         )
         span1.end(1L)
         val span2 = SpanImpl(
@@ -34,7 +34,7 @@ class SpanPayloadEncodingTest {
             0xbaddecaf,
             0L,
             testSpanProcessor,
-            false
+            false,
         )
         span2.end(11L)
         val spans = listOf(span1, span2)
@@ -45,7 +45,7 @@ class SpanPayloadEncodingTest {
                 attrs["service.name"] = "Test app"
                 attrs["telemetry.sdk.name"] = "bugsnag.performance.android"
                 attrs["telemetry.sdk.version"] = "0.0.0"
-            }
+            },
         )
 
         assertTraceDataValid(content)
@@ -102,7 +102,7 @@ class SpanPayloadEncodingTest {
                   ]
                 }
             """.trimIndent(),
-            content.toString(Charsets.UTF_8)
+            content.toString(Charsets.UTF_8),
         )
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -41,7 +41,7 @@ class SpanTest {
             0xdecafbad,
             0L,
             mockSpanProcessor,
-            false
+            false,
         )
 
         span.end()
@@ -71,6 +71,6 @@ class SpanTest {
         0xdecafbad,
         0L,
         testSpanProcessor,
-        false
+        false,
     )
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -26,7 +26,7 @@ class SpanTrackerTest {
         val span = tracker.track("TestActivity") {
             spanFactory.newSpan(
                 processor = testSpanProcessor,
-                endTime = null
+                endTime = null,
             )
         }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
@@ -32,7 +32,7 @@ internal class TracePayloadTest {
         val tracePayload = TracePayload.createTracePayload("abc123", spans, Attributes())
         assertEquals(
             "0.1:1;0.3:3;0.5:2",
-            tracePayload.headers["Bugsnag-Span-Sampling"]
+            tracePayload.headers["Bugsnag-Span-Sampling"],
         )
     }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
@@ -94,7 +94,7 @@ class WorkerTest {
     }
 
     private class CountingTask(
-        private val maximum: Int
+        private val maximum: Int,
     ) : Task {
         private var latch = CountDownLatch(maximum)
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/OtelValidator.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/OtelValidator.kt
@@ -6,7 +6,7 @@ import net.jimblackler.jsonschemafriend.Validator
 object OtelValidator {
     private val schemaStore = SchemaStore()
     private val traceSchema = schemaStore.loadSchema(
-        OtelValidator::class.java.getResourceAsStream("/otel_trace_schema.json")
+        OtelValidator::class.java.getResourceAsStream("/otel_trace_schema.json"),
     )
 
     fun assertTraceDataValid(json: ByteArray) {

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
@@ -20,7 +20,7 @@ class TestSpanFactory {
         traceId: UUID = UUID(0L, spanCount),
         spanId: Long = spanCount,
         parentSpanId: Long = 0L,
-        processor: SpanProcessor
+        processor: SpanProcessor,
     ): SpanImpl {
         spanCount++
         return SpanImpl(name, kind, startTime, traceId, spanId, parentSpanId, processor, true)
@@ -29,7 +29,7 @@ class TestSpanFactory {
 
     fun newSpans(
         count: Int,
-        processor: SpanProcessor
+        processor: SpanProcessor,
     ): MutableList<SpanImpl> {
         val spans = mutableListOf<SpanImpl>()
         repeat(count) { spans.add(newSpan(processor = processor)) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
     id("com.android.library") version "7.3.0" apply false
     id("org.jetbrains.kotlin.android") version "1.5.20" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "10.1.0" apply false
+    id("org.jlleitschuh.gradle.ktlint") version "11.2.0" apply false
     id("io.gitlab.arturbosch.detekt") version "1.21.0" apply false
     id("org.jetbrains.dokka") version "1.7.20" apply false
     id("com.github.hierynomus.license") version "0.16.1" apply false


### PR DESCRIPTION
## Goal
Enforce a consistent use of trailing commas when formatting with ktlint. We previously had some code with trailing commas and some without.