### PR TITLE
Make SpanOptions more Java friendly

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -176,7 +176,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startSpan(name: String, options: SpanOptions = SpanOptions.defaults): Span =
+    fun startSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): Span =
         spanFactory.createCustomSpan(name, options)
 
     /**
@@ -191,7 +191,7 @@ object BugsnagPerformance {
     fun startNetworkRequestSpan(
         url: URL,
         verb: String,
-        options: SpanOptions = SpanOptions.defaults
+        options: SpanOptions = SpanOptions.DEFAULTS
     ): Span = spanFactory.createNetworkSpan(url, verb, options)
 
     /**
@@ -208,7 +208,7 @@ object BugsnagPerformance {
     @JvmOverloads
     fun startViewLoadSpan(
         activity: Activity,
-        options: SpanOptions = SpanOptions.defaults
+        options: SpanOptions = SpanOptions.DEFAULTS
     ): Span {
         // create & track Activity referenced ViewLoad spans
         return activitySpanTracker.track(activity) {
@@ -242,7 +242,7 @@ object BugsnagPerformance {
     fun startViewLoadSpan(
         viewType: ViewType,
         viewName: String,
-        options: SpanOptions = SpanOptions.defaults
+        options: SpanOptions = SpanOptions.DEFAULTS
     ): Span = spanFactory.createViewLoadSpan(viewType, viewName, options)
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Activity
 import com.bugsnag.android.performance.HasAttributes
-import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.ViewType
@@ -15,7 +14,7 @@ class SpanFactory(
     private val spanProcessor: SpanProcessor,
     val spanAttributeSource: AttributeSource = {},
 ) {
-    fun createCustomSpan(name: String, options: SpanOptions = SpanOptions.defaults): SpanImpl {
+    fun createCustomSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val isFirstClass = options.isFirstClass
         val span = createSpan("Custom/$name", SpanKind.INTERNAL, options)
         span.setAttribute("bugsnag.span.first_class", isFirstClass)
@@ -23,7 +22,7 @@ class SpanFactory(
     }
 
 
-    fun createNetworkSpan(url: URL, verb: String, options: SpanOptions = SpanOptions.defaults): SpanImpl {
+    fun createNetworkSpan(url: URL, verb: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val verbUpper = verb.uppercase()
         val span = createSpan("HTTP/$verbUpper", SpanKind.CLIENT, options)
         span.setAttribute("bugsnag.span.category", "network")
@@ -32,13 +31,13 @@ class SpanFactory(
         return span
     }
 
-    fun createViewLoadSpan(activity: Activity, options: SpanOptions = SpanOptions.defaults): SpanImpl {
+    fun createViewLoadSpan(activity: Activity, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val activityName = activity::class.java.simpleName
         return createViewLoadSpan(ViewType.ACTIVITY, activityName, options)
     }
 
     fun createViewLoadSpan(viewType: ViewType, viewName: String,
-                           options: SpanOptions = SpanOptions.defaults
+                           options: SpanOptions = SpanOptions.DEFAULTS
     ): SpanImpl {
         val isFirstClass = options.isFirstClass
         val span = createSpan(
@@ -66,7 +65,7 @@ class SpanFactory(
     private fun createSpan(
         name: String,
         kind: SpanKind,
-        options: SpanOptions = SpanOptions.defaults
+        options: SpanOptions = SpanOptions.DEFAULTS
     ): SpanImpl {
         val span = SpanImpl(
             name = name,

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
@@ -141,7 +141,7 @@ internal class SpanContextTest {
         assertEquals(collectedSpans[1].spanId, collectedSpans[0].parentSpanId)
     }
 
-    private fun createTestSpan(name: String = "Test/test span", options: SpanOptions = SpanOptions.defaults) =
+    private fun createTestSpan(name: String = "Test/test span", options: SpanOptions = SpanOptions.DEFAULTS) =
         spanFactory.createCustomSpan(name, options)
 
     private data class TestSpanContext(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -27,63 +27,63 @@ class SpanOptionsTest {
     fun testEquals() {
         assertEquals(
             // doesn't actually change the output
-            SpanOptions.defaults.makeCurrentContext(SpanOptions.defaults.makeContext),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.makeCurrentContext(SpanOptions.DEFAULTS.makeContext),
+            SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.defaults.makeCurrentContext(true),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.makeCurrentContext(true),
+            SpanOptions.DEFAULTS,
         )
 
         assertNotEquals(
-            SpanOptions.defaults.makeCurrentContext(false),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.makeCurrentContext(false),
+            SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.defaults.setFirstClass(true),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.setFirstClass(true),
+            SpanOptions.DEFAULTS,
         )
 
         assertNotEquals(
-            SpanOptions.defaults.setFirstClass(false),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.setFirstClass(false),
+            SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults.startTime(12345L),
+            SpanOptions.DEFAULTS.startTime(12345L),
+            SpanOptions.DEFAULTS.startTime(12345L),
         )
 
         assertNotEquals(
-            SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.startTime(12345L),
+            SpanOptions.DEFAULTS,
         )
 
         assertNotEquals(
-            SpanOptions.defaults.startTime(12345L),
-            SpanOptions.defaults.startTime(54321L),
+            SpanOptions.DEFAULTS.startTime(12345L),
+            SpanOptions.DEFAULTS.startTime(54321L),
         )
 
         assertEquals(
-            SpanOptions.defaults.within(SpanContext.invalid),
-            SpanOptions.defaults.within(SpanContext.invalid),
+            SpanOptions.DEFAULTS.within(SpanContext.invalid),
+            SpanOptions.DEFAULTS.within(SpanContext.invalid),
         )
 
         assertEquals(
-            SpanOptions.defaults.setFirstClass(true),
-            SpanOptions.defaults.setFirstClass(true),
+            SpanOptions.DEFAULTS.setFirstClass(true),
+            SpanOptions.DEFAULTS.setFirstClass(true),
         )
 
         assertEquals(
-            SpanOptions.defaults.within(SpanContext.current),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.within(SpanContext.current),
+            SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.defaults.within(SpanOptions.defaults.parentContext),
-            SpanOptions.defaults,
+            SpanOptions.DEFAULTS.within(SpanOptions.DEFAULTS.parentContext),
+            SpanOptions.DEFAULTS,
         )
     }
 
@@ -91,15 +91,15 @@ class SpanOptionsTest {
     fun defaultStartTime() = withStaticMock<SystemClock> { clock ->
         val expectedTime = 192837465L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
-        assertEquals(expectedTime, SpanOptions.defaults.startTime)
+        assertEquals(expectedTime, SpanOptions.DEFAULTS.startTime)
     }
 
     @Test
     fun overrideStartTime() {
         val time = 876123L
-        assertEquals(time, SpanOptions.defaults.startTime(time).startTime)
+        assertEquals(time, SpanOptions.DEFAULTS.startTime(time).startTime)
         // test multi overrides of the same value
-        assertEquals(time, SpanOptions.defaults.startTime(0L).startTime(time).startTime)
+        assertEquals(time, SpanOptions.DEFAULTS.startTime(0L).startTime(time).startTime)
     }
 
     @Test
@@ -107,16 +107,16 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertFalse(SpanOptions.defaults.setFirstClass(false).isFirstClass)
+        assertFalse(SpanOptions.DEFAULTS.setFirstClass(false).isFirstClass)
         // test multi overrides of the same value
-        assertTrue(SpanOptions.defaults.setFirstClass(false).setFirstClass(true).isFirstClass)
+        assertTrue(SpanOptions.DEFAULTS.setFirstClass(false).setFirstClass(true).isFirstClass)
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { rootSpan ->
             assertTrue(rootSpan.attributes.contains("bugsnag.span.first_class" to true))
             spanFactory.createCustomSpan("child").use { childSpan ->
                 assertTrue(childSpan.attributes.contains("bugsnag.span.first_class" to false))
-                spanFactory.createCustomSpan("override", SpanOptions.defaults.setFirstClass(true)).use { overrideSpan ->
+                spanFactory.createCustomSpan("override", SpanOptions.DEFAULTS.setFirstClass(true)).use { overrideSpan ->
                     assertTrue(overrideSpan.attributes.contains("bugsnag.span.first_class" to true))
                 }
             }
@@ -128,16 +128,16 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertNull(SpanOptions.defaults.within(null).parentContext)
+        assertNull(SpanOptions.DEFAULTS.within(null).parentContext)
         // test multi overrides of the same value
-        assertNull(SpanOptions.defaults.within(SpanContext.current).within(null).parentContext)
+        assertNull(SpanOptions.DEFAULTS.within(SpanContext.current).within(null).parentContext)
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { rootSpan ->
             assertEquals(0L, rootSpan.parentSpanId)
             spanFactory.createCustomSpan("child").use { childSpan ->
                 assertEquals(rootSpan.spanId, childSpan.parentSpanId)
-                spanFactory.createCustomSpan("override", SpanOptions.defaults.within(null)).use { overrideSpan ->
+                spanFactory.createCustomSpan("override", SpanOptions.DEFAULTS.within(null)).use { overrideSpan ->
                     assertEquals(0L, overrideSpan.parentSpanId)
                 }
             }
@@ -149,14 +149,14 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertFalse(SpanOptions.defaults.makeCurrentContext(false).makeContext)
+        assertFalse(SpanOptions.DEFAULTS.makeCurrentContext(false).makeContext)
         // test multi overrides of the same value
-        assertTrue(SpanOptions.defaults.makeCurrentContext(false).makeCurrentContext(true).isFirstClass)
+        assertTrue(SpanOptions.DEFAULTS.makeCurrentContext(false).makeCurrentContext(true).isFirstClass)
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { defaultSpan ->
             assertSame(SpanContext.current, defaultSpan)
-            spanFactory.createCustomSpan("child", SpanOptions.defaults.makeCurrentContext(false)).use { overrideSpan ->
+            spanFactory.createCustomSpan("child", SpanOptions.DEFAULTS.makeCurrentContext(false)).use { overrideSpan ->
                 assertNotSame(SpanContext.current, overrideSpan)
             }
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
@@ -27,11 +27,11 @@ class TracerTest {
     fun testBatchSize() = InternalDebug.withDebugValues {
         InternalDebug.spanBatchSizeSendTriggerPoint = 2
 
-        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.defaults.startTime(1L)).end(10L)
+        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.DEFAULTS.startTime(1L)).end(10L)
 
         // assert it won't be delivered immediately (the batch size is 2)
         assertNull(tracer.collectNextBatch())
-        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.defaults.startTime(1L)).end(10L)
+        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.DEFAULTS.startTime(1L)).end(10L)
         // give the delivery thread time to wake up and do it's work
         assertEquals(2, tracer.collectNextBatch()!!.size)
 
@@ -39,8 +39,8 @@ class TracerTest {
         assertNull(tracer.collectNextBatch())
 
         // we deliver another two to ensure that the loop behaves as expected
-        spanFactory.createCustomSpan("BatchSize2.1", SpanOptions.defaults.startTime(2L)).end(20L)
-        spanFactory.createCustomSpan("BatchSize2.2", SpanOptions.defaults.startTime(3L)).end(30L)
+        spanFactory.createCustomSpan("BatchSize2.1", SpanOptions.DEFAULTS.startTime(2L)).end(20L)
+        spanFactory.createCustomSpan("BatchSize2.2", SpanOptions.DEFAULTS.startTime(3L)).end(30L)
 
         assertEquals(2, tracer.collectNextBatch()!!.size)
     }
@@ -52,8 +52,8 @@ class TracerTest {
         val worker = mock<Worker>()
         tracer.worker = worker
 
-        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.defaults.startTime(2L)).end(20L)
-        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.defaults.startTime(3L)).end(30L)
+        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.DEFAULTS.startTime(2L)).end(20L)
+        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.DEFAULTS.startTime(3L)).end(30L)
 
         // ensure that 2 spans woke the worker up exactly once
         verify(worker, times(1)).wake()


### PR DESCRIPTION
## Goal
Rename `SpanOptions.defaults` to `SpanOptions.DEFAULTS` to make it more idiomatic to use from Java.

## Changelog
- Rename `SpanOptions.defaults` to `SpanOptions.DEFAULTS`
- Add more documentation comments explaining `SpanOptions.startTime`

## Testing
Relied on existing tests.