### PR TITLE
Use non-time randomness in the SpanId generator

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -8,6 +8,7 @@ import com.bugsnag.android.performance.HasAttributes
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
+import java.security.SecureRandom
 import java.util.Random
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLongFieldUpdater
@@ -151,7 +152,7 @@ class SpanImpl internal constructor(
 
         const val NO_END_TIME = -1L
 
-        private val spanIdRandom = Random()
+        private val spanIdRandom = Random(SecureRandom().nextLong())
 
         private fun nextSpanId(): Long {
             var id: Long


### PR DESCRIPTION
## Goal
Avoid using potentially time-based randomness in the SpanId generator.

## Design
We use a single-use `SecureRandom` to generate the seed for the standard `Random` used to generate span-ids. This avoids the overheads and locks imposed by `SecureRandom` by itself, and avoids using a time-based seed.

## Testing
Relied on existing tests.