### PR TITLE
Improve internal access to configuration

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -26,14 +26,14 @@
     <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
+    <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
-    <ID>SwallowedException:ResourceAttributes.kt$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
-    <ID>TooGenericExceptionCaught:ResourceAttributes.kt$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -7,6 +7,7 @@ import android.os.SystemClock
 import com.bugsnag.android.performance.BugsnagPerformance.start
 import com.bugsnag.android.performance.internal.ConnectivityCompat
 import com.bugsnag.android.performance.internal.HttpDelivery
+import com.bugsnag.android.performance.internal.ImmutableConfig
 import com.bugsnag.android.performance.internal.InstrumentedAppState
 import com.bugsnag.android.performance.internal.Module
 import com.bugsnag.android.performance.internal.Persistence
@@ -66,7 +67,7 @@ object BugsnagPerformance {
         if (!isStarted) {
             synchronized(this) {
                 if (!isStarted) {
-                    startUnderLock(configuration.validated())
+                    startUnderLock(ImmutableConfig(configuration))
                     isStarted = true
                 }
             }
@@ -79,14 +80,15 @@ object BugsnagPerformance {
         Logger.w("BugsnagPerformance.start has already been called")
     }
 
-    private fun startUnderLock(configuration: PerformanceConfiguration) {
-        val application = configuration.context.applicationContext as Application
-        instrumentedAppState.configure(application, configuration)
+    private fun startUnderLock(configuration: ImmutableConfig) {
+        instrumentedAppState.configure(configuration)
 
         if (configuration.autoInstrumentAppStarts) {
             // mark the app as "starting" (if it isn't already)
             reportApplicationClassLoaded()
         }
+
+        val application = configuration.application
 
         // update isInForeground to a more accurate value (if accessible)
         instrumentedAppState.defaultAttributeSource.update {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -34,19 +34,6 @@ class PerformanceConfiguration private constructor(val context: Context) {
             field = value
         }
 
-    internal fun validated(): PerformanceConfiguration {
-        validateApiKey(apiKey)
-        return this
-    }
-
-    private fun validateApiKey(apiKey: String) {
-        require(apiKey.length == VALID_API_KEY_LENGTH
-            && apiKey.all { it.isDigit() || it in 'a'..'f' }) {
-
-            "Invalid configuration. apiKey should be a 32-character hexademical string, got '$apiKey' "
-        }
-    }
-
     override fun toString(): String =
         "PerformanceConfiguration(" +
             "context=$context, " +
@@ -61,7 +48,6 @@ class PerformanceConfiguration private constructor(val context: Context) {
             ")"
 
     companion object Loader {
-        private const val VALID_API_KEY_LENGTH = 32
 
         // mandatory
         private const val BUGSNAG_NS = "com.bugsnag.android"

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
@@ -1,0 +1,64 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.PerformanceConfiguration
+
+internal data class ImmutableConfig(
+    val application: Application,
+    val apiKey: String,
+    val endpoint: String,
+    val autoInstrumentAppStarts: Boolean,
+    val autoInstrumentActivities: AutoInstrument,
+    val packageName: String,
+    val releaseStage: String,
+    val enabledReleaseStages: Set<String>,
+    val versionCode: Long?,
+    val samplingProbability: Double,
+) {
+    val isReleaseStageEnabled = enabledReleaseStages.contains(releaseStage)
+
+    constructor(configuration: PerformanceConfiguration) : this(
+        configuration.context.applicationContext as Application,
+        configuration.apiKey.also { validateApiKey(it) },
+        configuration.endpoint,
+        configuration.autoInstrumentAppStarts,
+        configuration.autoInstrumentActivities,
+        configuration.context.packageName,
+        configuration.releaseStage ?: configuration.context.releaseStage,
+        configuration.enabledReleaseStages.toSet(),
+        configuration.versionCode ?: versionCodeFor(configuration.context),
+        configuration.samplingProbability,
+    )
+
+    companion object {
+        private const val VALID_API_KEY_LENGTH = 32
+
+        private fun validateApiKey(apiKey: String) {
+            require(
+                apiKey.length == VALID_API_KEY_LENGTH
+                    && apiKey.all { it.isDigit() || it in 'a'..'f' },
+            ) {
+
+                "Invalid configuration. apiKey should be a 32-character hexademical string, got '$apiKey' "
+            }
+        }
+
+        private fun versionCodeFor(context: Context): Long? {
+            return try {
+                val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    packageInfo?.longVersionCode
+                } else {
+                    @Suppress("DEPRECATION")
+                    packageInfo?.versionCode?.toLong()
+                }
+            } catch (ex: RuntimeException) {
+                // swallow any exceptions to avoid any possible crash during startup
+                null
+            }
+        }
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -1,10 +1,8 @@
 package com.bugsnag.android.performance.internal
 
 import android.app.Application
-
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
-import com.bugsnag.android.performance.PerformanceConfiguration
 
 class InstrumentedAppState {
     internal val defaultAttributeSource = DefaultAttributeSource()
@@ -17,8 +15,8 @@ class InstrumentedAppState {
     lateinit var app: Application
         private set
 
-    internal fun configure(application: Application, configuration: PerformanceConfiguration) {
-        this.app = application
+    internal fun configure(configuration: ImmutableConfig) {
+        this.app = configuration.application
 
         configureLifecycleCallbacks(configuration)
 
@@ -34,7 +32,7 @@ class InstrumentedAppState {
         }
     }
 
-    private fun configureLifecycleCallbacks(configuration: PerformanceConfiguration) {
+    private fun configureLifecycleCallbacks(configuration: ImmutableConfig) {
         platformCallbacks.apply {
             openLoadSpans = configuration.autoInstrumentActivities != AutoInstrument.OFF
             closeLoadSpans = configuration.autoInstrumentActivities == AutoInstrument.FULL

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
@@ -1,14 +1,11 @@
 package com.bugsnag.android.performance.internal
 
-import android.content.Context
 import android.os.Build
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.BugsnagPerformance
-import com.bugsnag.android.performance.PerformanceConfiguration
 
-internal fun createResourceAttributes(configuration: PerformanceConfiguration): Attributes {
+internal fun createResourceAttributes(configuration: ImmutableConfig): Attributes {
     val resourceAttributes = Attributes()
-    val context = configuration.context
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         resourceAttributes["host.arch"] = abiToArchitecture(Build.SUPPORTED_ABIS.firstOrNull())
@@ -23,14 +20,11 @@ internal fun createResourceAttributes(configuration: PerformanceConfiguration): 
 
     resourceAttributes["device.model.identifier"] = Build.MODEL
     resourceAttributes["device.manufacturer"] = Build.MANUFACTURER
-    resourceAttributes["deployment.environment"] =
-        configuration.releaseStage ?: context.releaseStage
+    resourceAttributes["deployment.environment"] = configuration.releaseStage
 
-    configuration.versionCodeFor(context)?.let { versionCode ->
-        resourceAttributes["bugsnag.app.version_code"] = versionCode.toString()
-    }
+    resourceAttributes["bugsnag.app.version_code"] = configuration.versionCode.toString()
 
-    resourceAttributes["service.name"] = configuration.context.packageName
+    resourceAttributes["service.name"] = configuration.packageName
     resourceAttributes["telemetry.sdk.name"] = "bugsnag.performance.android"
     resourceAttributes["telemetry.sdk.version"] = BugsnagPerformance.VERSION
 
@@ -43,19 +37,4 @@ private fun abiToArchitecture(abi: String?): String? = when (abi?.lowercase()) {
     "armeabi-v7a" -> "arm32"
     "x86" -> "x86"
     else -> null
-}
-
-private fun PerformanceConfiguration.versionCodeFor(context: Context): Long? {
-    if (versionCode != null) return versionCode
-    return try {
-        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            packageInfo?.longVersionCode
-        } else {
-            @Suppress("DEPRECATION")
-            packageInfo?.versionCode?.toLong()
-        }
-    } catch (ex: RuntimeException) {
-        null
-    }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ApiKeyValidationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ApiKeyValidationTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance
 
 import android.content.Context
+import com.bugsnag.android.performance.internal.ImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -16,24 +17,26 @@ class ApiKeyValidationTest {
     @Test
     fun invalidApiKey() {
         assertThrows(IllegalArgumentException::class.java) {
-            PerformanceConfiguration.load(context, "not a valid key")
-                .validated()
+            ImmutableConfig(PerformanceConfiguration.load(context, "not a valid key"))
         }
     }
 
     @Test
     fun uppercaseApiKeyInvalid() {
         assertThrows(IllegalArgumentException::class.java) {
-            PerformanceConfiguration.load(context, "DECAFBADDECAFBADDECAFBADDECAFBAD")
-                .validated()
+            ImmutableConfig(
+                PerformanceConfiguration.load(
+                    context,
+                    "DECAFBADDECAFBADDECAFBADDECAFBAD",
+                ),
+            )
         }
     }
 
     @Test
     fun validApiKey() {
         val apiKey = "decafbaddecafbaddecafbaddecafbad"
-        val config = PerformanceConfiguration.load(context, apiKey)
-            .validated()
+        val config = ImmutableConfig(PerformanceConfiguration.load(context, apiKey))
 
         assertEquals(apiKey, config.apiKey)
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
@@ -1,0 +1,91 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.PerformanceConfiguration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+
+class ImmutableConfigTest {
+    @Test
+    fun copyFromPerformanceConfiguration() {
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY).apply {
+            endpoint = "https://test.com/testing"
+            releaseStage = "staging"
+            enabledReleaseStages = setOf("staging", "production")
+            autoInstrumentAppStarts = false
+            autoInstrumentActivities = AutoInstrument.START_ONLY
+            versionCode = 543L
+            samplingProbability = 0.25
+        }
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+
+        assertEquals(perfConfig.context, immutableConfig.application)
+        assertEquals(perfConfig.apiKey, immutableConfig.apiKey)
+        assertEquals(perfConfig.endpoint, immutableConfig.endpoint)
+        assertEquals(perfConfig.autoInstrumentAppStarts, immutableConfig.autoInstrumentAppStarts)
+        assertEquals(TEST_PACKAGE_NAME, immutableConfig.packageName)
+        assertEquals(perfConfig.releaseStage, immutableConfig.releaseStage)
+        assertEquals(perfConfig.enabledReleaseStages, immutableConfig.enabledReleaseStages)
+        assertEquals(perfConfig.versionCode, immutableConfig.versionCode)
+        assertEquals(perfConfig.samplingProbability, immutableConfig.samplingProbability, 0.001)
+    }
+
+    @Test
+    fun immutableEnabledReleaseStages() {
+        val releaseStages = mutableSetOf("staging")
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        perfConfig.enabledReleaseStages = releaseStages
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+        assertNotSame(releaseStages, immutableConfig.enabledReleaseStages)
+        assertEquals(releaseStages, immutableConfig.enabledReleaseStages)
+
+        releaseStages.add("production")
+        assertNotEquals(releaseStages, immutableConfig.enabledReleaseStages)
+    }
+
+    @Test
+    fun versionCodeFromContext() {
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        val immutableConfig = ImmutableConfig(perfConfig)
+
+        assertEquals(TEST_VERSION_CODE.toLong(), immutableConfig.versionCode)
+    }
+
+    private fun mockedContext(): Context {
+        val packageInfo = mock<PackageInfo> { info ->
+            // versionCode is a Java field, not a getter
+            @Suppress("DEPRECATION")
+            info.versionCode = TEST_VERSION_CODE
+
+            on { info.longVersionCode } doReturn TEST_VERSION_CODE.toLong()
+        }
+
+        val packageManager = mock<PackageManager> { pm ->
+            on { (pm.getPackageInfo(eq(TEST_PACKAGE_NAME), any())) } doReturn packageInfo
+        }
+
+        return mock<Application> { ctx ->
+            on { ctx.packageName } doReturn TEST_PACKAGE_NAME
+            on { ctx.applicationContext } doReturn ctx
+            on { ctx.packageManager } doReturn packageManager
+        }
+    }
+
+    companion object {
+        const val TEST_PACKAGE_NAME = "com.test.pckname"
+        const val TEST_API_KEY = "decafbaddecafbaddecafbaddecafbad"
+        const val TEST_VERSION_CODE = 987654321
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Application
 import android.os.Build
-import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.test.setStatic
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -20,8 +20,19 @@ class ResourceAttributesTest {
     fun testAttributeDefaults() {
         val application = configureApplication()
 
-        val configuration = PerformanceConfiguration
-            .load(application, "decafbaddecafbaddecafbaddecafbad")
+        val configuration = ImmutableConfig(
+            application,
+            "decafbaddecafbaddecafbaddecafbad",
+            "",
+            true,
+            AutoInstrument.FULL,
+            "bugsnag.performance.android",
+            "development",
+            setOf("production"),
+            321L,
+            1.0,
+        )
+
         val attributes = createResourceAttributes(configuration).toList().toMap()
 
         assertEquals("amd64", attributes["host.arch"])
@@ -32,7 +43,7 @@ class ResourceAttributesTest {
         assertEquals("Bugsnag", attributes["device.manufacturer"])
         assertEquals("development", attributes["deployment.environment"])
         assertEquals("321", attributes["bugsnag.app.version_code"])
-        assertEquals(application.packageName, attributes["service.name"])
+        assertEquals("bugsnag.performance.android", attributes["service.name"])
         assertEquals("bugsnag.performance.android", attributes["telemetry.sdk.name"])
     }
 
@@ -40,12 +51,18 @@ class ResourceAttributesTest {
     fun testAttributeOverrides() {
         val application = configureApplication()
 
-        val configuration = PerformanceConfiguration
-            .load(application, "decafbaddecafbaddecafbaddecafbad")
-            .apply {
-                versionCode = 123
-                releaseStage = "production"
-            }
+        val configuration = ImmutableConfig(
+            application,
+            "decafbaddecafbaddecafbaddecafbad",
+            "",
+            true,
+            AutoInstrument.FULL,
+            "bugsnag.performance.android",
+            "production",
+            setOf("production"),
+            123L,
+            1.0,
+        )
 
         val attributes = createResourceAttributes(configuration).toList().toMap()
 
@@ -57,7 +74,7 @@ class ResourceAttributesTest {
         assertEquals("Bugsnag", attributes["device.manufacturer"])
         assertEquals("production", attributes["deployment.environment"]) // overridden
         assertEquals("123", attributes["bugsnag.app.version_code"]) // overridden
-        assertEquals(application.packageName, attributes["service.name"])
+        assertEquals("bugsnag.performance.android", attributes["service.name"])
         assertEquals("bugsnag.performance.android", attributes["telemetry.sdk.name"])
     }
 


### PR DESCRIPTION
## Goal
Improve and focus internal access to configuration and its defaults.

## Design
Similar to `bugsnag-android` we use an `ImmutableConfig` class which contains immutable copies of the parameters specifies by `PerformanceConfiguration` after validation and normalisation.

## Testing
New unit tests added.