### PR TITLE
Fix enabledReleaseStages implementation

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
@@ -1,21 +1,33 @@
 package com.bugsnag.android.performance.internal
 
 import androidx.annotation.FloatRange
-import com.bugsnag.android.performance.internal.SpanImpl
 
-internal class Sampler(
-    /**
-     * The probability that any given [Span] is retained during sampling as a value between 0 and 1.
-     */
-    @FloatRange(from = 0.0, to = 1.0)
-    var sampleProbability: Double
-) {
+internal interface Sampler {
     fun sampled(spans: Collection<SpanImpl>): Collection<SpanImpl> {
         return spans.filter { shouldKeepSpan(it) }
     }
 
+    fun shouldKeepSpan(span: SpanImpl): Boolean
+}
+
+/**
+ * A Sampler implementation that discards all Spans used when the SDK is configured in a
+ * disabled releaseStage.
+ */
+internal object DiscardingSampler : Sampler {
+    override fun sampled(spans: Collection<SpanImpl>): Collection<SpanImpl> = emptyList()
+    override fun shouldKeepSpan(span: SpanImpl): Boolean = false
+}
+
+internal class ProbabilitySampler(
+    /**
+     * The probability that any given [Span] is retained during sampling as a value between 0 and 1.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    var sampleProbability: Double,
+) : Sampler {
     // Side effect: Sets span.samplingProbability to the current probability
-    fun shouldKeepSpan(span: SpanImpl): Boolean {
+    override fun shouldKeepSpan(span: SpanImpl): Boolean {
         val upperBound = sampleProbability
         span.samplingProbability = upperBound
         return upperBound > 0.0 && span.samplingValue <= upperBound

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SamplerTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SamplerTask.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android.performance.internal
 
 internal class SamplerTask(
     private val delivery: Delivery,
-    private val sampler: Sampler,
+    private val sampler: ProbabilitySampler,
     private val persistentState: PersistentState
 ) : Task, NewProbabilityCallback {
     override fun onAttach(worker: Worker) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Tracer.kt
@@ -10,7 +10,7 @@ class Tracer : SpanProcessor {
 
     private var lastBatchSendTime = SystemClock.elapsedRealtime()
 
-    internal var sampler = Sampler(1.0)
+    internal var sampler: Sampler = ProbabilitySampler(1.0)
 
     internal var worker: Worker? = null
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ProbabilitySamplerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ProbabilitySamplerTest.kt
@@ -10,7 +10,7 @@ import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
-class SamplerTest {
+class ProbabilitySamplerTest {
     val spanFactory = TestSpanFactory()
     val spanProcessor = CollectingSpanProcessor()
 
@@ -21,7 +21,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanProbability1() {
-        val sampler = Sampler(1.0)
+        val sampler = ProbabilitySampler(1.0)
         var span = spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0))
         assertTrue(sampler.shouldKeepSpan(span))
         span = spanFactory.newSpan(
@@ -43,7 +43,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanProbability0() {
-        val sampler = Sampler(0.0)
+        val sampler = ProbabilitySampler(0.0)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
             traceId = uuidWithUpper(0),
@@ -68,7 +68,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanProbability0_5() {
-        val sampler = Sampler(0.5)
+        val sampler = ProbabilitySampler(0.5)
         var span = spanFactory.newSpan(
             processor = spanProcessor,
             traceId = uuidWithUpper(0),
@@ -88,7 +88,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability1() {
-        val sampler = Sampler(1.0)
+        val sampler = ProbabilitySampler(1.0)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
@@ -110,7 +110,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability0() {
-        val sampler = Sampler(0.0)
+        val sampler = ProbabilitySampler(0.0)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(
@@ -129,7 +129,7 @@ class SamplerTest {
 
     @Test
     fun testSampleSpanBatchProbability0_5() {
-        val sampler = Sampler(0.5)
+        val sampler = ProbabilitySampler(0.5)
         val batch = listOf(
             spanFactory.newSpan(processor = spanProcessor, traceId = uuidWithUpper(0)),
             spanFactory.newSpan(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SamplerTaskTest.kt
@@ -20,7 +20,7 @@ internal class SamplerTaskTest {
     @Test
     fun fetchWithoutResponse() {
         val delivery = mock<Delivery>()
-        val sampler = Sampler(0.23)
+        val sampler = ProbabilitySampler(0.23)
         val samplerTask = SamplerTask(delivery, sampler, mock())
 
         samplerTask.onAttach(mock())
@@ -39,7 +39,7 @@ internal class SamplerTaskTest {
         InternalDebug.pValueExpireAfterMs = 200
 
         val delivery = mock<Delivery>()
-        val sampler = Sampler(1.0)
+        val sampler = ProbabilitySampler(1.0)
         val persistentState = mock<PersistentState> {
             whenever(it.pValue) doReturn 0.5
             whenever(it.pValueExpiryTime) doAnswer {
@@ -63,7 +63,7 @@ internal class SamplerTaskTest {
         InternalDebug.pValueExpireAfterMs = 200
 
         val delivery = mock<Delivery>()
-        val sampler = Sampler(1.0)
+        val sampler = ProbabilitySampler(1.0)
         val persistentState = mock<PersistentState>()
 
         val samplerTask = SamplerTask(delivery, sampler, persistentState)

--- a/features/discarded_spans.feature
+++ b/features/discarded_spans.feature
@@ -1,6 +1,10 @@
-Feature: Span Sampling
+Feature: Configuration for discarding Spans
 
   Scenario: No spans should be sent when samplingProbability is zero
     Given I set the sampling probability for the next traces to "null,null,null"
     When I run "SamplingProbabilityZeroScenario" and discard the initial p-value request
+    Then I should have received no spans
+
+  Scenario: No spans should be sent when releaseStage is disabled
+    When I run "DisabledReleaseStageScenario"
     Then I should have received no spans

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -10,6 +10,8 @@
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$250</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$30</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$50</ID>
+    <ID>MagicNumber:DisabledReleaseStageScenario.kt$DisabledReleaseStageScenario$100L</ID>
+    <ID>MagicNumber:DisabledReleaseStageScenario.kt$DisabledReleaseStageScenario$500L</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$1000L</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/DisabledReleaseStageScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/DisabledReleaseStageScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.mazeracer.scenarios
+
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.internal.InternalDebug
+import com.bugsnag.mazeracer.Scenario
+
+class DisabledReleaseStageScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    init {
+        InternalDebug.workerSleepMs = 500L
+        config.enabledReleaseStages = setOf("staging")
+    }
+
+    override fun startScenario() {
+        BugsnagPerformance.start(config)
+
+        BugsnagPerformance.startSpan("Custom Span").use {
+            Thread.sleep(100L)
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Implement `enabledReleaseStages` so that spans are discarded instead of being sent, avoiding possible application behaviour if the performance SDK is not actually activated.

## Design
Abstracted the idea of "sampling" to a more generic "should this span be discarded" level. `Sampler` is now an interface with only this functionality.

When the configured `releaseStage` is not enabled the `sampler` being used is replaced with a specialised `DiscardingSampler` and the `SamplerTask` is not registered with the `Worker`. No requests are made to `Delivery` and all `Span`s are discarded instead of being sent. The SDK continues to otherwise work as expected.

## Testing
A new end2end test was introduced, all other tests should continue to function as before.