### PR TITLE
Move dependency versions into a Gradle version catalog

### DIFF
--- a/bugsnag-android-performance/build.gradle.kts
+++ b/bugsnag-android-performance/build.gradle.kts
@@ -10,8 +10,6 @@ plugins {
 
 apply(from = "../gradle/release.gradle")
 
-val kotlinVersion = "1.5.20"
-
 version = "${project.properties["VERSION_NAME"]}"
 group = "${project.properties["GROUP"]}"
 
@@ -50,17 +48,14 @@ android {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api(libs.kotlin.stdlib)
 
-    implementation("androidx.annotation:annotation:1.3.0")
+    implementation(libs.androidx.annotation)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("androidx.test.ext:junit:1.1.3")
-    testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    testImplementation("org.robolectric:robolectric:4.8")
-    testImplementation("org.mockito:mockito-inline:4.8.1")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
-    testImplementation("net.jimblackler.jsonschemafriend:core:0.11.4")
+    testImplementation(libs.bundles.test.jvm)
+
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.jsonSchemaFriend)
 }
 
 license {

--- a/bugsnag-plugin-android-performance-appcompat/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-appcompat/build.gradle.kts
@@ -49,14 +49,12 @@ android {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api(libs.kotlin.stdlib)
 
     implementation(project(":bugsnag-android-performance"))
 
-    implementation("androidx.appcompat:appcompat:1.4.2")
+    implementation(libs.androidx.annotation)
+    implementation(libs.androidx.appcompat)
 
-    testImplementation("junit:junit:4.13.2")
-
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    testImplementation(libs.bundles.test.jvm)
 }

--- a/bugsnag-plugin-android-performance-coroutines/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-coroutines/build.gradle.kts
@@ -10,9 +10,6 @@ plugins {
 
 apply(from = "../gradle/release.gradle")
 
-val kotlinVersion = "1.5.0"
-val coroutinesVersion = "1.6.4"
-
 version = "${project.properties["VERSION_NAME"]}"
 group = "${project.properties["GROUP"]}"
 
@@ -51,19 +48,17 @@ android {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api(libs.kotlin.stdlib)
 
     implementation(project(":bugsnag-android-performance"))
-    implementation("androidx.annotation:annotation:1.3.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("androidx.test.ext:junit:1.1.3")
-    testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    testImplementation("org.robolectric:robolectric:4.8")
-    testImplementation("org.mockito:mockito-inline:4.8.1")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+    implementation(libs.androidx.annotation)
+    implementation(libs.kotlinx.coroutines)
+
+    testImplementation(libs.bundles.test.jvm)
+
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 license {

--- a/bugsnag-plugin-android-performance-okhttp/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-okhttp/build.gradle.kts
@@ -10,8 +10,6 @@ plugins {
 
 apply(from = "../gradle/release.gradle")
 
-val kotlinVersion = "1.5.0"
-
 version = "${project.properties["VERSION_NAME"]}"
 group = "${project.properties["GROUP"]}"
 
@@ -50,21 +48,19 @@ android {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api(libs.kotlin.stdlib)
 
-    compileOnly("com.squareup.okhttp3:okhttp:4.9.1")
+    compileOnly(libs.okhttp)
 
     implementation(project(":bugsnag-android-performance"))
-    implementation("androidx.annotation:annotation:1.3.0")
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("androidx.test.ext:junit:1.1.3")
-    testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    testImplementation("org.robolectric:robolectric:4.8")
-    testImplementation("org.mockito:mockito-inline:4.8.1")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
-    testImplementation("net.jimblackler.jsonschemafriend:core:0.11.4")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+    implementation(libs.androidx.annotation)
+
+    testImplementation(libs.bundles.test.jvm)
+
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.jsonSchemaFriend)
+    testImplementation(libs.okhttp.mockServer)
 }
 
 license {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.library") version "7.3.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.5.20" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "11.2.0" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.21.0" apply false
-    id("org.jetbrains.dokka") version "1.7.20" apply false
-    id("com.github.hierynomus.license") version "0.16.1" apply false
+    alias(libs.plugins.agp.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.licenseCheck) apply false
 }
 
 tasks.create("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,42 @@
+[versions]
+agp = "7.3.0"
+appcompat = "1.4.2"
+detekt = "1.21.0"
+dokka = "1.7.20"
+kotlin = "1.5.20"
+kotlinCoroutines = "1.6.4"
+ktlint = "11.2.0"
+licenseCheck = "0.16.1"
+
+[plugins]
+agp-library = { id = "com.android.library", version.ref = "agp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+licenseCheck = { id = "com.github.hierynomus.license", version.ref = "licenseCheck" }
+
+[libraries]
+androidx-annotation = "androidx.annotation:annotation:1.3.0"
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-test-junit = "androidx.test.ext:junit:1.1.3"
+
+jsonSchemaFriend = "net.jimblackler.jsonschemafriend:core:0.11.4"
+
+junit = "junit:junit:4.13.2"
+
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
+
+mockito-inline = "org.mockito:mockito-inline:4.8.1"
+mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
+
+okhttp = "com.squareup.okhttp3:okhttp:4.9.1"
+okhttp-mockServer = "com.squareup.okhttp3:mockwebserver:4.9.1"
+
+robolectric = "org.robolectric:robolectric:4.8"
+
+[bundles]
+test-jvm = ["androidx-test-junit", "junit", "mockito-inline", "mockito-kotlin", "robolectric"]


### PR DESCRIPTION
## Goal
Move all of our Gradle dependencies into a version catalog for easier management.

## Testing
Existing build and tests still work as expected