### PR TITLE
Encode enums as integers to comply with OTEL specs

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -22,6 +22,9 @@
     <ID>MagicNumber:InternalDebug.kt$InternalDebug$60</ID>
     <ID>MagicNumber:Persistence.kt$RetryQueue$19</ID>
     <ID>MagicNumber:Persistence.kt$TraceFileDecoder$1024</ID>
+    <ID>MagicNumber:SpanKind.kt$SpanKind.CLIENT$3</ID>
+    <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
+    <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanKind.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanKind.kt
@@ -2,11 +2,13 @@ package com.bugsnag.android.performance
 
 enum class SpanKind(
     @JvmField
-    internal val otelName: String
+    internal val otelName: String,
+    @JvmField
+    internal val otelOrdinal: Int,
 ) {
-    INTERNAL("SPAN_KIND_INTERNAL"),
-    SERVER("SPAN_KIND_SERVER"),
-    CLIENT("SPAN_KIND_CLIENT"),
-    PRODUCER("SPAN_KIND_PRODUCER"),
-    CONSUMER("SPAN_KIND_CONSUMER"),
+    INTERNAL("SPAN_KIND_INTERNAL", 1),
+    SERVER("SPAN_KIND_SERVER", 2),
+    CLIENT("SPAN_KIND_CLIENT", 3),
+    PRODUCER("SPAN_KIND_PRODUCER", 4),
+    CONSUMER("SPAN_KIND_CONSUMER", 5),
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -80,7 +80,7 @@ class SpanImpl internal constructor(
     internal fun toJson(json: JsonWriter) {
         json.beginObject()
             .name("name").value(name)
-            .name("kind").value(kind.otelName)
+            .name("kind").value(kind.otelOrdinal)
             .name("spanId").value(spanId.toHexString())
             .name("traceId").value(traceId.toHexString())
             .name("startTimeUnixNano")

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -43,7 +43,7 @@ class SpanJsonTest {
             """
                 {
                     "name": "test span",
-                    "kind": "SPAN_KIND_INTERNAL",
+                    "kind": 1,
                     "spanId": "00000000decafbad",
                     "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                     "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(0)}",

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -81,7 +81,7 @@ class SpanPayloadEncodingTest {
                           "spans": [
                             {
                               "name": "test span",
-                              "kind": "SPAN_KIND_INTERNAL",
+                              "kind": 1,
                               "spanId": "00000000decafbad",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.startTime)}",
@@ -89,7 +89,7 @@ class SpanPayloadEncodingTest {
                             },
                             {
                               "name": "second span",
-                              "kind": "SPAN_KIND_INTERNAL",
+                              "kind": 1,
                               "spanId": "00000000baddecaf",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.startTime)}",

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -9,7 +9,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 1
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" exists

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -6,7 +6,7 @@ Feature: Manual creation of spans
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_CLIENT"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"

--- a/features/retries.feature
+++ b/features/retries.feature
@@ -15,7 +15,7 @@ Feature: Retries
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 1
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazeracer"
@@ -30,7 +30,7 @@ Feature: Retries
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 1
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazeracer"


### PR DESCRIPTION
## Goal
Encode the `SpanKind` enums as integers in order to comply with the [OpenTelemetry JSON](https://opentelemetry.io/docs/reference/specification/protocol/otlp/#json-protobuf-encoding) spec, which states:
> Values of enum fields MUST be encoded as integer values.

This is currently the only OpenTelemetry enum that we use is `SpanKind`.

## Testing
Altered existing tests to expect integer values for the `SpanKind` enum.