### PR TITLE
Remove "Custom/" prefixes from custom span names

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -164,8 +164,7 @@ object BugsnagPerformance {
     }
 
     /**
-     * Open a custom span with a given name and options. The reported
-     * name of these spans is `"Custom/$name"`.
+     * Open a custom span with a given name and options.
      *
      * @param name the name of the custom span to open
      * @param options the optional configuration for the span

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -16,11 +16,10 @@ class SpanFactory(
 ) {
     fun createCustomSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val isFirstClass = options.isFirstClass
-        val span = createSpan("Custom/$name", SpanKind.INTERNAL, options)
+        val span = createSpan(name, SpanKind.INTERNAL, options)
         span.setAttribute("bugsnag.span.first_class", isFirstClass)
         return span
     }
-
 
     fun createNetworkSpan(url: URL, verb: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val verbUpper = verb.uppercase()

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -6,7 +6,7 @@ Feature: Manual creation of spans
     Then the trace Bugsnag-Integrity header is valid
     And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
@@ -36,28 +36,28 @@ Feature: Manual creation of spans
   Scenario: Spans can be logged before start
     Given I run "PreStartSpansScenario" and discard the initial p-value request
     And I wait to receive a trace
-    Then a span name equals "Custom/Post Start"
-    * a span name equals "Custom/Thread Span 0"
-    * a span name equals "Custom/Thread Span 1"
-    * a span name equals "Custom/Thread Span 2"
+    Then a span name equals "Post Start"
+    * a span name equals "Thread Span 0"
+    * a span name equals "Thread Span 1"
+    * a span name equals "Thread Span 2"
 
   # TODO: Flaky - Pending PLAT-9364
   @skip
   Scenario: Span batch times out
     Given I run "BatchTimeoutScenario" and discard the initial p-value request
     And I wait to receive at least 2 spans
-    Then a span name equals "Custom/Span 1"
-    * a span name equals "Custom/Span 2"
+    Then a span name equals "Span 1"
+    * a span name equals "Span 2"
 
   Scenario: Send on App backgrounded
     Given I run "AppBackgroundedScenario" and discard the initial p-value request
     And I send the app to the background for 5 seconds
     And I wait for 1 span
-    Then a span name equals "Custom/Span 1"
+    Then a span name equals "Span 1"
 
   Scenario: Spans logged in the background
     Given I run "BackgroundSpanScenario" and discard the initial p-value request
     And I send the app to the background for 5 seconds
     And I wait for 1 span
-    Then a span name equals "Custom/BackgroundSpan"
+    Then a span name equals "BackgroundSpan"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.app.in_foreground" is false

--- a/features/retries.feature
+++ b/features/retries.feature
@@ -6,13 +6,13 @@ Feature: Retries
     And I run "RetryScenario" and discard the initial p-value request
     And I wait to receive 3 traces
     # 500 - Payload rejected (but will still be tracked by MazeRunner)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 200 - Payload delivered (retry)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 200 - Second payload delivered
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
@@ -27,7 +27,7 @@ Feature: Retries
     Given I set the HTTP status code for the next request to 500
     And I run "RetryTimeoutScenario" and discard the initial p-value request
     And I wait to receive 2 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals "SPAN_KIND_INTERNAL"
@@ -37,4 +37,4 @@ Feature: Retries
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.android"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0.0"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"

--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -9,79 +9,79 @@ Feature: Server responses
     Given I set the HTTP status code for the next requests to "200,200,400,500"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 3 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 3"
 
   Scenario: No P update: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
     # 200 - Payload accepted
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 500 - Server error (retry) but still recorded by MazeRunner
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
     And I discard the oldest trace
     # Retry of the previous request
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: No P update: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
     # 500 - Server error (retry) but still recorded by MazeRunner
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 400 - Retry, payload rejected (no retry)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 200 - Payload accepted
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: No P update: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
     # 500 - Server error (retry) but still recorded by MazeRunner
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 200 - Payload accepted
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 400 - Payload rejected
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: No P update: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 3 traces
     # 400 - Payload rejected, no retry
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 500 - Server error (retry) but still recorded by MazeRunner
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
     And I discard the oldest trace
     # Retry of the previous request
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: No P update: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive 4 traces
     # 400 - Payload rejected, no retry
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # 200 - Payload accepted
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
     And I discard the oldest trace
     # 500 - Payload rejected (retry)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 3"
     And I discard the oldest trace
     # Retry of the previous request
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 3"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 3"
 
   # P=0 on first response
 
@@ -90,42 +90,42 @@ Feature: Server responses
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait for 1 span
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on first response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on first response: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on first response: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on first response: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on first response: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     Given I set the sampling probability for the next traces to "1,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 1 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   # P=0 on second response
 
@@ -134,18 +134,18 @@ Feature: Server responses
     Given I set the sampling probability for the next traces to "1,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: Update P to 0 on second response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"
     Given I set the sampling probability for the next traces to "1,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: Update P to 0 on second response: fail-retriable, fail-permanent, success
     Given I set the HTTP status code for the next requests to "200,500,400,200"
@@ -153,10 +153,10 @@ Feature: Server responses
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
     # 500 - Payload rejected (retry)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # Retry of previously rejected trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on second response: fail-retriable, success, fail-permanent
     Given I set the HTTP status code for the next requests to "200,500,200,400"
@@ -164,25 +164,25 @@ Feature: Server responses
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
     # 500 - Payload rejected (retry)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
     # Retry of previously rejected trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
 
   Scenario: Update P to 0 on second response: fail-permanent, fail-retriable, success
     Given I set the HTTP status code for the next requests to "200,400,500,200"
     Given I set the sampling probability for the next traces to "1,null,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
 
   Scenario: Update P to 0 on second response: fail-permanent, success, fail-retriable
     Given I set the HTTP status code for the next requests to "200,400,200,500"
     Given I set the sampling probability for the next traces to "1,null ,0"
     And I run "ThreeSpansScenario" and discard the initial p-value request
     And I wait to receive at least 2 traces
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 1"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/span 2"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"


### PR DESCRIPTION
## Goal
Custom spans started with `BugsnagPerformance.startSpan` should *not* be prefixed, and should have the name used verbatim.

## Testing
Modified existing tests to expect the custom name.