### PR TITLE
Add @JvmOverloads to PerformanceConfiguration.load

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -67,6 +67,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
         private const val BSG_VERSION_CODE_KEY = "$BUGSNAG_NS.VERSION_CODE"
 
         @JvmStatic
+        @JvmOverloads
         fun load(ctx: Context, apiKey: String? = null): PerformanceConfiguration {
             try {
                 val packageManager = ctx.packageManager


### PR DESCRIPTION
## Goal
Allow Java code to use `PerformanceConfiguration.load` without passing an `apiKey`.

```java
PerformanceConfiguration.load(context);
```

instead of

```java
PerformanceConfiguration.load(context, null /* apiKey placeholder */);
```

## Testing
Relied on existing tests