### PR TITLE
Make ending a Span lock-free

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
@@ -9,99 +9,6 @@ package com.bugsnag.android.performance.internal
 internal typealias SpanChain = SpanImpl
 
 /**
- * *Warning O(n) operation*
- *
- * Returns the number of `SpanImpl` objects in this `SpanChain`, by counting each  link in the chain.
- * This should only be called on `SpanChain`s that are stable.
- *
- * @see toList
- */
-internal val SpanChain.size: Int
-    get() {
-        var count = 0
-        var span: SpanImpl? = this
-
-        while (span != null) {
-            count++
-            span = span.next
-        }
-
-        return count
-    }
-
-/**
- * Find the head of this `SpanChain`, traversing up the chain until a `SpanImpl` with no "previous"
- * node is found. This method should only be invoked on stable `SpanChain`s, that is: those
- * only accessible be a single thread.
- */
-internal fun SpanChain.tail(): SpanImpl {
-    var span = this
-
-    // this awkward little dance of keeping `span.next` local avoids extra null enforcement, and
-    // slightly side-steps some possible races
-    var previous = span.next
-
-    while (previous != null) {
-        span = previous
-        previous = span.next
-    }
-
-    return span
-}
-
-internal inline fun SpanChain.forEach(action: (SpanImpl) -> Unit) {
-    var span: SpanImpl? = this
-
-    while (span != null) {
-        action(span)
-        span = span.next
-    }
-}
-
-internal inline fun SpanChain.find(predicate: (SpanImpl) -> Boolean): SpanImpl? {
-    var span: SpanImpl? = this
-    while (span != null) {
-        if (predicate(span)) {
-            return span
-        }
-
-        span = span.next
-    }
-
-    return null
-}
-
-/**
- * Filter this span chain (starting at this `SpanChain`) using the given [predicate] and return the
- * new "tail" of the filtered chain. Unlike normal `filter` operations this is *destructive* once
- * called the `SpanImpl`s in the chain should *only* be accessed by the returned value.
- *
- * @see toList
- */
-internal inline fun SpanChain.filter(predicate: (SpanImpl) -> Boolean): SpanImpl? {
-    val root = find(predicate) ?: return null
-
-    var span: SpanImpl? = root
-    var tail = root
-    while (span != null) {
-        if (!predicate(span)) {
-            tail.next = span.next
-            span.next?.let { tail = it }
-        }
-
-        span = span.next
-    }
-
-    return root
-}
-
-internal fun SpanChain.toList(): List<SpanImpl> {
-    val list = ArrayList<SpanImpl>()
-    forEach(list::add)
-    return list
-}
-
-/**
  * Unrolls this [SpanChain] into the given [output] collection. This is *destructive* and the
  * [SpanChain] links will be broken as part of this process (turning each link back into a "normal"
  * [SpanImpl]).
@@ -116,7 +23,3 @@ internal fun <C : MutableCollection<SpanImpl>> SpanChain.unlinkTo(output: C): C 
     }
     return output
 }
-
-internal fun SpanChain?.isNotEmpty() = this != null
-
-internal fun SpanChain?.isEmpty() = this == null

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanChain.kt
@@ -1,0 +1,122 @@
+@file:JvmName("SpanChains")
+
+package com.bugsnag.android.performance.internal
+
+/**
+ * SpanChain is a type alias of [SpanImpl] to be used when a "list" of spans is expected instead of
+ * single span objects.
+ */
+internal typealias SpanChain = SpanImpl
+
+/**
+ * *Warning O(n) operation*
+ *
+ * Returns the number of `SpanImpl` objects in this `SpanChain`, by counting each  link in the chain.
+ * This should only be called on `SpanChain`s that are stable.
+ *
+ * @see toList
+ */
+internal val SpanChain.size: Int
+    get() {
+        var count = 0
+        var span: SpanImpl? = this
+
+        while (span != null) {
+            count++
+            span = span.next
+        }
+
+        return count
+    }
+
+/**
+ * Find the head of this `SpanChain`, traversing up the chain until a `SpanImpl` with no "previous"
+ * node is found. This method should only be invoked on stable `SpanChain`s, that is: those
+ * only accessible be a single thread.
+ */
+internal fun SpanChain.tail(): SpanImpl {
+    var span = this
+
+    // this awkward little dance of keeping `span.next` local avoids extra null enforcement, and
+    // slightly side-steps some possible races
+    var previous = span.next
+
+    while (previous != null) {
+        span = previous
+        previous = span.next
+    }
+
+    return span
+}
+
+internal inline fun SpanChain.forEach(action: (SpanImpl) -> Unit) {
+    var span: SpanImpl? = this
+
+    while (span != null) {
+        action(span)
+        span = span.next
+    }
+}
+
+internal inline fun SpanChain.find(predicate: (SpanImpl) -> Boolean): SpanImpl? {
+    var span: SpanImpl? = this
+    while (span != null) {
+        if (predicate(span)) {
+            return span
+        }
+
+        span = span.next
+    }
+
+    return null
+}
+
+/**
+ * Filter this span chain (starting at this `SpanChain`) using the given [predicate] and return the
+ * new "tail" of the filtered chain. Unlike normal `filter` operations this is *destructive* once
+ * called the `SpanImpl`s in the chain should *only* be accessed by the returned value.
+ *
+ * @see toList
+ */
+internal inline fun SpanChain.filter(predicate: (SpanImpl) -> Boolean): SpanImpl? {
+    val root = find(predicate) ?: return null
+
+    var span: SpanImpl? = root
+    var tail = root
+    while (span != null) {
+        if (!predicate(span)) {
+            tail.next = span.next
+            span.next?.let { tail = it }
+        }
+
+        span = span.next
+    }
+
+    return root
+}
+
+internal fun SpanChain.toList(): List<SpanImpl> {
+    val list = ArrayList<SpanImpl>()
+    forEach(list::add)
+    return list
+}
+
+/**
+ * Unrolls this [SpanChain] into the given [output] collection. This is *destructive* and the
+ * [SpanChain] links will be broken as part of this process (turning each link back into a "normal"
+ * [SpanImpl]).
+ */
+internal fun <C : MutableCollection<SpanImpl>> SpanChain.unlinkTo(output: C): C {
+    var s: SpanImpl? = this
+    while (s != null) {
+        val next = s.next
+        s.next = null
+        output.add(s)
+        s = next
+    }
+    return output
+}
+
+internal fun SpanChain?.isNotEmpty() = this != null
+
+internal fun SpanChain?.isEmpty() = this == null

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -28,6 +28,16 @@ class SpanImpl internal constructor(
     override val attributes: Attributes = Attributes()
 
     /**
+     * Internally SpanImpl objects can be chained together as a fast linked-list structure
+     * (nicknamed [SpanChain]) allowing us a lock-free / allocation-free batching structure.
+     *
+     * See [Tracer] for more information on how this is used.
+     */
+    @JvmField
+    @JvmSynthetic
+    internal var next: SpanImpl? = null
+
+    /**
      * The name of this `Span`
      */
     internal var name: String = name

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
@@ -1,0 +1,121 @@
+package com.bugsnag.android.performance.internal
+
+import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.testSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SpanChainTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun setupDependencies() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun filterFirstItem() {
+        val span1 = spanFactory.newSpan(spanId = 1L, processor = testSpanProcessor)
+        val span2 = spanFactory.newSpan(spanId = 2L, processor = testSpanProcessor)
+
+        span1.next = span2
+
+        val filteredChain = span1.filter { it.spanId != 1L }
+
+        assertSame(span2, filteredChain)
+        assertNull(filteredChain!!.next)
+    }
+
+    @Test
+    fun filterItems() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.spanId % 2 == 0L }!!.toList()
+        assertEquals(5, filtered.size)
+        // SpanFactory starts counting at 1
+        assertSame(spans[1], filtered[0]) // id == 2
+        assertSame(spans[3], filtered[1]) // id == 4
+        assertSame(spans[5], filtered[2]) // id == 6
+        assertSame(spans[7], filtered[3]) // id == 8
+        assertSame(spans[9], filtered[4]) // id == 10
+    }
+
+    @Test
+    fun tail() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        assertSame(spans.last(), root.tail())
+    }
+
+    @Test
+    fun filterAllItems() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.spanId == -1L }
+        assertNull(filtered)
+    }
+
+    @Test
+    fun filterNothing() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        val filtered = root.filter { it.spanId != -1L }!!.toList()
+        assertEquals(spans, filtered)
+    }
+
+    @Test
+    fun size() {
+        val spanList = spanFactory.newSpans(25, testSpanProcessor)
+        var chain: SpanChain? = spanList.toSpanChain()
+
+        // assert the chain size is the same for each link in the chain
+        repeat(spanList.size) { index ->
+            assertEquals(spanList.size - index, chain?.size)
+            chain = chain?.next
+        }
+    }
+
+    @Test
+    fun emptyChecks() {
+        val nullSpan: SpanChain? = null
+        val notNull: SpanChain = spanFactory.newSpan(processor = testSpanProcessor)
+
+        assertTrue(nullSpan.isEmpty())
+        assertTrue(notNull.isNotEmpty())
+
+        assertFalse(nullSpan.isNotEmpty())
+        assertFalse(notNull.isEmpty())
+    }
+
+    @Test
+    fun unlinkTo() {
+        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val root = spans.toSpanChain()
+
+        // check that all the spans (except the last) have a `next` link
+        (0 until spans.lastIndex).forEach { index -> assertNotNull(spans[index].next) }
+
+        val unlinked = root.unlinkTo(arrayListOf())
+
+        // ensure all of the links have been cleared
+        unlinked.forEach { assertNull(it.next) }
+
+        // the output list should be the same as the input list at this point
+        assertEquals(spans, unlinked)
+    }
+
+    private fun List<SpanImpl>.toSpanChain(): SpanChain {
+        reduce { acc, span -> span.also { acc.next = span } }
+        return first()
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
@@ -3,11 +3,8 @@ package com.bugsnag.android.performance.internal
 import com.bugsnag.android.performance.test.TestSpanFactory
 import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -17,84 +14,6 @@ class SpanChainTest {
     @Before
     fun setupDependencies() {
         spanFactory = TestSpanFactory()
-    }
-
-    @Test
-    fun filterFirstItem() {
-        val span1 = spanFactory.newSpan(spanId = 1L, processor = testSpanProcessor)
-        val span2 = spanFactory.newSpan(spanId = 2L, processor = testSpanProcessor)
-
-        span1.next = span2
-
-        val filteredChain = span1.filter { it.spanId != 1L }
-
-        assertSame(span2, filteredChain)
-        assertNull(filteredChain!!.next)
-    }
-
-    @Test
-    fun filterItems() {
-        val spans = spanFactory.newSpans(10, testSpanProcessor)
-        val root = spans.toSpanChain()
-
-        val filtered = root.filter { it.spanId % 2 == 0L }!!.toList()
-        assertEquals(5, filtered.size)
-        // SpanFactory starts counting at 1
-        assertSame(spans[1], filtered[0]) // id == 2
-        assertSame(spans[3], filtered[1]) // id == 4
-        assertSame(spans[5], filtered[2]) // id == 6
-        assertSame(spans[7], filtered[3]) // id == 8
-        assertSame(spans[9], filtered[4]) // id == 10
-    }
-
-    @Test
-    fun tail() {
-        val spans = spanFactory.newSpans(10, testSpanProcessor)
-        val root = spans.toSpanChain()
-
-        assertSame(spans.last(), root.tail())
-    }
-
-    @Test
-    fun filterAllItems() {
-        val spans = spanFactory.newSpans(10, testSpanProcessor)
-        val root = spans.toSpanChain()
-
-        val filtered = root.filter { it.spanId == -1L }
-        assertNull(filtered)
-    }
-
-    @Test
-    fun filterNothing() {
-        val spans = spanFactory.newSpans(10, testSpanProcessor)
-        val root = spans.toSpanChain()
-
-        val filtered = root.filter { it.spanId != -1L }!!.toList()
-        assertEquals(spans, filtered)
-    }
-
-    @Test
-    fun size() {
-        val spanList = spanFactory.newSpans(25, testSpanProcessor)
-        var chain: SpanChain? = spanList.toSpanChain()
-
-        // assert the chain size is the same for each link in the chain
-        repeat(spanList.size) { index ->
-            assertEquals(spanList.size - index, chain?.size)
-            chain = chain?.next
-        }
-    }
-
-    @Test
-    fun emptyChecks() {
-        val nullSpan: SpanChain? = null
-        val notNull: SpanChain = spanFactory.newSpan(processor = testSpanProcessor)
-
-        assertTrue(nullSpan.isEmpty())
-        assertTrue(notNull.isNotEmpty())
-
-        assertFalse(nullSpan.isNotEmpty())
-        assertFalse(notNull.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Goal
Reduce the overhead of ending a `Span` by removing the locks and allocations on the "hot" side of `Span.end()`

## Design
`SpanImpl` objects can now be formed into linked-lists (type-aliased as `SpanChain` for clarity) without any external structure. When adding them to a pending batch the `Tracer` only keeps track of the most recently added `Span` instead of a traditional `Collection<Span>`. This allows us to atomically add new items, or clear the entire batch (using `getAndSet`).

## Changeset

- `SpanImpl` instances have an internal `next` field that allows them to be chained together (this is similar to how `android.os.Message` [sometimes works](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/Message.java;l=137))
- `SpanChain` is an `internal` type alias of `SpanImpl` to be used when we expect spans as linked-lists
- `Tracer.batch` is now a `AtomicReference<SpanChain>(null)`
- `Tracer` now keeps track of an "estimated" `batchSize` independently of the `batch`, allowing a fast way to check the number of spans in a current batch (without needing to count them)
- Once collected (drained) a batch is added to an `ArrayList` and the order reversed (reversing can probably be optimised out later on, as the order is not significant outside of tests)

## Testing
Added new unit tests for `SpanChain` specific functionality, and relied on existing batching tests to ensure overall behaviour has not changed