### PR TITLE
Any releaseStage value should be considered "enabled" by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* PerformanceConfiguration.enabledReleaseStages now defaults to `null` effectively enabling all release stages (and follows the logic in `bugsnag-android`)
+  []()
+
 ## 0.1.1 (2023-03-15)
 
 * Invalid api-keys are logged as warnings instead of failing startup

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -5,7 +5,6 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.FloatRange
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.internal.RELEASE_STAGE_PRODUCTION
 
 class PerformanceConfiguration private constructor(val context: Context) {
 
@@ -23,7 +22,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
 
     var releaseStage: String? = null
 
-    var enabledReleaseStages: Set<String> = mutableSetOf(RELEASE_STAGE_PRODUCTION)
+    var enabledReleaseStages: Set<String>? = null
 
     var versionCode: Long? = null
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
@@ -15,11 +15,12 @@ internal data class ImmutableConfig(
     val autoInstrumentActivities: AutoInstrument,
     val packageName: String,
     val releaseStage: String,
-    val enabledReleaseStages: Set<String>,
+    val enabledReleaseStages: Set<String>?,
     val versionCode: Long?,
     val samplingProbability: Double,
 ) {
-    val isReleaseStageEnabled = enabledReleaseStages.contains(releaseStage)
+    val isReleaseStageEnabled =
+        enabledReleaseStages == null || enabledReleaseStages.contains(releaseStage)
 
     constructor(configuration: PerformanceConfiguration) : this(
         configuration.context.applicationContext as Application,
@@ -29,7 +30,7 @@ internal data class ImmutableConfig(
         configuration.autoInstrumentActivities,
         configuration.context.packageName,
         configuration.releaseStage ?: configuration.context.releaseStage,
-        configuration.enabledReleaseStages.toSet(),
+        configuration.enabledReleaseStages?.toSet(),
         configuration.versionCode ?: versionCodeFor(configuration.context),
         configuration.samplingProbability,
     )

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
@@ -10,6 +10,7 @@ import com.bugsnag.android.performance.PerformanceConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.startsWith
@@ -62,6 +63,16 @@ class ImmutableConfigTest {
 
         releaseStages.add("production")
         assertNotEquals(releaseStages, immutableConfig.enabledReleaseStages)
+    }
+
+    @Test
+    fun enableAllReleaseStages() {
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        perfConfig.releaseStage = "this is a very interesting releaseStage"
+        perfConfig.enabledReleaseStages = null
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+        assertTrue(immutableConfig.isReleaseStageEnabled)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Any `releaseStage` should be considered "enabled" unless a set of `enabledReleaseStages` is explicitly set (following the standard notifier logic).

## Changeset
`enabledReleaseStages` can be `null` (and is by default) indicating that any `releaseStage` value is considered "enabled". This follows the same logic as `bugsnag-android`.

## Testing
Added a new unit test for this behaviour