### PR TITLE
feat(activity): added activity load phase instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.14.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.23.0'
 
 # Or follow master:
 # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b39799d1fdc49fa69676c5732dd68ea62e66d975
-  tag: v7.14.0
+  revision: f33ab96c1c9e39c906972cace41d703556378b3b
+  tag: v7.23.0
   specs:
-    bugsnag-maze-runner (7.14.0)
+    bugsnag-maze-runner (7.23.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -13,6 +13,7 @@ GIT
       json_schemer (~> 0.2.24)
       optimist (~> 3.0.1)
       os (~> 1.0.0)
+      rack (~> 2.2)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
       selenium-webdriver (~> 4.0)
@@ -29,11 +30,11 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.25.1)
+    bugsnag (6.25.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -89,16 +90,17 @@ GEM
       xml-simple (~> 1.1.5)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     multi_test (0.1.2)
-    nokogiri (1.14.0-x86_64-darwin)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.3)
     racc (1.6.2)
+    rack (2.2.6.4)
     rake (12.3.3)
-    regexp_parser (2.6.2)
+    regexp_parser (2.7.0)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -222,7 +222,7 @@ object BugsnagPerformance {
     @JvmStatic
     @JvmOverloads
     fun endViewLoadSpan(activity: Activity, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
-        instrumentedAppState.spanTracker.endSpan(activity, endTime)
+        instrumentedAppState.spanTracker.endSpan(activity, endTime = endTime)
     }
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -80,27 +80,27 @@ class PerformanceLifecycleCallbacks internal constructor(
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         startViewLoad(activity, savedInstanceState)
-        startViewLoadPhase(activity, "Create")
+        startViewLoadPhase(activity, ViewLifecyclePhase.CREATE)
     }
 
     override fun onActivityPreStarted(activity: Activity) {
-        startViewLoadPhase(activity, "Start")
+        startViewLoadPhase(activity, ViewLifecyclePhase.START)
     }
 
     override fun onActivityPreResumed(activity: Activity) {
-        startViewLoadPhase(activity, "Resume")
+        startViewLoadPhase(activity, ViewLifecyclePhase.RESUME)
     }
 
     override fun onActivityPostCreated(activity: Activity, savedInstanceState: Bundle?) {
-        endViewLoadPhase(activity, "Create")
+        endViewLoadPhase(activity, ViewLifecyclePhase.CREATE)
     }
 
     override fun onActivityPostStarted(activity: Activity) {
-        endViewLoadPhase(activity, "Start")
+        endViewLoadPhase(activity, ViewLifecyclePhase.START)
     }
 
     override fun onActivityPostResumed(activity: Activity) {
-        endViewLoadPhase(activity, "Resume")
+        endViewLoadPhase(activity, ViewLifecyclePhase.RESUME)
         endViewLoad(activity)
     }
 
@@ -199,12 +199,11 @@ class PerformanceLifecycleCallbacks internal constructor(
         }
     }
 
-    private fun startViewLoadPhase(activity: Activity, phase: String) {
+    private fun startViewLoadPhase(activity: Activity, phase: ViewLifecyclePhase) {
         val viewLoadSpan = spanTracker[activity]
         if (openLoadSpans && viewLoadSpan != null) {
-            val spanName = spanNameForPhase(activity,phase)
-            spanTracker.associate(spanName) {
-                spanFactory.createCustomSpan(spanName,
+            spanTracker.associate(activity, phase) {
+                spanFactory.createCustomSpan(spanNameForPhase(activity,phase),
                     SpanOptions.DEFAULTS.within(viewLoadSpan)).apply {
                     setAttribute("bugsnag.span.category", "view_load_phase")
                 }
@@ -212,12 +211,12 @@ class PerformanceLifecycleCallbacks internal constructor(
         }
     }
 
-    private fun endViewLoadPhase(activity: Activity, phase: String) {
-        spanTracker.endSpan(spanNameForPhase(activity,phase))
+    private fun endViewLoadPhase(activity: Activity, phase: ViewLifecyclePhase) {
+        spanTracker.endSpan(activity, phase)
     }
 
-    private fun spanNameForPhase(activity: Activity, phase: String): String {
-        return "ViewLoadPhase/Activity${phase}/${activity::class.java.simpleName}"
+    private fun spanNameForPhase(activity: Activity, phase: ViewLifecyclePhase): String {
+        return "ViewLoadPhase/Activity${phase.spanName}/${activity::class.java.simpleName}"
     }
 
     override fun onActivityPaused(activity: Activity) = Unit

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -200,11 +200,12 @@ class PerformanceLifecycleCallbacks internal constructor(
     }
 
     private fun startViewLoadPhase(activity: Activity, phase: String) {
-        if (openLoadSpans) {
-            val spanName = "ViewLoadPhase/Activity${phase}/${activity::class.java.simpleName}"
+        val viewLoadSpan = spanTracker[activity]
+        if (openLoadSpans && viewLoadSpan != null) {
+            val spanName = spanNameForPhase(activity,phase)
             spanTracker.associate(spanName) {
                 spanFactory.createCustomSpan(spanName,
-                    SpanOptions.DEFAULTS.within(spanTracker[activity])).apply {
+                    SpanOptions.DEFAULTS.within(viewLoadSpan)).apply {
                     setAttribute("bugsnag.span.category", "view_load_phase")
                 }
             }
@@ -212,7 +213,11 @@ class PerformanceLifecycleCallbacks internal constructor(
     }
 
     private fun endViewLoadPhase(activity: Activity, phase: String) {
-        spanTracker.endSpan("ViewLoadPhase/Activity${phase}/${activity::class.java.simpleName}")
+        spanTracker.endSpan(spanNameForPhase(activity,phase))
+    }
+
+    private fun spanNameForPhase(activity: Activity, phase: String): String {
+        return "ViewLoadPhase/Activity${phase}/${activity::class.java.simpleName}"
     }
 
     override fun onActivityPaused(activity: Activity) = Unit

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -80,27 +80,27 @@ class PerformanceLifecycleCallbacks internal constructor(
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         startViewLoad(activity, savedInstanceState)
-        startViewLoadPhase(activity, ViewLifecyclePhase.CREATE)
+        startViewLoadPhase(activity, ViewLoadPhase.CREATE)
     }
 
     override fun onActivityPreStarted(activity: Activity) {
-        startViewLoadPhase(activity, ViewLifecyclePhase.START)
+        startViewLoadPhase(activity, ViewLoadPhase.START)
     }
 
     override fun onActivityPreResumed(activity: Activity) {
-        startViewLoadPhase(activity, ViewLifecyclePhase.RESUME)
+        startViewLoadPhase(activity, ViewLoadPhase.RESUME)
     }
 
     override fun onActivityPostCreated(activity: Activity, savedInstanceState: Bundle?) {
-        endViewLoadPhase(activity, ViewLifecyclePhase.CREATE)
+        endViewLoadPhase(activity, ViewLoadPhase.CREATE)
     }
 
     override fun onActivityPostStarted(activity: Activity) {
-        endViewLoadPhase(activity, ViewLifecyclePhase.START)
+        endViewLoadPhase(activity, ViewLoadPhase.START)
     }
 
     override fun onActivityPostResumed(activity: Activity) {
-        endViewLoadPhase(activity, ViewLifecyclePhase.RESUME)
+        endViewLoadPhase(activity, ViewLoadPhase.RESUME)
         endViewLoad(activity)
     }
 
@@ -199,7 +199,7 @@ class PerformanceLifecycleCallbacks internal constructor(
         }
     }
 
-    private fun startViewLoadPhase(activity: Activity, phase: ViewLifecyclePhase) {
+    private fun startViewLoadPhase(activity: Activity, phase: ViewLoadPhase) {
         val viewLoadSpan = spanTracker[activity]
         if (openLoadSpans && viewLoadSpan != null) {
             spanTracker.associate(activity, phase) {
@@ -211,11 +211,11 @@ class PerformanceLifecycleCallbacks internal constructor(
         }
     }
 
-    private fun endViewLoadPhase(activity: Activity, phase: ViewLifecyclePhase) {
+    private fun endViewLoadPhase(activity: Activity, phase: ViewLoadPhase) {
         spanTracker.endSpan(activity, phase)
     }
 
-    private fun spanNameForPhase(activity: Activity, phase: ViewLifecyclePhase): String {
+    private fun spanNameForPhase(activity: Activity, phase: ViewLoadPhase): String {
         return "ViewLoadPhase/Activity${phase.spanName}/${activity::class.java.simpleName}"
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.performance.internal
 import android.os.SystemClock
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.internal.SpanImpl.Companion.NO_END_TIME
+import java.util.EnumMap
 import java.util.WeakHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -17,25 +18,27 @@ import kotlin.concurrent.write
  * time is used to close it.
  */
 class SpanTracker {
-    private val backingStore: MutableMap<Any, SpanBinding> = WeakHashMap()
+    private val backingStore: MutableMap<Any, EnumMap<ViewLifecyclePhase, SpanBinding>> = WeakHashMap()
     private val lock = ReentrantReadWriteLock()
 
-    operator fun get(token: Any): SpanImpl? {
-        return lock.read { backingStore[token]?.span }
+    operator fun get(token: Any, subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE): SpanImpl? {
+        return lock.read { backingStore[token]?.get(subToken)?.span }
     }
 
     /**
-     * Track a `SpanImpl` against a specified [token] object, returning the actual `Span` being
-     * tracked. This function may discard [span] if the given [token] is already being tracked,
-     * if this is the case the tracked span will be returned.
+     * Track a `SpanImpl` against a specified [token] object, and an optional [subToken], returning
+     * the actual `Span` being tracked. This function may discard [span] if the given [token] is
+     * already being tracked, if this is the case the tracked span will be returned.
      */
-    fun associate(token: Any, span: SpanImpl): SpanImpl {
+    fun associate(token: Any, subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE, span: SpanImpl): SpanImpl {
         lock.write {
-            val existingSpan = backingStore[token]
+            val trackedSpans = backingStore[token] ?: EnumMap(ViewLifecyclePhase::class.java)
+            val existingSpan = trackedSpans[subToken]
             if (existingSpan != null) {
                 return existingSpan.span
             } else {
-                backingStore[token] = SpanBinding(span)
+                trackedSpans[subToken] = SpanBinding(span)
+                backingStore[token] = trackedSpans
                 return span
             }
         }
@@ -49,17 +52,21 @@ class SpanTracker {
      * Note: in race scenarios the [createSpan] may be invoked and the resulting `Span` discarded,
      * the currently tracked `Span` will however always be returned.
      */
-    inline fun associate(token: Any, createSpan: () -> SpanImpl): SpanImpl {
-        var associatedSpan = this[token]
+    inline fun associate(
+        token: Any,
+        subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE,
+        createSpan: () -> SpanImpl
+    ): SpanImpl {
+        var associatedSpan = this[token, subToken]
         if (associatedSpan == null) {
-            associatedSpan = associate(token, createSpan())
+            associatedSpan = associate(token, subToken, createSpan())
         }
 
         return associatedSpan
     }
 
-    fun removeAssociation(tag: Any?): SpanImpl? {
-        return lock.write { backingStore.remove(tag)?.span }
+    fun removeAssociation(tag: Any?, subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE): SpanImpl? {
+        return lock.write { backingStore.remove(tag)?.get(subToken)?.span }
     }
 
     /**
@@ -67,8 +74,8 @@ class SpanTracker {
      * marked as [leaked](markSpanLeaked) then its `endTime` will be set to [autoEndTime]. Otherwise
      * this value will be discarded.
      */
-    fun markSpanAutomaticEnd(token: Any) {
-        backingStore[token]?.autoEndTime = SystemClock.elapsedRealtimeNanos()
+    fun markSpanAutomaticEnd(token: Any, subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE) {
+        backingStore[token]?.get(subToken)?.autoEndTime = SystemClock.elapsedRealtimeNanos()
     }
 
     /**
@@ -76,16 +83,32 @@ class SpanTracker {
      * Returns `true` if the `Span` was marked as leaked, or `false` if the `Span` was already
      * considered to be closed (or was not tracked).
      */
-    fun markSpanLeaked(token: Any): Boolean {
-        return lock.write { backingStore.remove(token)?.markLeaked() == true }
+    fun markSpanLeaked(token: Any, subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE): Boolean {
+        return lock.write {
+            if (subToken == ViewLifecyclePhase.NONE) {
+                backingStore.remove(token)?.get(subToken)?.markLeaked() == true
+            } else {
+                backingStore[token]?.remove(subToken)?.markLeaked() == true
+            }
+        }
     }
 
     /**
      * End the tracking of a `Span` marking its `endTime` if it has not already been closed.
      * This *must* be called in order to ensure tokens can be garbage-collected.
      */
-    fun endSpan(token: Any, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
-        lock.write { backingStore.remove(token)?.span?.end(endTime) }
+    fun endSpan(
+        token: Any,
+        subToken: ViewLifecyclePhase = ViewLifecyclePhase.NONE,
+        endTime: Long = SystemClock.elapsedRealtimeNanos()
+    ) {
+        lock.write {
+            if (subToken == ViewLifecyclePhase.NONE) {
+                backingStore.remove(token)?.get(subToken)?.span?.end(endTime)
+            } else {
+                backingStore[token]?.remove(subToken)?.span?.end(endTime)
+            }
+        }
     }
 
     private class SpanBinding(val span: SpanImpl) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLifecyclePhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLifecyclePhase.kt
@@ -1,0 +1,11 @@
+package com.bugsnag.android.performance.internal
+
+enum class ViewLifecyclePhase(internal val spanName: String) {
+    NONE(""),
+    CREATE("Create"),
+    START("Start"),
+    RESUME("Resume"),
+}
+
+
+

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
-enum class ViewLifecyclePhase(internal val spanName: String) {
-    NONE(""),
+enum class ViewLoadPhase(internal val spanName: String) {
     CREATE("Create"),
     START("Start"),
     RESUME("Resume"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -163,10 +163,165 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals(400_000_000L, span2.endTime)
     }
 
+    @Test fun fullViewLoadPhaseTracking() {
+        // this is actually the default initial value for Robolectric, but we set it manually
+        // just as a form of documentation
+        SystemClock.setCurrentTimeMillis(100L)
+
+        val callbacks = PerformanceLifecycleCallbacks(
+            spanTracker = spanTracker,
+            spanFactory = spanFactory,
+            inForegroundCallback = {},
+        ).apply {
+            openLoadSpans = true
+            closeLoadSpans = true
+            instrumentAppStart = false
+        }
+
+        cycleActivityLoad(activity, callbacks)
+
+        val spans = spanProcessor.toList()
+        assertEquals(4, spans.size)
+
+        // we expect the view load span to be second as it was ended after the onCreate span
+        val viewLoadSpan = spans[1]
+        assertEquals("ViewLoad/Activity/Activity", viewLoadSpan.name)
+        assertEquals(100_000_000L, viewLoadSpan.startTime)
+        assertEquals(200_000_000L, viewLoadSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, viewLoadSpan.kind)
+        assertTrue(viewLoadSpan.isEnded())
+
+        val onCreateSpan = spans.first()
+        assertEquals("ViewLoadPhase/ActivityCreate/Activity", onCreateSpan.name)
+        assertEquals(viewLoadSpan.spanId, onCreateSpan.parentSpanId)
+        assertEquals(100_000_000L, onCreateSpan.startTime)
+        assertEquals(100_000_000L, onCreateSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onCreateSpan.kind)
+        assertTrue(onCreateSpan.isEnded())
+
+        val onStartSpan = spans[2]
+        assertEquals("ViewLoadPhase/ActivityStart/Activity", onStartSpan.name)
+        assertEquals(viewLoadSpan.spanId, onStartSpan.parentSpanId)
+        assertEquals(150_000_000L, onStartSpan.startTime)
+        assertEquals(150_000_000L, onStartSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onStartSpan.kind)
+        assertTrue(onStartSpan.isEnded())
+
+        val onResumeSpan = spans[3]
+        assertEquals("ViewLoadPhase/ActivityResume/Activity", onResumeSpan.name)
+        assertEquals(viewLoadSpan.spanId, onResumeSpan.parentSpanId)
+        assertEquals(200_000_000L, onResumeSpan.startTime)
+        assertEquals(200_000_000L, onResumeSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onResumeSpan.kind)
+        assertTrue(onResumeSpan.isEnded())
+    }
+
+    @Test
+    fun startOnlyViewLoadPhaseTracking() {
+        // this is actually the default initial value for Robolectric, but we set it manually
+        // just as a form of documentation
+        SystemClock.setCurrentTimeMillis(100L)
+
+        val callbacks = PerformanceLifecycleCallbacks(
+            spanTracker = spanTracker,
+            spanFactory = spanFactory,
+            inForegroundCallback = {},
+        ).apply {
+            openLoadSpans = true
+            closeLoadSpans = false
+            instrumentAppStart = false
+        }
+
+        cycleActivityLoad(activity, callbacks)
+
+        // at this stage the 3 view load phase spans should have been ended but
+        // the parent view load span is still open
+        assertEquals(3, spanProcessor.toList().size)
+
+        // end view load span
+        callbacks.onActivityDestroyed(activity)
+
+        val spans = spanProcessor.toList()
+        assertEquals(4, spans.size)
+
+        // we expect the view load span to be second as it was ended after the onCreate span
+        val viewLoadSpan = spans[1]
+        assertEquals("ViewLoad/Activity/Activity", viewLoadSpan.name)
+        assertEquals(100_000_000L, viewLoadSpan.startTime)
+        assertEquals(200_000_000L, viewLoadSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, viewLoadSpan.kind)
+        assertTrue(viewLoadSpan.isEnded())
+
+        val onCreateSpan = spans.first()
+        assertEquals("ViewLoadPhase/ActivityCreate/Activity", onCreateSpan.name)
+        assertEquals(viewLoadSpan.spanId, onCreateSpan.parentSpanId)
+        assertEquals(100_000_000L, onCreateSpan.startTime)
+        assertEquals(100_000_000L, onCreateSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onCreateSpan.kind)
+        assertTrue(onCreateSpan.isEnded())
+
+        val onStartSpan = spans[2]
+        assertEquals("ViewLoadPhase/ActivityStart/Activity", onStartSpan.name)
+        assertEquals(viewLoadSpan.spanId, onStartSpan.parentSpanId)
+        assertEquals(150_000_000L, onStartSpan.startTime)
+        assertEquals(150_000_000L, onStartSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onStartSpan.kind)
+        assertTrue(onStartSpan.isEnded())
+
+        val onResumeSpan = spans[3]
+        assertEquals("ViewLoadPhase/ActivityResume/Activity", onResumeSpan.name)
+        assertEquals(viewLoadSpan.spanId, onResumeSpan.parentSpanId)
+        assertEquals(200_000_000L, onResumeSpan.startTime)
+        assertEquals(200_000_000L, onResumeSpan.endTime)
+        assertEquals(SpanKind.INTERNAL, onResumeSpan.kind)
+        assertTrue(onResumeSpan.isEnded())
+    }
+
+    @Test
+    fun noViewLoadPhaseTracking() {
+        // this is actually the default initial value for Robolectric, but we set it manually
+        // just as a form of documentation
+        SystemClock.setCurrentTimeMillis(100L)
+
+        val callbacks = PerformanceLifecycleCallbacks(
+            spanTracker = spanTracker,
+            spanFactory = spanFactory,
+            inForegroundCallback = {},
+        ).apply {
+            openLoadSpans = false
+            closeLoadSpans = false
+            instrumentAppStart = false
+        }
+
+        cycleActivityLoad(activity, callbacks)
+        callbacks.onActivityDestroyed(activity)
+
+        val spans = spanProcessor.toList()
+        assertEquals(0, spans.size)
+    }
+
     private fun cycleActivity(activity: Activity, callbacks: PerformanceLifecycleCallbacks) {
         callbacks.onActivityCreated(activity, null)
         callbacks.onActivityStarted(activity)
         callbacks.onActivityStopped(activity)
         callbacks.onActivityDestroyed(activity)
+    }
+
+    private fun cycleActivityLoad(activity: Activity, callbacks: PerformanceLifecycleCallbacks) {
+        callbacks.onActivityPreCreated(activity, null)
+        callbacks.onActivityCreated(activity, null) // shouldn't do anything
+        callbacks.onActivityPostCreated(activity, null)
+
+        SystemClock.setCurrentTimeMillis(150L)
+
+        callbacks.onActivityPreStarted(activity)
+        callbacks.onActivityStarted(activity) // shouldn't do anything
+        callbacks.onActivityPostStarted(activity)
+
+        SystemClock.setCurrentTimeMillis(200L)
+
+        callbacks.onActivityPreResumed(activity)
+        callbacks.onActivityResumed(activity) // shouldn't do anything
+        callbacks.onActivityPostResumed(activity)
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -296,8 +296,20 @@ class PerformanceLifecycleCallbacksTest {
         cycleActivityLoad(activity, callbacks)
         callbacks.onActivityDestroyed(activity)
 
-        val spans = spanProcessor.toList()
-        assertEquals(0, spans.size)
+        assertEquals(0, spanProcessor.toList().size)
+
+        callbacks.openLoadSpans = true
+        callbacks.closeLoadSpans = true
+
+        callbacks.onActivityPreStarted(activity)
+        callbacks.onActivityStarted(activity)
+        callbacks.onActivityPostStarted(activity)
+        callbacks.onActivityPreResumed(activity)
+        callbacks.onActivityResumed(activity)
+        callbacks.onActivityPostResumed(activity)
+
+        // there is no parent view load span so we expect no spans for the view load phases
+        assertEquals(0, spanProcessor.toList().size)
     }
 
     private fun cycleActivity(activity: Activity, callbacks: PerformanceLifecycleCallbacks) {

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import android.app.Activity
+import android.os.Build
 import android.os.SystemClock
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.SpanKind
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowPausedSystemClock
+import org.robolectric.util.ReflectionHelpers
 
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowPausedSystemClock::class])
@@ -163,10 +165,13 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals(400_000_000L, span2.endTime)
     }
 
-    @Test fun fullViewLoadPhaseTracking() {
+    @Test
+    fun fullViewLoadPhaseTracking() {
         // this is actually the default initial value for Robolectric, but we set it manually
         // just as a form of documentation
         SystemClock.setCurrentTimeMillis(100L)
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.Q)
 
         val callbacks = PerformanceLifecycleCallbacks(
             spanTracker = spanTracker,
@@ -221,6 +226,8 @@ class PerformanceLifecycleCallbacksTest {
         // this is actually the default initial value for Robolectric, but we set it manually
         // just as a form of documentation
         SystemClock.setCurrentTimeMillis(100L)
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.Q)
 
         val callbacks = PerformanceLifecycleCallbacks(
             spanTracker = spanTracker,

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -30,15 +30,15 @@ class SpanTrackerTest {
             createSpan()
         }
 
-        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+        val onCreateSpan = tracker.associate("TestActivity", ViewLoadPhase.CREATE) {
             createSpan()
         }
 
-        tracker.markSpanAutomaticEnd("TestActivity", ViewLifecyclePhase.CREATE)
-        tracker.markSpanLeaked("TestActivity", ViewLifecyclePhase.CREATE)
+        tracker.markSpanAutomaticEnd("TestActivity", ViewLoadPhase.CREATE)
+        tracker.markSpanLeaked("TestActivity", ViewLoadPhase.CREATE)
 
         assertEquals(autoEndTime, onCreateSpan.endTime)
-        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
+        assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
 
         assertNotNull(tracker["TestActivity"])
         assertNotEquals(autoEndTime, loadSpan.endTime)
@@ -62,17 +62,17 @@ class SpanTrackerTest {
             createSpan()
         }
 
-        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+        val onCreateSpan = tracker.associate("TestActivity", ViewLoadPhase.CREATE) {
             createSpan()
         }
 
         // Check that subtoken spans can also be ended manually
-        tracker.markSpanAutomaticEnd("TestActivity", ViewLifecyclePhase.CREATE)
+        tracker.markSpanAutomaticEnd("TestActivity", ViewLoadPhase.CREATE)
         onCreateSpan.end(realEndTime)
-        tracker.markSpanLeaked("TestActivity", ViewLifecyclePhase.CREATE)
+        tracker.markSpanLeaked("TestActivity", ViewLoadPhase.CREATE)
 
         assertEquals(realEndTime, onCreateSpan.endTime)
-        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
+        assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
 
         // Activity.onResume
         tracker.markSpanAutomaticEnd("TestActivity")
@@ -96,18 +96,18 @@ class SpanTrackerTest {
             createSpan()
         }
 
-        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+        val onCreateSpan = tracker.associate("TestActivity", ViewLoadPhase.CREATE) {
             createSpan()
         }
 
         assertSame(loadSpan, tracker["TestActivity"])
-        assertSame(onCreateSpan, tracker["TestActivity", ViewLifecyclePhase.CREATE])
+        assertSame(onCreateSpan, tracker["TestActivity", ViewLoadPhase.CREATE])
 
         // end the onCreate span
-        tracker.endSpan("TestActivity", ViewLifecyclePhase.CREATE, endTime = endTime)
+        tracker.endSpan("TestActivity", ViewLoadPhase.CREATE, endTime = endTime)
 
         assertEquals(endTime, onCreateSpan.endTime)
-        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
+        assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
         assertSame(loadSpan, tracker["TestActivity"])
 
         // end the view load span

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -5,7 +5,10 @@ import com.bugsnag.android.performance.test.TestSpanFactory
 import com.bugsnag.android.performance.test.testSpanProcessor
 import com.bugsnag.android.performance.test.withStaticMock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 
@@ -23,17 +26,27 @@ class SpanTrackerTest {
         mockedClock.`when`<Long>(SystemClock::elapsedRealtimeNanos).thenReturn(autoEndTime)
 
         val tracker = SpanTracker()
-        val span = tracker.associate("TestActivity") {
-            spanFactory.newSpan(
-                processor = testSpanProcessor,
-                endTime = null,
-            )
+        val loadSpan = tracker.associate("TestActivity") {
+            createSpan()
         }
+
+        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+            createSpan()
+        }
+
+        tracker.markSpanAutomaticEnd("TestActivity", ViewLifecyclePhase.CREATE)
+        tracker.markSpanLeaked("TestActivity", ViewLifecyclePhase.CREATE)
+
+        assertEquals(autoEndTime, onCreateSpan.endTime)
+        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
+
+        assertNotNull(tracker["TestActivity"])
+        assertNotEquals(autoEndTime, loadSpan.endTime)
 
         tracker.markSpanAutomaticEnd("TestActivity")
         tracker.markSpanLeaked("TestActivity")
 
-        assertEquals(autoEndTime, span.endTime)
+        assertEquals(autoEndTime, loadSpan.endTime)
         assertNull(tracker["TestActivity"])
     }
 
@@ -45,20 +58,32 @@ class SpanTrackerTest {
         mockedClock.`when`<Long>(SystemClock::elapsedRealtimeNanos).thenReturn(autoEndTime)
 
         val tracker = SpanTracker()
-        val span = tracker.associate("TestActivity") {
-            spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        val loadSpan = tracker.associate("TestActivity") {
+            createSpan()
         }
+
+        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+            createSpan()
+        }
+
+        // Check that subtoken spans can also be ended manually
+        tracker.markSpanAutomaticEnd("TestActivity", ViewLifecyclePhase.CREATE)
+        onCreateSpan.end(realEndTime)
+        tracker.markSpanLeaked("TestActivity", ViewLifecyclePhase.CREATE)
+
+        assertEquals(realEndTime, onCreateSpan.endTime)
+        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
 
         // Activity.onResume
         tracker.markSpanAutomaticEnd("TestActivity")
 
         // manually end the returned Span
-        span.end(realEndTime)
+        loadSpan.end(realEndTime)
 
         // Activity.onDestroy
         tracker.markSpanLeaked("TestActivity")
 
-        assertEquals(realEndTime, span.endTime)
+        assertEquals(realEndTime, loadSpan.endTime)
         assertNull(tracker["TestActivity"])
     }
 
@@ -67,13 +92,32 @@ class SpanTrackerTest {
         val endTime = 150L
 
         val tracker = SpanTracker()
-        val span = tracker.associate("TestActivity") {
-            spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        val loadSpan = tracker.associate("TestActivity") {
+            createSpan()
         }
 
-        tracker.endSpan("TestActivity", endTime)
+        val onCreateSpan = tracker.associate("TestActivity", ViewLifecyclePhase.CREATE) {
+            createSpan()
+        }
 
-        assertEquals(endTime, span.endTime)
+        assertSame(loadSpan, tracker["TestActivity"])
+        assertSame(onCreateSpan, tracker["TestActivity", ViewLifecyclePhase.CREATE])
+
+        // end the onCreate span
+        tracker.endSpan("TestActivity", ViewLifecyclePhase.CREATE, endTime = endTime)
+
+        assertEquals(endTime, onCreateSpan.endTime)
+        assertNull(tracker["TestActivity", ViewLifecyclePhase.CREATE])
+        assertSame(loadSpan, tracker["TestActivity"])
+
+        // end the view load span
+        tracker.endSpan("TestActivity", endTime = endTime)
+
+        assertEquals(endTime, loadSpan.endTime)
         assertNull(tracker["TestActivity"])
+    }
+
+    private fun createSpan(): SpanImpl {
+        return spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
     }
 }

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -1,38 +1,45 @@
 Feature: Automatic creation of spans
 
+  @skip_above_android_9
   Scenario: Activity with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL" and discard the initial p-value request
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.view.type" equals "activity"
-    * a span string attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
+    Then a span named "ViewLoad/Activity/ActivityViewLoadActivity" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | activity                 |
+                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
 
-    * a span name equals "ViewLoad/Fragment/LoaderFragment"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.view.type" equals "fragment"
-    * a span string attribute "bugsnag.view.name" equals "LoaderFragment"
+    * a span named "ViewLoad/Fragment/LoaderFragment" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | fragment                 |
+                | bugsnag.view.name       | stringValue | LoaderFragment           |
 
+  @skip_above_android_9
   Scenario: Activity with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY" and discard the initial p-value request
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.view.type" equals "activity"
-    * a span string attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
+    Then a span named "ViewLoad/Activity/ActivityViewLoadActivity" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | activity                 |
+                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
 
-    * a span name equals "ViewLoad/Fragment/LoaderFragment"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.view.type" equals "fragment"
-    * a span string attribute "bugsnag.view.name" equals "LoaderFragment"
+    * a span named "ViewLoad/Fragment/LoaderFragment" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load                |
+               | bugsnag.view.type       | stringValue | fragment                 |
+               | bugsnag.view.name       | stringValue | LoaderFragment           |
 
   Scenario: Activity with no automatic ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "OFF" and discard the initial p-value request
     And I wait to receive 1 traces
-    Then a span name equals "ViewLoad/Activity/ActivityViewLoadActivity"
-    * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span string attribute "bugsnag.view.type" equals "activity"
-    * a span string attribute "bugsnag.view.name" equals "ActivityViewLoadActivity"
+    Then a span named "ViewLoad/Activity/ActivityViewLoadActivity" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | activity                 |
+                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
 
   Scenario: AppStart instrumentation
     Given I run "AppStartScenario"
@@ -40,6 +47,63 @@ Feature: Automatic creation of spans
     * I load scenario "AppStartScenario"
     * I wait to receive 2 traces
     * I discard the oldest trace
-    * a span name equals "AppStart/Cold"
-    * a span string attribute "bugsnag.span.category" equals "app_start"
-    * a span string attribute "bugsnag.app_start.type" equals "cold"
+    * a span named "AppStart/Cold" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | app_start                |
+                | bugsnag.app_start.type  | stringValue | cold                     |
+
+  @skip_below_android_10
+  Scenario: Activity load breakdown with full ViewLoad instrumentation
+    Given I run "ActivityLoadInstrumentationScenario" configured as "FULL" and discard the initial p-value request
+    And I wait for 5 spans
+    Then a span named "ViewLoad/Activity/ActivityViewLoadActivity" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | activity                 |
+                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+
+    * a span named "ViewLoadPhase/ActivityCreate/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoadPhase/ActivityStart/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoadPhase/ActivityResume/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoad/Fragment/LoaderFragment" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load                |
+               | bugsnag.view.type       | stringValue | fragment                 |
+               | bugsnag.view.name       | stringValue | LoaderFragment           |
+
+  @skip_below_android_10
+  Scenario: Activity load breakdown with start-only ViewLoad instrumentation
+    Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY" and discard the initial p-value request
+    And I wait for 5 spans
+    Then a span named "ViewLoad/Activity/ActivityViewLoadActivity" contains the attributes:
+                | attribute               | type        | value                    |
+                | bugsnag.span.category   | stringValue | view_load                |
+                | bugsnag.view.type       | stringValue | activity                 |
+                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+
+    * a span named "ViewLoadPhase/ActivityCreate/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoadPhase/ActivityStart/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoadPhase/ActivityResume/ActivityViewLoadActivity" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load_phase          |
+
+    * a span named "ViewLoad/Fragment/LoaderFragment" contains the attributes:
+               | attribute               | type        | value                    |
+               | bugsnag.span.category   | stringValue | view_load                |
+               | bugsnag.view.type       | stringValue | fragment                 |
+               | bugsnag.view.name       | stringValue | LoaderFragment           |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,3 +6,11 @@ end
 Before('@skip') do |scenario|
   skip_this_scenario("Skipping scenario")
 end
+
+Before('@skip_above_android_9') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.os_version > 9
+end
+
+Before('@skip_below_android_10') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.os_version < 10
+end


### PR DESCRIPTION
## Goal

Adds automatic instrumentation for the `onCreate` `onStart` and `onResume` phases of an activity load

## Design

On >= Android 10 (API level 29) the pre/post callbacks of ActivityLifecycleCallbacks are used to start and end spans for each of the Activity lifecycle phases `onCreate` `onStart` and `onResume`.

These spans are nested under a `ViewLoad` span for the `Activity`, and are not created if `autoInstrumentActivities = AutoInstrument.OFF`

## Testing

- Added new unit tests for the new lifecycle callback implementation 
- Bumped maze-runner to latest (v7.23.0) - this allows us to test for spans with a particular name and set of attributes
- Extended the end to end instrumentation tests to cover new functionality