### PR TITLE
Fix the name of the `first_view_name` attribute

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -151,7 +151,7 @@ class PerformanceLifecycleCallbacks internal constructor(
                 if (activity != null) {
                     val activityName = activity::class.java.simpleName
                     setAttribute("bugsnag.view.type", "Activity")
-                    setAttribute("bugsnag.first_view", activityName)
+                    setAttribute("bugsnag.app_start.first_view_name", activityName)
                 }
             }
 

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -43,3 +43,4 @@ Feature: Automatic creation of spans
     * a span name equals "AppStart/Cold"
     * a span string attribute "bugsnag.span.category" equals "app_start"
     * a span string attribute "bugsnag.app_start.type" equals "cold"
+    * a span string attribute "bugsnag.app_start.first_view_name" equals "MainActivity"


### PR DESCRIPTION
## Goal
AppStart spans should have an attribute named `bugsnag.app_start.first_view_name` rather than `bugsnag.first_view`

## Testing
Added a new check to the existing end to end tests