### PR TITLE
Improve logging

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -83,6 +83,7 @@ object BugsnagPerformance {
     }
 
     private fun startUnderLock(configuration: ImmutableConfig) {
+        Logger.delegate = configuration.logger
         instrumentedAppState.configure(configuration)
 
         if (configuration.autoInstrumentAppStarts) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -33,6 +33,8 @@ class PerformanceConfiguration private constructor(val context: Context) {
             field = value
         }
 
+    var logger: Logger? = null
+
     override fun toString(): String =
         "PerformanceConfiguration(" +
             "context=$context, " +

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -8,11 +8,13 @@ internal class SendBatchTask(
     @get:VisibleForTesting
     val delivery: Delivery,
     private val tracer: Tracer,
-    private val resourceAttributes: Attributes
+    private val resourceAttributes: Attributes,
 ) : AbstractTask() {
     override fun execute(): Boolean {
         val nextBatch = tracer.collectNextBatch() ?: return false
-        Logger.d("Sending a batch of ${nextBatch.size} spans to $delivery")
+        if (nextBatch.isNotEmpty()) {
+            Logger.d("Sending a batch of ${nextBatch.size} spans to $delivery")
+        }
         delivery.deliver(nextBatch, resourceAttributes)
         return nextBatch.isNotEmpty()
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
@@ -10,6 +10,7 @@ import com.bugsnag.android.performance.PerformanceConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -73,6 +74,44 @@ class ImmutableConfigTest {
 
         val immutableConfig = ImmutableConfig(perfConfig)
         assertTrue(immutableConfig.isReleaseStageEnabled)
+    }
+
+    @Test
+    fun noopLoggerInProduction() {
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        perfConfig.releaseStage = RELEASE_STAGE_PRODUCTION
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+        assertSame(NoopLogger, immutableConfig.logger)
+    }
+
+    @Test
+    fun debugLoggerDefault() {
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        perfConfig.releaseStage = RELEASE_STAGE_DEVELOPMENT
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+        assertSame(DebugLogger, immutableConfig.logger)
+    }
+
+    @Test
+    fun overrideLogger() {
+        val testLogger = object : Logger {
+            override fun e(msg: String) = Unit
+            override fun e(msg: String, throwable: Throwable) = Unit
+            override fun w(msg: String) = Unit
+            override fun w(msg: String, throwable: Throwable) = Unit
+            override fun i(msg: String) = Unit
+            override fun i(msg: String, throwable: Throwable) = Unit
+            override fun d(msg: String) = Unit
+            override fun d(msg: String, throwable: Throwable) = Unit
+        }
+
+        val perfConfig = PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+        perfConfig.logger = testLogger
+
+        val immutableConfig = ImmutableConfig(perfConfig)
+        assertSame(testLogger, immutableConfig.logger)
     }
 
     @Test

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -31,6 +31,7 @@ class ResourceAttributesTest {
             setOf("production"),
             321L,
             1.0,
+            NoopLogger,
         )
 
         val attributes = createResourceAttributes(configuration).toList().toMap()
@@ -62,6 +63,7 @@ class ResourceAttributesTest {
             setOf("production"),
             123L,
             1.0,
+            NoopLogger,
         )
 
         val attributes = createResourceAttributes(configuration).toList().toMap()


### PR DESCRIPTION
## Goal
Improve general logging and align it with `bugsnag-android`:

- Use a `NoopLogger` when `releaseStage` is "production"
- Don't log `"Sending $spanCount spans to $delivery"` messages when there are no spans actually being sent

## Testing
Manually tested and added a new unit test for the configuration