### PR TITLE
Add test scenario for nested spans and coroutines

### DIFF
--- a/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
+++ b/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
@@ -72,5 +72,6 @@ operator fun CoroutineContext.plus(context: SpanContext) : CoroutineContext {
 class BugsnagPerformanceScope(dispatcher: CoroutineDispatcher = Dispatchers.Main) : CoroutineScope {
     private val baseContext = SupervisorJob() + dispatcher
 
-    override val coroutineContext: CoroutineContext = baseContext + SpanContext.current.asCoroutineElement()
+    override val coroutineContext: CoroutineContext
+        get() = baseContext + SpanContext.current.asCoroutineElement()
 }

--- a/features/fixtures/mazeracer/app/build.gradle
+++ b/features/fixtures/mazeracer/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation 'com.bugsnag:bugsnag-android-performance:9.9.9'
     implementation 'com.bugsnag:bugsnag-plugin-android-performance-okhttp:9.9.9'
     implementation 'com.bugsnag:bugsnag-plugin-android-performance-appcompat:9.9.9'
+    implementation 'com.bugsnag:bugsnag-plugin-android-performance-coroutines:9.9.9'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/features/fixtures/mazeracer/app/proguard-rules.pro
+++ b/features/fixtures/mazeracer/app/proguard-rules.pro
@@ -1,2 +1,4 @@
 -keep class com.bugsnag.mazeracer.scenarios.** {*;}
 -keep class com.bugsnag.mazeracer.ActivityViewLoadActivity$LoaderFragment
+-keep class com.bugsnag.mazeracer.NestedSpansActivity$FirstFragment
+-keep class com.bugsnag.mazeracer.NestedSpansActivity$SecondFragment

--- a/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         </activity>
 
         <activity android:name=".ActivityViewLoadActivity"/>
+        <activity android:name=".NestedSpansActivity"/>
     </application>
 
 </manifest>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
@@ -11,8 +11,11 @@ import com.bugsnag.android.performance.coroutines.BugsnagPerformanceScope
 import com.bugsnag.android.performance.measureSpan
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+const val DELAY_TIME = 50L
 
 class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerformanceScope() {
 
@@ -41,11 +44,12 @@ class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerfor
         // launch a coroutine
         launch {
             measureSpan("DoStuff") {
-                "Do stuff"
+                delay(DELAY_TIME)
             }
 
             // move to an IO thread
             withContext(Dispatchers.IO) {
+                delay(DELAY_TIME)
                 measureSpan("LoadData") {
                     "Load some data"
                 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
@@ -1,0 +1,80 @@
+package com.bugsnag.mazeracer
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.coroutines.BugsnagPerformanceScope
+import com.bugsnag.android.performance.measureSpan
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerformanceScope() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_view_load)
+
+        // load first fragment
+        supportFragmentManager
+            .beginTransaction()
+            .add(R.id.fragment_container, FirstFragment())
+            .commit()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // start a custom span
+        val customRootSpan = BugsnagPerformance.startSpan("CustomRoot")
+
+        // load a second fragment
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.fragment_container, SecondFragment())
+            .commit()
+
+        // launch a coroutine
+        launch {
+            measureSpan("DoStuff") {
+                "Do stuff"
+            }
+
+            // move to an IO thread
+            withContext(Dispatchers.IO) {
+                measureSpan("LoadData") {
+                    "Load some data"
+                }
+            }
+
+            // end the custom span
+            customRootSpan.end()
+        }
+
+        finish()
+    }
+
+    class FirstFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?,
+        ): View? {
+            return inflater.inflate(R.layout.fragment_1, container, false)
+        }
+    }
+
+    class SecondFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?,
+        ): View? {
+            return inflater.inflate(R.layout.fragment_2, container, false)
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.mazeracer.scenarios
+
+import android.content.Intent
+import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.internal.InternalDebug
+import com.bugsnag.mazeracer.NestedSpansActivity
+import com.bugsnag.mazeracer.Scenario
+
+const val BATCH_SIZE = 10
+
+class NestedSpansScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String
+) : Scenario(config, scenarioMetadata) {
+    init {
+        InternalDebug.spanBatchSizeSendTriggerPoint = BATCH_SIZE
+        config.autoInstrumentAppStarts = true
+        config.autoInstrumentActivities = AutoInstrument.FULL
+    }
+
+    override fun startScenario() {
+        BugsnagPerformance.start(config)
+        context.startActivity(Intent(context, NestedSpansActivity::class.java))
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/res/layout/fragment_1.xml
+++ b/features/fixtures/mazeracer/app/src/main/res/layout/fragment_1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fragment 1"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1" />
+</LinearLayout>

--- a/features/fixtures/mazeracer/app/src/main/res/layout/fragment_2.xml
+++ b/features/fixtures/mazeracer/app/src/main/res/layout/fragment_2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fragment 2"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1" />
+</LinearLayout>

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -1,0 +1,87 @@
+Feature: Nested spans
+
+  @skip_below_android_10
+  Scenario: Nested spans
+    Given I run "NestedSpansScenario" and discard the initial p-value request
+    And I wait to receive 1 traces
+    # Check we have received all the spans we are expecting
+    * a span named "ViewLoadPhase/ActivityCreate/NestedSpansActivity" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load_phase     |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "ViewLoadPhase/ActivityStart/NestedSpansActivity" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load_phase     |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "ViewLoad/Fragment/FirstFragment" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load           |
+                | bugsnag.view.type                 | stringValue | fragment            |
+                | bugsnag.view.name                 | stringValue | FirstFragment       |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "ViewLoad/Fragment/SecondFragment" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load           |
+                | bugsnag.view.type                 | stringValue | fragment            |
+                | bugsnag.view.name                 | stringValue | SecondFragment      |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "ViewLoadPhase/ActivityResume/NestedSpansActivity" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load_phase     |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "AppStart/Cold" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | app_start           |
+                | bugsnag.app_start.first_view_name | stringValue | NestedSpansActivity |
+                | bugsnag.app_start.type            | stringValue | cold                |
+
+    * a span named "ViewLoad/Activity/NestedSpansActivity" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load           |
+                | bugsnag.view.type                 | stringValue | activity            |
+                | bugsnag.view.name                 | stringValue | NestedSpansActivity |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "DoStuff" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "LoadData" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    * a span named "CustomRoot" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.first_class          | boolValue   | false               |
+
+    # Check span parentage
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" is stored as the value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.spanId" is stored as the value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.spanId" is stored as the value "custom_root_span_id"
+
+    # view load span should be nested under AppStart
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "app_start_span_id"
+
+    # view load phase spans (Create, Start, Resume) should be nested under ViewLoad
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.parentSpanId" equals the stored value "view_load_span_id"
+
+    # FirstFragment should be nested under ViewLoadPhase/Start
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "activity_start_span_id"
+
+    # CustomRoot should be nested under ViewLoadPhase/Resume
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "activity_resume_span_id"
+
+    # Remaining spans (SecondFragment, DoStuff, LoadData) should be nested under CustomRoot
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.parentSpanId" equals the stored value "custom_root_span_id"
+


### PR DESCRIPTION
## Goal

Adds a new e2e scenario to test nested spans and coroutine support.

## Design

The scenario does a bunch of things such as:
- launches an activity with full view load instrumentation
- loads some Fragments
- creates some custom spans
- starts some coroutines

The test checks that all of the expected spans are received and that spans are correctly nested under the expected parent span