### PR TITLE
Correctly handle null batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Fixed the null-pointer warning in Tracer when dealing with empty batches of spans
+  [#107](https://github.com/bugsnag/bugsnag-android-performance/pull/107)
+
 ## 0.1.3 (2023-03-28)
 
 ### Enhancements

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracerTest.kt
@@ -58,4 +58,15 @@ class TracerTest {
         // ensure that 2 spans woke the worker up exactly once
         verify(worker, times(1)).wake()
     }
+
+    @Test
+    fun emptyBatch() = InternalDebug.withDebugValues {
+        InternalDebug.workerSleepMs = 0L
+
+        val worker = mock<Worker>()
+        tracer.worker = worker
+
+        val batch = tracer.collectNextBatch()
+        assertEquals(0, batch?.size) // we expect an empty batch, not null
+    }
 }


### PR DESCRIPTION
## Goal
Avoid emitting null-pointer exceptions as warnings when there is no batch to be collected

## Testing
Added a new unit test to cover this case