### PR TITLE
Add mapping for non-otel network subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed the null-pointer warning in Tracer when dealing with empty batches of spans
   [#107](https://github.com/bugsnag/bugsnag-android-performance/pull/107)
+* Observed non-OpenTelemetry network subtypes are mapped to known values
+  [#108](https://github.com/bugsnag/bugsnag-android-performance/pull/108)
 
 ## 0.1.3 (2023-03-28)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -97,20 +97,20 @@ internal class ConnectivityLegacy(
 ) : BroadcastReceiver(), Connectivity {
 
     override val hasConnection: Boolean
-        get() {
-            return activeNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION
-        }
+        get() = activeNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION
     override val metering: ConnectionMetering
-        get() {
-            return activeNetworkInfo?.metering ?: UnknownNetwork.METERING
-        }
+        get() = activeNetworkInfo?.metering ?: UnknownNetwork.METERING
     override val networkType: NetworkType
-        get() {
-            return activeNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE
-        }
+        get() = activeNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE
     override val networkSubType: String?
         get() {
-            return activeNetworkInfo?.subtypeName
+            val subtype = activeNetworkInfo?.subtypeName
+            return when (subtype?.lowercase()) {
+                "hsdpa+" -> "hsdpa"
+                "cdma - evdo rev. 0" -> "evdo_0"
+                "cdma - evdo rev. a" -> "evdo_a"
+                else -> subtype
+            }
         }
 
     private val receivedFirstCallback = AtomicBoolean(false)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
@@ -1,0 +1,104 @@
+@file:Suppress("DEPRECATION")
+
+package com.bugsnag.android.performance.internal
+
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(Parameterized::class)
+class ConnectivityLegacyTest {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        internal fun createTestNetworkParameters(): Collection<Pair<ExpectedInfo, NetworkInfo>> {
+            return listOf(
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.UNMETERED,
+                        NetworkType.WIFI,
+                        null,
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_WIFI, null),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.UNMETERED,
+                        NetworkType.WIRED,
+                        null,
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_ETHERNET, null),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.POTENTIALLY_METERED,
+                        NetworkType.CELL,
+                        "CDMA",
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "CDMA"),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.POTENTIALLY_METERED,
+                        NetworkType.CELL,
+                        "hsdpa",
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "HSDPA+"),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.POTENTIALLY_METERED,
+                        NetworkType.CELL,
+                        "evdo_a",
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "CDMA - EvDo rev. A"),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.POTENTIALLY_METERED,
+                        NetworkType.CELL,
+                        "evdo_0",
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "CDMA - EvDo rev. 0"),
+                ),
+            )
+        }
+
+        private fun mockNetworkInfo(
+            type: Int,
+            subtypeName: String?,
+        ) = mock<NetworkInfo> {
+            whenever(it.type) doReturn type
+            whenever(it.subtypeName) doReturn subtypeName
+        }
+    }
+
+    @Parameterized.Parameter
+    internal lateinit var testCase: Pair<ExpectedInfo, NetworkInfo>
+
+    @Test
+    fun testNetworkProperties() {
+        val (expected, networkInfo) = testCase
+        val connectivityManager = mock<ConnectivityManager> {
+            whenever(it.activeNetworkInfo) doReturn networkInfo
+        }
+
+        val connectivity = ConnectivityLegacy(mock(), connectivityManager, null)
+
+        assertEquals(expected.metering, connectivity.metering)
+        assertEquals(expected.networkType, connectivity.networkType)
+        assertEquals(expected.networkSubType, connectivity.networkSubType)
+    }
+
+    internal data class ExpectedInfo(
+        val metering: ConnectionMetering,
+        val networkType: NetworkType,
+        val networkSubType: String?,
+    )
+}


### PR DESCRIPTION
## Goal
Map the non-OpenTelemetry network subtypes to known values.

## Testing
New unit test covering various expected mappings from `ConnectivityLegacyTest`