### PR TITLE
Network request attributes

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
@@ -1,0 +1,56 @@
+package com.bugsnag.android.performance
+
+import com.bugsnag.android.performance.internal.SpanImpl
+
+/**
+ * A container object for the well-known attributes for network request spans (started
+ * with [BugsnagPerformance.startNetworkRequestSpan]).
+ */
+object NetworkRequestAttributes {
+    /**
+     * Set the `"http.response_code"` attribute on the given [Span].
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param statusCode the HTTP response code to record on the `Span`
+     */
+    @JvmStatic
+    fun setResponseCode(span: Span, statusCode: Int) {
+        (span as SpanImpl).setAttribute("http.response_code", statusCode)
+    }
+
+    /**
+     * Set the `"http.request_content_length"` attribute on the given [Span].
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param contentLength the number of bytes in the request body
+     */
+    @JvmStatic
+    fun setRequestContentLength(span: Span, contentLength: Long) {
+        (span as SpanImpl).setAttribute("http.request_content_length", contentLength)
+    }
+
+    /**
+     * Set the `"http.response_content_length"` attribute on the given [Span].
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param contentLength the number of bytes in the response body
+     */
+    @JvmStatic
+    fun setResponseContentLength(span: Span, contentLength: Long) {
+        (span as SpanImpl).setAttribute("http.response_content_length", contentLength)
+    }
+
+    /**
+     * Set the `"http.flavor"` attribute on the given [Span]. Typically one of:
+     * - "1.0" for HTTP/1.0
+     * - "1.1" for HTTP/1.1
+     * - "2.0" for HTTP/2.0
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param httpFlavor the HTTP flavor
+     */
+    @JvmStatic
+    fun setHttpFlavor(span: Span, httpFlavor: String) {
+        (span as SpanImpl).setAttribute("http.flavor", httpFlavor)
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
@@ -30,6 +30,17 @@ object NetworkRequestAttributes {
     }
 
     /**
+     * Set the `"http.request_content_length_uncompressed"` attribute on the given [Span].
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param contentLength the number of bytes in the uncompressed request body
+     */
+    @JvmStatic
+    fun setUncompressedRequestContentLength(span: Span, contentLength: Long) {
+        (span as? SpanImpl)?.setAttribute("http.request_content_length_uncompressed", contentLength)
+    }
+
+    /**
      * Set the `"http.response_content_length"` attribute on the given [Span].
      *
      * @param span the `Span` measuring the HTTP request
@@ -38,6 +49,20 @@ object NetworkRequestAttributes {
     @JvmStatic
     fun setResponseContentLength(span: Span, contentLength: Long) {
         (span as? SpanImpl)?.setAttribute("http.response_content_length", contentLength)
+    }
+
+    /**
+     * Set the `"http.response_content_length_uncompressed"` attribute on the given [Span].
+     *
+     * @param span the `Span` measuring the HTTP request
+     * @param contentLength the number of bytes in the uncompressed response body
+     */
+    @JvmStatic
+    fun setUncompressedResponseContentLength(span: Span, contentLength: Long) {
+        (span as? SpanImpl)?.setAttribute(
+            "http.response_content_length_uncompressed",
+            contentLength,
+        )
     }
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
@@ -15,7 +15,7 @@ object NetworkRequestAttributes {
      */
     @JvmStatic
     fun setResponseCode(span: Span, statusCode: Int) {
-        (span as SpanImpl).setAttribute("http.response_code", statusCode)
+        (span as? SpanImpl)?.setAttribute("http.response_code", statusCode)
     }
 
     /**
@@ -26,7 +26,7 @@ object NetworkRequestAttributes {
      */
     @JvmStatic
     fun setRequestContentLength(span: Span, contentLength: Long) {
-        (span as SpanImpl).setAttribute("http.request_content_length", contentLength)
+        (span as? SpanImpl)?.setAttribute("http.request_content_length", contentLength)
     }
 
     /**
@@ -37,7 +37,7 @@ object NetworkRequestAttributes {
      */
     @JvmStatic
     fun setResponseContentLength(span: Span, contentLength: Long) {
-        (span as SpanImpl).setAttribute("http.response_content_length", contentLength)
+        (span as? SpanImpl)?.setAttribute("http.response_content_length", contentLength)
     }
 
     /**
@@ -51,6 +51,6 @@ object NetworkRequestAttributes {
      */
     @JvmStatic
     fun setHttpFlavor(span: Span, httpFlavor: String) {
-        (span as SpanImpl).setAttribute("http.flavor", httpFlavor)
+        (span as? SpanImpl)?.setAttribute("http.flavor", httpFlavor)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
@@ -8,14 +8,14 @@ import com.bugsnag.android.performance.internal.SpanImpl
  */
 object NetworkRequestAttributes {
     /**
-     * Set the `"http.response_code"` attribute on the given [Span].
+     * Set the `"http.status_code"` attribute on the given [Span].
      *
      * @param span the `Span` measuring the HTTP request
      * @param statusCode the HTTP response code to record on the `Span`
      */
     @JvmStatic
     fun setResponseCode(span: Span, statusCode: Int) {
-        (span as? SpanImpl)?.setAttribute("http.response_code", statusCode)
+        (span as? SpanImpl)?.setAttribute("http.status_code", statusCode)
     }
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -52,10 +52,11 @@ internal class HttpDelivery(
         deliver(initialProbabilityRequest)
     }
 
+    @Suppress("MagicNumber")
     private fun getDeliveryResult(statusCode: Int, payload: TracePayload): DeliveryResult {
         return when {
-            statusCode / 100 == 2 -> DeliveryResult.Success
-            statusCode / 100 == 4 && statusCode !in httpRetryCodes ->
+            statusCode in 200..299 -> DeliveryResult.Success
+            statusCode in 400..499 && statusCode !in httpRetryCodes ->
                 DeliveryResult.Failed(payload, false)
             else -> DeliveryResult.Failed(payload, true)
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
@@ -43,12 +43,35 @@ class NetworkRequestAttributesTest {
     }
 
     @Test
+    fun setUncompressedRequestContentLength() {
+        val requestBodySize = 1024L
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        NetworkRequestAttributes.setUncompressedRequestContentLength(span, requestBodySize)
+
+        val requestLength = span.attributes
+            .find { it.first == "http.request_content_length_uncompressed" }!!.second as Long
+
+        assertEquals(requestBodySize, requestLength)
+    }
+
+    @Test
     fun setResponseContentLength() {
         val span = spanFactory.newSpan(processor = NoopSpanProcessor)
         NetworkRequestAttributes.setResponseContentLength(span, Long.MAX_VALUE)
 
         val responseLength = span.attributes
             .find { it.first == "http.response_content_length" }!!.second as Long
+
+        assertEquals(Long.MAX_VALUE, responseLength)
+    }
+
+    @Test
+    fun setUncompressedResponseContentLength() {
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        NetworkRequestAttributes.setUncompressedResponseContentLength(span, Long.MAX_VALUE)
+
+        val responseLength = span.attributes
+            .find { it.first == "http.response_content_length_uncompressed" }!!.second as Long
 
         assertEquals(Long.MAX_VALUE, responseLength)
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
@@ -24,7 +24,7 @@ class NetworkRequestAttributesTest {
 
             // Integer attributes are stored as Long, not Int
             val statusCodeAttr =
-                span.attributes.find { it.first == "http.response_code" }!!.second as Long
+                span.attributes.find { it.first == "http.status_code" }!!.second as Long
 
             assertEquals(code, statusCodeAttr.toInt())
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
@@ -1,0 +1,75 @@
+package com.bugsnag.android.performance
+
+import com.bugsnag.android.performance.test.NoopSpanProcessor
+import com.bugsnag.android.performance.test.TestSpanFactory
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class NetworkRequestAttributesTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun setup() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun setResponseCode() {
+        val expectedCodes = intArrayOf(100, 200, 400, 404, 500)
+        for (code in expectedCodes) {
+            val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+            NetworkRequestAttributes.setResponseCode(span, code)
+
+            // Integer attributes are stored as Long, not Int
+            val statusCodeAttr =
+                span.attributes.find { it.first == "http.response_code" }!!.second as Long
+
+            assertEquals(code, statusCodeAttr.toInt())
+        }
+    }
+
+    @Test
+    fun setRequestContentLength() {
+        val requestBodySize = 1024L
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        NetworkRequestAttributes.setRequestContentLength(span, requestBodySize)
+
+        val requestLength = span.attributes
+            .find { it.first == "http.request_content_length" }!!.second as Long
+
+        assertEquals(requestBodySize, requestLength)
+    }
+
+    @Test
+    fun setResponseContentLength() {
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        NetworkRequestAttributes.setResponseContentLength(span, Long.MAX_VALUE)
+
+        val responseLength = span.attributes
+            .find { it.first == "http.response_content_length" }!!.second as Long
+
+        assertEquals(Long.MAX_VALUE, responseLength)
+    }
+
+    @Test
+    fun setHttpFlavor() {
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        NetworkRequestAttributes.setHttpFlavor(span, "1.1")
+        val flavor = span.attributes.find { it.first == "http.flavor" }!!.second as String
+        assertEquals("1.1", flavor)
+    }
+
+    /**
+     * NetworkRequestAttributes should not cause exceptions when a non `SpanImpl` object is specified.
+     */
+    @Test
+    fun supportsMockSpans() {
+        val span = mock<Span>()
+        NetworkRequestAttributes.setResponseCode(span, 200)
+        NetworkRequestAttributes.setRequestContentLength(span, 64)
+        NetworkRequestAttributes.setResponseContentLength(span, Long.MAX_VALUE)
+        NetworkRequestAttributes.setHttpFlavor(span, "2.0")
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -3,8 +3,8 @@ package com.bugsnag.android.performance
 import android.util.JsonWriter
 import com.bugsnag.android.performance.internal.BugsnagClock
 import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.assertJsonEquals
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -24,7 +24,7 @@ class SpanJsonTest {
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
             0xdecafbad,
             123L,
-            testSpanProcessor,
+            NoopSpanProcessor,
             false,
         )
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android.performance
 
 import android.os.SystemClock
 import com.bugsnag.android.performance.internal.SpanFactory
-import com.bugsnag.android.performance.test.testSpanProcessor
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.withStaticMock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -20,7 +20,7 @@ class SpanOptionsTest {
 
     @Before
     fun newSpanFactory() {
-        spanFactory = SpanFactory(testSpanProcessor)
+        spanFactory = SpanFactory(NoopSpanProcessor)
     }
 
     @Test

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -6,7 +6,7 @@ import android.os.SystemClock
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.test.CollectingSpanProcessor
-import com.bugsnag.android.performance.test.testSpanProcessor
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -22,7 +22,7 @@ import org.robolectric.util.ReflectionHelpers
 class PerformanceLifecycleCallbacksTest {
     private val activity = Activity()
 
-    private var spanFactory = SpanFactory(testSpanProcessor)
+    private var spanFactory = SpanFactory(NoopSpanProcessor)
     private var spanTracker = SpanTracker()
 
     private lateinit var spanProcessor: CollectingSpanProcessor

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -2,9 +2,9 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.StubDelivery
 import com.bugsnag.android.performance.test.endedSpans
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,7 +36,7 @@ class RetryDeliveryTest {
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
                     0xdecafbad,
                     0L,
-                    testSpanProcessor,
+                    NoopSpanProcessor,
                     false,
                 ),
             ),
@@ -55,7 +55,7 @@ class RetryDeliveryTest {
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
                     0xdecafbad,
                     0L,
-                    testSpanProcessor,
+                    NoopSpanProcessor,
                     false,
                 ),
             ),
@@ -74,7 +74,7 @@ class RetryDeliveryTest {
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
                     0xdecafbad,
                     0L,
-                    testSpanProcessor,
+                    NoopSpanProcessor,
                     false,
                 ),
             ),
@@ -103,7 +103,7 @@ class RetryDeliveryTest {
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
                     0xdecafbad,
                     0L,
-                    testSpanProcessor,
+                    NoopSpanProcessor,
                     false,
                 ),
             ),
@@ -133,7 +133,7 @@ class RetryDeliveryTest {
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
                     0xdecafbad,
                     0L,
-                    testSpanProcessor,
+                    NoopSpanProcessor,
                     false,
                 ),
             ),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
@@ -2,8 +2,8 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -33,7 +33,7 @@ class SendBatchTaskTest {
     fun sendBatch() {
         val spanFactory = TestSpanFactory()
         val tracer = mock<Tracer> {
-            on { collectNextBatch() } doReturn spanFactory.newSpans(10, testSpanProcessor)
+            on { collectNextBatch() } doReturn spanFactory.newSpans(10, NoopSpanProcessor)
         }
 
         val delivery = mock<Delivery>()

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanChainTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.performance.internal
 
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -18,7 +18,7 @@ class SpanChainTest {
 
     @Test
     fun unlinkTo() {
-        val spans = spanFactory.newSpans(10, testSpanProcessor)
+        val spans = spanFactory.newSpans(10, NoopSpanProcessor)
         val root = spans.toSpanChain()
 
         // check that all the spans (except the last) have a `next` link

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -2,9 +2,9 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.OtelValidator.assertTraceDataValid
 import com.bugsnag.android.performance.test.assertJsonEquals
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,7 +22,7 @@ class SpanPayloadEncodingTest {
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
             0xdecafbad,
             0L,
-            testSpanProcessor,
+            NoopSpanProcessor,
             false,
         )
         span1.end(1L)
@@ -33,7 +33,7 @@ class SpanPayloadEncodingTest {
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
             0xbaddecaf,
             0L,
-            testSpanProcessor,
+            NoopSpanProcessor,
             false,
         )
         span2.end(11L)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.SpanKind
-import com.bugsnag.android.performance.test.testSpanProcessor
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -70,7 +70,7 @@ class SpanTest {
         UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
         0xdecafbad,
         0L,
-        testSpanProcessor,
+        NoopSpanProcessor,
         false,
     )
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.performance.internal
 
 import android.os.SystemClock
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import com.bugsnag.android.performance.test.testSpanProcessor
 import com.bugsnag.android.performance.test.withStaticMock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -118,6 +118,6 @@ class SpanTrackerTest {
     }
 
     private fun createSpan(): SpanImpl {
-        return spanFactory.newSpan(processor = testSpanProcessor, endTime = null)
+        return spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import com.bugsnag.android.performance.test.testSpanProcessor
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +37,7 @@ internal class TracePayloadTest {
     }
 
     private fun createSpan(pValue: Double): SpanImpl =
-        spanFactory.newSpan(processor = testSpanProcessor).apply {
+        spanFactory.newSpan(processor = NoopSpanProcessor).apply {
             samplingProbability = pValue
         }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/NoopSpanProcessor.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/NoopSpanProcessor.kt
@@ -1,0 +1,8 @@
+package com.bugsnag.android.performance.test
+
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.internal.SpanProcessor
+
+object NoopSpanProcessor : SpanProcessor {
+    override fun onEnd(span: Span) = Unit // discard all spans
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestUtils.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestUtils.kt
@@ -1,15 +1,12 @@
 package com.bugsnag.android.performance.test
 
 import com.bugsnag.android.performance.internal.SpanImpl
-import com.bugsnag.android.performance.internal.SpanProcessor
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.mockito.MockedStatic
 import org.mockito.Mockito
 import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
-
-val testSpanProcessor = SpanProcessor { }
 
 fun assertJsonEquals(expected: String, actual: String) {
     val expectedObject = JSONObject(expected).toString()


### PR DESCRIPTION
## Goal
Allow manually instrumented network requests to set HTTP related attributes on the `Span` without reaching into the `internal` APIs.

## Design

Added a new `NetworkRequestAttributes` object with utility methods for each of the "NetworkRequest" attributes currently supported. Each of these methods accepts a `Span` and the value of the attribute to set.

The approach was used in favour of dedicated types (such as `NetworkRequestSpan`) as those would likely become an obsolete concept fairly quickly. The `NetworkRequestAttributes` object will also make a convenient container for the actual attribute constants when we allow arbitrary attributes to be specified.

Extension functions were avoided as it was found they either become verbose to use (`span.setNetworkRequestResponseCode`) or ambiguous (as they would apply to all span types).

## Testing
New unit tests were added to cover the new logic. Otherwise the existing NetworkRequest end-to-end tests are used.