### PR TITLE
Only first ViewLoad in context should be first-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `service.version` is now correctly reported as the app versionName
   [#113](https://github.com/bugsnag/bugsnag-android-performance/pull/113)
+* ViewLoad spans should only be marked "first class" when there are no other ViewLoad spans in the SpanContext
+  [#115](https://github.com/bugsnag/bugsnag-android-performance/pull/115)
 
 ## 0.1.4 (2023-04-11)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -40,10 +40,8 @@ class SpanOptions private constructor(
             if (isOptionSet(OPT_START_TIME)) _startTime
             else SystemClock.elapsedRealtimeNanos()
 
-    val isFirstClass: Boolean
-        get() =
-            if (isOptionSet(OPT_IS_FIRST_CLASS)) _isFirstClass
-            else SpanContext.current.spanId == 0L
+    val isFirstClass: Boolean?
+        get() = _isFirstClass.takeIf { isOptionSet(OPT_IS_FIRST_CLASS) }
 
     val parentContext: SpanContext?
         get() =

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -1,0 +1,8 @@
+package com.bugsnag.android.performance.internal
+
+enum class SpanCategory(val category: String?) {
+    CUSTOM(null),
+    VIEW_LOAD("view_load"),
+    NETWORK("network"),
+    APP_START("app_start"),
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanContextExtensions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanContextExtensions.kt
@@ -10,3 +10,11 @@ import com.bugsnag.android.performance.SpanContext
 var SpanContext.Storage.currentStack
     get() = contextStack
     set(value) = setContextStackUnsafe(value)
+
+/**
+ * Test that no [SpanImpl] objects within the current [SpanContext] match the given [predicate].
+ * Returns `true` if [predicate] only returned `false`, otherwise `false`.
+ */
+internal inline fun SpanContext.Storage.noSpansMatch(predicate: (SpanImpl) -> Boolean): Boolean {
+    return contextStack.none { it is SpanImpl && predicate(it) }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Activity
 import com.bugsnag.android.performance.HasAttributes
+import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.ViewType
@@ -14,7 +15,7 @@ class SpanFactory(
     val spanAttributeSource: AttributeSource = {},
 ) {
     fun createCustomSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
-        val isFirstClass = options.isFirstClass
+        val isFirstClass = options.isFirstClass != false
         val span = createSpan(name, SpanKind.INTERNAL, SpanCategory.CUSTOM, options)
         span.setAttribute("bugsnag.span.first_class", isFirstClass)
         return span
@@ -45,6 +46,8 @@ class SpanFactory(
         options: SpanOptions = SpanOptions.DEFAULTS,
     ): SpanImpl {
         val isFirstClass = options.isFirstClass
+            ?: SpanContext.noSpansMatch { it.category == SpanCategory.VIEW_LOAD }
+
         val span = createSpan(
             "[ViewLoad/${viewType.spanName}]$viewName",
             SpanKind.INTERNAL,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -15,36 +15,43 @@ class SpanFactory(
 ) {
     fun createCustomSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
         val isFirstClass = options.isFirstClass
-        val span = createSpan(name, SpanKind.INTERNAL, options)
+        val span = createSpan(name, SpanKind.INTERNAL, SpanCategory.CUSTOM, options)
         span.setAttribute("bugsnag.span.first_class", isFirstClass)
         return span
     }
 
-    fun createNetworkSpan(url: String, verb: String, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
+    fun createNetworkSpan(
+        url: String,
+        verb: String,
+        options: SpanOptions = SpanOptions.DEFAULTS,
+    ): SpanImpl {
         val verbUpper = verb.uppercase()
-        val span = createSpan("[HTTP/$verbUpper]", SpanKind.CLIENT, options)
-        span.setAttribute("bugsnag.span.category", "network")
+        val span = createSpan("[HTTP/$verbUpper]", SpanKind.CLIENT, SpanCategory.NETWORK, options)
         span.setAttribute("http.url", url)
         span.setAttribute("http.method", verbUpper)
         return span
     }
 
-    fun createViewLoadSpan(activity: Activity, options: SpanOptions = SpanOptions.DEFAULTS): SpanImpl {
+    fun createViewLoadSpan(
+        activity: Activity,
+        options: SpanOptions = SpanOptions.DEFAULTS,
+    ): SpanImpl {
         val activityName = activity::class.java.simpleName
         return createViewLoadSpan(ViewType.ACTIVITY, activityName, options)
     }
 
-    fun createViewLoadSpan(viewType: ViewType, viewName: String,
-                           options: SpanOptions = SpanOptions.DEFAULTS
+    fun createViewLoadSpan(
+        viewType: ViewType, viewName: String,
+        options: SpanOptions = SpanOptions.DEFAULTS,
     ): SpanImpl {
         val isFirstClass = options.isFirstClass
         val span = createSpan(
             "[ViewLoad/${viewType.spanName}]$viewName",
             SpanKind.INTERNAL,
-            options
+            SpanCategory.VIEW_LOAD,
+            options,
         )
 
-        span.setAttribute("bugsnag.span.category", "view_load")
         span.setAttribute("bugsnag.view.type", viewType.typeName)
         span.setAttribute("bugsnag.view.name", viewName)
         span.setAttribute("bugsnag.span.first_class", isFirstClass)
@@ -54,25 +61,28 @@ class SpanFactory(
     fun createAppStartSpan(startType: String): SpanImpl =
         createSpan(
             "[AppStart/$startType]",
-            SpanKind.INTERNAL
+            SpanKind.INTERNAL,
+            SpanCategory.APP_START,
         ).apply {
-            setAttribute("bugsnag.span.category", "app_start")
             setAttribute("bugsnag.app_start.type", startType.lowercase())
         }
 
     private fun createSpan(
         name: String,
         kind: SpanKind,
-        options: SpanOptions = SpanOptions.DEFAULTS
+        category: SpanCategory,
+        options: SpanOptions = SpanOptions.DEFAULTS,
     ): SpanImpl {
         val span = SpanImpl(
             name = name,
             kind = kind,
+            category = category,
             startTime = options.startTime,
-            traceId = options.parentContext?.traceId?.takeIf { it.isValidTraceId() } ?: UUID.randomUUID(),
+            traceId = options.parentContext?.traceId?.takeIf { it.isValidTraceId() }
+                ?: UUID.randomUUID(),
             parentSpanId = options.parentContext?.spanId ?: 0L,
             processor = spanProcessor,
-            makeContext = options.makeContext
+            makeContext = options.makeContext,
         )
 
         spanAttributeSource(span)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater
 @Suppress("LongParameterList")
 class SpanImpl internal constructor(
     name: String,
+    internal val category: SpanCategory,
     internal val kind: SpanKind,
     internal val startTime: Long,
     override val traceId: UUID,
@@ -61,10 +62,12 @@ class SpanImpl internal constructor(
         internal set(value) {
             require(field in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
             field = value
-            attributes.set("bugsnag.sampling.p", value)
+            attributes["bugsnag.sampling.p"] = value
         }
 
     init {
+        category.category?.let { attributes["bugsnag.span.category"] = it }
+
         // Our "random" sampling value is actually derived from the traceId
         val msw = traceId.mostSignificantBits ushr 1
         samplingValue = when (msw) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
@@ -144,7 +144,11 @@ internal class Worker(
     private fun waitForWorkOrWakeup() {
         lock.withLock {
             if (!wakeIsPending) {
-                wakeWorker.await(InternalDebug.workerSleepMs, TimeUnit.MILLISECONDS)
+                try {
+                    wakeWorker.await(InternalDebug.workerSleepMs, TimeUnit.MILLISECONDS)
+                } catch(ie: InterruptedException) {
+                    // ignore these, we treat interrupts as wake-ups
+                }
             }
 
             wakeIsPending = false

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance
 
 import android.util.JsonWriter
 import com.bugsnag.android.performance.internal.BugsnagClock
+import com.bugsnag.android.performance.internal.SpanCategory
 import com.bugsnag.android.performance.internal.SpanImpl
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.assertJsonEquals
@@ -19,6 +20,7 @@ class SpanJsonTest {
 
         val span = SpanImpl(
             "test span",
+            SpanCategory.CUSTOM,
             SpanKind.INTERNAL,
             0L,
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -19,6 +19,7 @@ import java.util.UUID
 class RetryDeliveryTest {
 
     @Test
+    @Suppress("LongMethod")
     fun testSuccess() {
         val attributes = Attributes()
         val stub = StubDelivery()
@@ -31,6 +32,7 @@ class RetryDeliveryTest {
             endedSpans(
                 SpanImpl(
                     "test span",
+                    SpanCategory.CUSTOM,
                     SpanKind.INTERNAL,
                     0L,
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -50,6 +52,7 @@ class RetryDeliveryTest {
             endedSpans(
                 SpanImpl(
                     "test span",
+                    SpanCategory.CUSTOM,
                     SpanKind.INTERNAL,
                     0L,
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -69,6 +72,7 @@ class RetryDeliveryTest {
             endedSpans(
                 SpanImpl(
                     "test span",
+                    SpanCategory.CUSTOM,
                     SpanKind.INTERNAL,
                     0L,
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -98,6 +102,7 @@ class RetryDeliveryTest {
             endedSpans(
                 SpanImpl(
                     "test span",
+                    SpanCategory.CUSTOM,
                     SpanKind.INTERNAL,
                     0L,
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -128,6 +133,7 @@ class RetryDeliveryTest {
             endedSpans(
                 SpanImpl(
                     "test span",
+                    SpanCategory.CUSTOM,
                     SpanKind.INTERNAL,
                     0L,
                     UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -17,6 +17,7 @@ class SpanPayloadEncodingTest {
     fun testDeliver() {
         val span1 = SpanImpl(
             "test span",
+            SpanCategory.CUSTOM,
             SpanKind.INTERNAL,
             0L,
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -28,6 +29,7 @@ class SpanPayloadEncodingTest {
         span1.end(1L)
         val span2 = SpanImpl(
             "second span",
+            SpanCategory.CUSTOM,
             SpanKind.INTERNAL,
             10L,
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -35,6 +35,7 @@ class SpanTest {
         val mockSpanProcessor = mock<SpanProcessor>()
         val span = SpanImpl(
             "test span",
+            SpanCategory.CUSTOM,
             SpanKind.INTERNAL,
             0L,
             UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),
@@ -65,6 +66,7 @@ class SpanTest {
 
     private fun createTestSpan() = SpanImpl(
         "Test/test span",
+        SpanCategory.CUSTOM,
         SpanKind.INTERNAL,
         0L,
         UUID.fromString("4ee26661-4650-4c7f-a35f-00f007cd24e7"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/TestSpanFactory.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.test
 
 import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.internal.SpanCategory
 import com.bugsnag.android.performance.internal.SpanImpl
 import com.bugsnag.android.performance.internal.SpanProcessor
 import java.util.UUID
@@ -23,7 +24,17 @@ class TestSpanFactory {
         processor: SpanProcessor,
     ): SpanImpl {
         spanCount++
-        return SpanImpl(name, kind, startTime, traceId, spanId, parentSpanId, processor, true)
+        return SpanImpl(
+            name,
+            SpanCategory.CUSTOM,
+            kind,
+            startTime,
+            traceId,
+            spanId,
+            parentSpanId,
+            processor,
+            true,
+        )
             .apply { if (endTime != null) end(endTime(startTime)) }
     }
 

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -8,14 +8,12 @@ Feature: Nested spans
     * a span named "[ViewLoadPhase/ActivityCreate]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | view_load_phase     |
-                | bugsnag.span.first_class          | boolValue   | false               |
                 | bugsnag.phase                     | stringValue | ActivityCreate      |
                 | bugsnag.view.name                 | stringValue | NestedSpansActivity |
 
     * a span named "[ViewLoadPhase/ActivityStart]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | view_load_phase     |
-                | bugsnag.span.first_class          | boolValue   | false               |
                 | bugsnag.phase                     | stringValue | ActivityStart       |
                 | bugsnag.view.name                 | stringValue | NestedSpansActivity |
 
@@ -24,19 +22,16 @@ Feature: Nested spans
                 | bugsnag.span.category             | stringValue | view_load           |
                 | bugsnag.view.type                 | stringValue | fragment            |
                 | bugsnag.view.name                 | stringValue | FirstFragment       |
-                | bugsnag.span.first_class          | boolValue   | false               |
 
     * a span named "[ViewLoad/Fragment]SecondFragment" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | view_load           |
                 | bugsnag.view.type                 | stringValue | fragment            |
                 | bugsnag.view.name                 | stringValue | SecondFragment      |
-                | bugsnag.span.first_class          | boolValue   | false               |
 
     * a span named "[ViewLoadPhase/ActivityResume]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | view_load_phase     |
-                | bugsnag.span.first_class          | boolValue   | false               |
                 | bugsnag.phase                     | stringValue | ActivityResume      |
                 | bugsnag.view.name                 | stringValue | NestedSpansActivity |
 
@@ -51,19 +46,19 @@ Feature: Nested spans
                 | bugsnag.span.category             | stringValue | view_load           |
                 | bugsnag.view.type                 | stringValue | activity            |
                 | bugsnag.view.name                 | stringValue | NestedSpansActivity |
-                | bugsnag.span.first_class          | boolValue   | false               |
+                | bugsnag.span.first_class          | boolValue   | true                |
 
     * a span named "DoStuff" contains the attributes:
                 | attribute                         | type        | value               |
-                | bugsnag.span.first_class          | boolValue   | false               |
+                | bugsnag.span.first_class          | boolValue   | true                |
 
     * a span named "LoadData" contains the attributes:
                 | attribute                         | type        | value               |
-                | bugsnag.span.first_class          | boolValue   | false               |
+                | bugsnag.span.first_class          | boolValue   | true                |
 
     * a span named "CustomRoot" contains the attributes:
                 | attribute                         | type        | value               |
-                | bugsnag.span.first_class          | boolValue   | false               |
+                | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "app_start_span_id"


### PR DESCRIPTION
## Goal
Only the first `ViewLoad` span in a SpanContext should be considered "first class", and the first "ViewLoad" span in a `SpanContext` should be first class by default.

## Changeset

- *Breaking change*: `SpanOptions.isFirstClass` is now a nullable `Boolean?` (`Boolean` in Java instead of `boolean`) and will default to `null` instead of attempting to derive a global default
- `SpanImpl` now tracks the `SpanCategory` (VIEW_LOAD, NETWORK, etc.) as an enum property, instead of just an attribute
- `SpanFactory.createViewLoadSpan` will search for existing `SpanCategory.VIEW_LOAD` spans when deciding on a default value for `isFirstClass`
- `SpanFactory.createCustomSpan` retains the previous behaviour (first span on the context is first class)

## Testing
New unit test for this specific behaviour.
Modified existing tests, and manually tested the behaviour.