### PR TITLE
Improve the reporting of the network subtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   [#115](https://github.com/bugsnag/bugsnag-android-performance/pull/115)
 * The "first view" reported as part of AppStart spans is based on the first ViewLoad started rather than the first Actvity resumed
   [#119](https://github.com/bugsnag/bugsnag-android-performance/pull/119)
+* Fixed the reporting of cellular network subtypes (when the app has appropriate permissions)
+  [#116](https://github.com/bugsnag/bugsnag-android-performance/pull/116)
+
 
 ## 0.1.4 (2023-04-11)
 

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -24,12 +24,12 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
-    <ID>SwallowedException:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
+    <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
-    <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityLegacy$e: NullPointerException</ID>
+    <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.SystemClock
 import com.bugsnag.android.performance.BugsnagPerformance.start
-import com.bugsnag.android.performance.internal.ConnectivityCompat
+import com.bugsnag.android.performance.internal.Connectivity
 import com.bugsnag.android.performance.internal.DiscardingSampler
 import com.bugsnag.android.performance.internal.HttpDelivery
 import com.bugsnag.android.performance.internal.ImmutableConfig
@@ -100,15 +100,15 @@ object BugsnagPerformance {
         }
 
         val connectivity =
-            ConnectivityCompat(application) { hasConnection, _, networkType, networkSubType ->
-                if (hasConnection && this::worker.isInitialized) {
+            Connectivity.newInstance(application) { status ->
+                if (status.hasConnection && this::worker.isInitialized) {
                     worker.wake()
                 }
 
                 instrumentedAppState.defaultAttributeSource.update {
                     it.copy(
-                        networkType = networkType,
-                        networkSubType = networkSubType,
+                        networkType = status.networkType,
+                        networkSubType = status.networkSubType,
                     )
                 }
             }
@@ -139,7 +139,7 @@ object BugsnagPerformance {
 
             delivery.newProbabilityCallback = samplerTask
             workerTasks.add(samplerTask)
-            
+
             tracer.sampler = sampler
         } else {
             tracer.sampler = DiscardingSampler

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -20,17 +19,22 @@ import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
-import java.util.concurrent.atomic.AtomicBoolean
 
-private const val READ_BASIC_PHONE_STATE = "android.permission.READ_BASIC_PHONE_STATE"
-private const val READ_PHONE_STATE = android.Manifest.permission.READ_PHONE_STATE
+internal data class ConnectivityStatus(
+    val hasConnection: Boolean,
+    val metering: ConnectionMetering,
+    val networkType: NetworkType,
+    val networkSubType: String?,
+)
 
-internal typealias NetworkChangeCallback = (
-    hasConnection: Boolean,
-    metering: ConnectionMetering,
-    networkType: NetworkType,
-    networkSubType: String?,
-) -> Unit
+private val unknownNetwork = ConnectivityStatus(
+    false,
+    ConnectionMetering.DISCONNECTED,
+    NetworkType.UNKNOWN,
+    null,
+)
+
+internal typealias NetworkChangeCallback = (status: ConnectivityStatus) -> Unit
 
 internal enum class ConnectionMetering {
     DISCONNECTED,
@@ -39,153 +43,127 @@ internal enum class ConnectionMetering {
 }
 
 internal interface Connectivity {
-    val hasConnection: Boolean
-    val metering: ConnectionMetering
-    val networkType: NetworkType
-    val networkSubType: String?
+
+    val connectivityStatus: ConnectivityStatus
+
     fun registerForNetworkChanges()
     fun unregisterForNetworkChanges()
-}
 
-private object UnknownNetwork {
-    const val HAS_CONNECTION = false
-    val METERING = ConnectionMetering.DISCONNECTED
-    val NETWORK_TYPE = NetworkType.UNKNOWN
-    val NETWORK_SUBTYPE: String? = null
-}
+    companion object Factory {
+        fun newInstance(
+            context: Context,
+            callback: NetworkChangeCallback?,
+        ): Connectivity {
+            val cm = context.getConnectivityManager()
 
-internal class ConnectivityCompat(
-    context: Context,
-    callback: NetworkChangeCallback?,
-) : Connectivity {
-
-    private val cm = context.getConnectivityManager()
-
-    private val connectivity: Connectivity =
-        when {
-            cm == null -> UnknownConnectivity
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
-                ConnectivityApi31(context, cm, callback)
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ->
-                ConnectivityApi24(context, cm, callback)
-            else -> ConnectivityLegacy(context, cm, callback)
+            return when {
+                cm == null -> UnknownConnectivity
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+                    ConnectivityApi31(context, cm, callback)
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ->
+                    ConnectivityApi24(context, cm, callback)
+                else -> ConnectivityLegacy(context, cm, callback)
+            }
         }
-
-    override fun registerForNetworkChanges() {
-        runCatching { connectivity.registerForNetworkChanges() }
     }
-
-    override fun unregisterForNetworkChanges() {
-        runCatching { connectivity.unregisterForNetworkChanges() }
-    }
-
-    override val hasConnection: Boolean
-        get() = connectivity.hasConnection
-    override val metering: ConnectionMetering
-        get() = connectivity.metering
-    override val networkType: NetworkType
-        get() = connectivity.networkType
-    override val networkSubType: String?
-        get() = connectivity.networkSubType
 }
 
 @Suppress("DEPRECATION")
 internal class ConnectivityLegacy(
     private val context: Context,
-    private val cm: ConnectivityManager,
+    cm: ConnectivityManager,
     private val callback: NetworkChangeCallback?,
 ) : BroadcastReceiver(), Connectivity {
+    override var connectivityStatus: ConnectivityStatus = networkInfoToStatus(cm.activeNetworkInfo)
+        private set(newStatus) {
+            if (field != newStatus) {
+                field = newStatus
+                callback?.invoke(newStatus)
+            }
+        }
 
-    override val hasConnection: Boolean
-        get() = activeNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION
-    override val metering: ConnectionMetering
-        get() = activeNetworkInfo?.metering ?: UnknownNetwork.METERING
-    override val networkType: NetworkType
-        get() = activeNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE
-    override val networkSubType: String?
-        get() {
-            val subtype = activeNetworkInfo?.subtypeName
-            return when (subtype?.lowercase()) {
+    override fun registerForNetworkChanges() {
+        runCatching {
+            val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+            context.registerReceiverSafe(this, intentFilter)
+        }
+    }
+
+    override fun unregisterForNetworkChanges() {
+        runCatching {
+            context.unregisterReceiverSafe(this)
+        }
+    }
+
+    private fun networkInfoToStatus(info: android.net.NetworkInfo?): ConnectivityStatus {
+        if (info == null) {
+            return unknownNetwork
+        }
+
+        val subtype = info.subtypeName
+        return ConnectivityStatus(
+            info.isConnectedOrConnecting,
+            when (info.type) {
+                ConnectivityManager.TYPE_WIFI, ConnectivityManager.TYPE_ETHERNET ->
+                    ConnectionMetering.UNMETERED
+                else -> ConnectionMetering.POTENTIALLY_METERED
+            },
+            when (info.type) {
+                ConnectivityManager.TYPE_WIFI -> NetworkType.WIFI
+                ConnectivityManager.TYPE_MOBILE -> NetworkType.CELL
+                ConnectivityManager.TYPE_ETHERNET -> NetworkType.WIRED
+                else -> NetworkType.UNKNOWN
+            },
+            when (subtype?.lowercase()) {
                 "hsdpa+" -> "hsdpa"
                 "cdma - evdo rev. 0" -> "evdo_0"
                 "cdma - evdo rev. a" -> "evdo_a"
                 else -> subtype
-            }
-        }
-
-    private val receivedFirstCallback = AtomicBoolean(false)
-
-    private val activeNetworkInfo: android.net.NetworkInfo?
-        get() = try {
-            cm.activeNetworkInfo
-        } catch (e: NullPointerException) {
-            // in some rare cases we get a remote NullPointerException via Parcel.readException
-            null
-        }
-
-    override fun registerForNetworkChanges() {
-        val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-        context.registerReceiverSafe(this, intentFilter)
+            },
+        )
     }
 
-    override fun unregisterForNetworkChanges() = context.unregisterReceiverSafe(this)
-
-    private val android.net.NetworkInfo.metering: ConnectionMetering
-        get() = when (type) {
-            ConnectivityManager.TYPE_WIFI, ConnectivityManager.TYPE_ETHERNET ->
-                ConnectionMetering.UNMETERED
-            else -> ConnectionMetering.POTENTIALLY_METERED // all other types are cellular in some form
-        }
-
-    private val android.net.NetworkInfo.networkType: NetworkType
-        get() = when (type) {
-            ConnectivityManager.TYPE_WIFI -> NetworkType.WIFI
-            ConnectivityManager.TYPE_MOBILE -> NetworkType.CELL
-            ConnectivityManager.TYPE_ETHERNET -> NetworkType.WIRED
-            else -> NetworkType.UNKNOWN
-        }
-
     override fun onReceive(context: Context, intent: Intent) {
-        // don't send a callback for the first state-update event
-        if (receivedFirstCallback.getAndSet(true)) {
-            val newNetworkInfo: android.net.NetworkInfo? =
-                intent.getParcelableExtra(ConnectivityManager.EXTRA_NETWORK_INFO)
-                    ?: activeNetworkInfo
+        val newNetworkInfo: android.net.NetworkInfo? =
+            intent.getParcelableExtra(ConnectivityManager.EXTRA_NETWORK_INFO)
 
-            callback?.invoke(
-                newNetworkInfo?.isConnectedOrConnecting ?: UnknownNetwork.HAS_CONNECTION,
-                newNetworkInfo?.metering ?: UnknownNetwork.METERING,
-                newNetworkInfo?.networkType ?: UnknownNetwork.NETWORK_TYPE,
-                newNetworkInfo?.subtypeName,
-            )
-        }
+        connectivityStatus = networkInfoToStatus(newNetworkInfo)
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.N)
 internal open class ConnectivityApi24(
-    private val context: Context,
-    internal val cm: ConnectivityManager,
+    context: Context,
+    private val cm: ConnectivityManager,
     private val callback: NetworkChangeCallback?,
 ) : ConnectivityManager.NetworkCallback(), Connectivity {
 
-    override val hasConnection: Boolean
-        get() = connectedFor(capabilities)
-    override val metering: ConnectionMetering
-        get() = meteringFor(capabilities)
-    override val networkType: NetworkType
-        get() = networkTypeFor(capabilities)
-    override val networkSubType: String?
-        get() = networkSubTypeFor(capabilities)
-
-    private var capabilities: NetworkCapabilities? =
-        cm.getNetworkCapabilities(cm.boundNetworkForProcess)
-    private val receivedFirstCallback = AtomicBoolean(false)
     private val tm: TelephonyManager? = context.getTelephonyManager()
 
-    protected open fun networkTypeFor(capabilities: NetworkCapabilities?): NetworkType {
+    override var connectivityStatus: ConnectivityStatus =
+        networkCapabilitiesToStatus(cm.getNetworkCapabilities(cm.activeNetwork))
+        protected set(newStatus) {
+            if (field != newStatus) {
+                field = newStatus
+                callback?.invoke(field)
+            }
+        }
+
+    private fun networkCapabilitiesToStatus(capabilities: NetworkCapabilities?): ConnectivityStatus {
+        if (capabilities == null) {
+            return unknownNetwork
+        }
+
+        return ConnectivityStatus(
+            connectedFor(capabilities),
+            meteringFor(capabilities),
+            networkTypeFor(capabilities),
+            networkSubTypeFor(capabilities),
+        )
+    }
+
+    protected open fun networkTypeFor(capabilities: NetworkCapabilities): NetworkType {
         return when {
-            capabilities == null -> UnknownConnectivity.networkType
             capabilities.hasTransport(TRANSPORT_ETHERNET) ||
                 capabilities.hasTransport(TRANSPORT_USB) -> NetworkType.WIRED
             capabilities.hasTransport(TRANSPORT_WIFI) -> NetworkType.WIFI
@@ -195,41 +173,43 @@ internal open class ConnectivityApi24(
     }
 
     @SuppressLint("MissingPermission")
-    protected open fun networkSubTypeFor(capabilities: NetworkCapabilities?): String? {
-        if (capabilities == null || networkTypeFor(capabilities) != NetworkType.CELL || tm == null) {
+    protected open fun networkSubTypeFor(capabilities: NetworkCapabilities): String? {
+        if (networkTypeFor(capabilities) != NetworkType.CELL || tm == null) {
             return null
         }
 
-        return if (canReadPhoneState()) nameForDataNetworkType(tm.dataNetworkType) else null
+        return try {
+            nameForDataNetworkType(tm.dataNetworkType)
+        } catch (e: Exception) {
+            null
+        }
     }
-
-    private fun canReadPhoneState() =
-        (context.checkCallingPermission(READ_BASIC_PHONE_STATE) == PERMISSION_GRANTED
-            || context.checkCallingPermission(READ_PHONE_STATE) == PERMISSION_GRANTED)
 
     private fun nameForDataNetworkType(dataNetworkType: Int): String = when (dataNetworkType) {
-        TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
-        TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
-        TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-        TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
-        TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-        TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
-        TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
-        TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
-        TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
-        TelephonyManager.NETWORK_TYPE_EVDO_B -> "EVDO_B"
-        TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
-        TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
-        TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
-        TelephonyManager.NETWORK_TYPE_EHRPD -> "EHRPD"
-        TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPAP"
-        TelephonyManager.NETWORK_TYPE_NR -> "NR"
-        else -> "UNKNOWN"
+        TelephonyManager.NETWORK_TYPE_1xRTT -> "cdma2000_1xrtt"
+        TelephonyManager.NETWORK_TYPE_CDMA -> "cdma"
+        TelephonyManager.NETWORK_TYPE_EDGE -> "edge"
+        TelephonyManager.NETWORK_TYPE_EHRPD -> "ehrpd"
+        TelephonyManager.NETWORK_TYPE_EVDO_0 -> "evdo_0"
+        TelephonyManager.NETWORK_TYPE_EVDO_A -> "evdo_a"
+        TelephonyManager.NETWORK_TYPE_EVDO_B -> "evdo_b"
+        TelephonyManager.NETWORK_TYPE_GSM -> "gsm"
+        TelephonyManager.NETWORK_TYPE_GPRS -> "gprs"
+        TelephonyManager.NETWORK_TYPE_HSDPA -> "hsdpa"
+        TelephonyManager.NETWORK_TYPE_HSPA -> "hspa"
+        TelephonyManager.NETWORK_TYPE_HSPAP -> "hspap"
+        TelephonyManager.NETWORK_TYPE_HSUPA -> "hsupa"
+        TelephonyManager.NETWORK_TYPE_IDEN -> "iden"
+        TelephonyManager.NETWORK_TYPE_IWLAN -> "iwlan"
+        TelephonyManager.NETWORK_TYPE_LTE -> "lte"
+        TelephonyManager.NETWORK_TYPE_NR -> "nr"
+        TelephonyManager.NETWORK_TYPE_UMTS -> "umts"
+        TelephonyManager.NETWORK_TYPE_TD_SCDMA -> "td_scdma"
+        else -> "unknown"
     }
 
-    protected open fun meteringFor(capabilities: NetworkCapabilities?): ConnectionMetering {
+    protected open fun meteringFor(capabilities: NetworkCapabilities): ConnectionMetering {
         return when {
-            capabilities == null -> UnknownConnectivity.metering
             capabilities.hasTransport(TRANSPORT_WIFI) -> ConnectionMetering.UNMETERED
             capabilities.hasTransport(TRANSPORT_ETHERNET) ||
                 capabilities.hasTransport(TRANSPORT_USB) -> ConnectionMetering.UNMETERED
@@ -238,40 +218,33 @@ internal open class ConnectivityApi24(
         }
     }
 
-    protected open fun connectedFor(capabilities: NetworkCapabilities?): Boolean {
-        if (capabilities == null) return false
-
+    protected open fun connectedFor(capabilities: NetworkCapabilities): Boolean {
         return capabilities.hasCapability(NET_CAPABILITY_INTERNET) &&
-            capabilities.hasCapability(NET_CAPABILITY_VALIDATED) &&
-            receivedFirstCallback.get()
+            capabilities.hasCapability(NET_CAPABILITY_VALIDATED)
     }
 
-    override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(this)
-    override fun unregisterForNetworkChanges() = cm.unregisterNetworkCallback(this)
-
-    override fun onUnavailable() {
-        if (receivedFirstCallback.getAndSet(true)) {
-            callback?.invoke(
-                UnknownNetwork.HAS_CONNECTION,
-                UnknownNetwork.METERING,
-                UnknownNetwork.NETWORK_TYPE,
-                UnknownNetwork.NETWORK_SUBTYPE,
-            )
+    override fun registerForNetworkChanges() {
+        runCatching {
+            cm.registerDefaultNetworkCallback(this)
         }
     }
 
+    override fun unregisterForNetworkChanges() {
+        runCatching {
+            cm.unregisterNetworkCallback(this)
+        }
+    }
+
+    override fun onUnavailable() {
+        connectivityStatus = unknownNetwork
+    }
+
     override fun onAvailable(network: Network) {
-        capabilities = cm.getNetworkCapabilities(network)
-        if (capabilities?.hasCapability(NET_CAPABILITY_INTERNET) == true &&
-            capabilities?.hasCapability(NET_CAPABILITY_VALIDATED) == true &&
-            receivedFirstCallback.getAndSet(true)
+        val capabilities = cm.getNetworkCapabilities(network) ?: return
+        if (capabilities.hasCapability(NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NET_CAPABILITY_VALIDATED)
         ) {
-            callback?.invoke(
-                true,
-                meteringFor(capabilities),
-                networkTypeFor(capabilities),
-                networkSubTypeFor(capabilities),
-            )
+            connectivityStatus = networkCapabilitiesToStatus(capabilities)
         }
     }
 }
@@ -283,9 +256,8 @@ internal class ConnectivityApi31(
     callback: NetworkChangeCallback?,
 ) : ConnectivityApi24(context, cm, callback) {
 
-    override fun meteringFor(capabilities: NetworkCapabilities?): ConnectionMetering {
+    override fun meteringFor(capabilities: NetworkCapabilities): ConnectionMetering {
         return when {
-            capabilities == null -> UnknownConnectivity.metering
             capabilities.hasCapability(NET_CAPABILITY_NOT_METERED) ||
                 capabilities.hasCapability(NET_CAPABILITY_TEMPORARILY_NOT_METERED) -> ConnectionMetering.UNMETERED
 
@@ -299,12 +271,11 @@ internal class ConnectivityApi31(
  * We assume that there is some sort of network and do not attempt to report any network changes.
  */
 internal object UnknownConnectivity : Connectivity {
+    override val connectivityStatus: ConnectivityStatus
+        get() = unknownNetwork
+
     override fun registerForNetworkChanges() = Unit
     override fun unregisterForNetworkChanges() = Unit
-    override val hasConnection = false
-    override val metering = ConnectionMetering.DISCONNECTED
-    override val networkType = NetworkType.UNKNOWN
-    override val networkSubType = null
 }
 
 /**
@@ -313,4 +284,4 @@ internal object UnknownConnectivity : Connectivity {
  * where the network status has not been set yet, or the app might not have appropriate permissions).
  */
 internal fun Connectivity.shouldAttemptDelivery(): Boolean =
-    networkType == NetworkType.UNKNOWN || hasConnection
+    connectivityStatus.networkType == NetworkType.UNKNOWN || connectivityStatus.hasConnection

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
@@ -6,10 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
-import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.os.RemoteException
-import android.os.storage.StorageManager
 import android.telephony.TelephonyManager
 import com.bugsnag.android.performance.Logger
 
@@ -73,14 +71,6 @@ internal fun Context.getConnectivityManager(): ConnectivityManager? =
 @JvmName("getTelephonyManagerFrom")
 internal fun Context.getTelephonyManager(): TelephonyManager? =
     safeGetSystemService(Context.TELEPHONY_SERVICE)
-
-@JvmName("getStorageManagerFrom")
-internal fun Context.getStorageManager(): StorageManager? =
-    safeGetSystemService(Context.STORAGE_SERVICE)
-
-@JvmName("getLocationManager")
-internal fun Context.getLocationManager(): LocationManager? =
-    safeGetSystemService(Context.LOCATION_SERVICE)
 
 internal val Context.releaseStage: String
     get() {

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
@@ -32,8 +32,8 @@ class Api24NetworkTypeTest {
         val connectivityManager = mock<ConnectivityManager>()
         var callbackInvoked = false
 
-        val connectivity = ConnectivityApi24(context, connectivityManager) { _, _, networkType, _ ->
-            assertEquals(expectedNetworkType, networkType)
+        val connectivity = ConnectivityApi24(context, connectivityManager) { status ->
+            assertEquals(expectedNetworkType, status.networkType)
             callbackInvoked = true
         }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
@@ -90,10 +90,11 @@ class ConnectivityLegacyTest {
         }
 
         val connectivity = ConnectivityLegacy(mock(), connectivityManager, null)
+        val status = connectivity.connectivityStatus
 
-        assertEquals(expected.metering, connectivity.metering)
-        assertEquals(expected.networkType, connectivity.networkType)
-        assertEquals(expected.networkSubType, connectivity.networkSubType)
+        assertEquals(expected.metering, status.metering)
+        assertEquals(expected.networkType, status.networkType)
+        assertEquals(expected.networkSubType, status.networkSubType)
     }
 
     internal data class ExpectedInfo(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
@@ -18,9 +18,15 @@ class HttpDeliveryTest {
     @Test
     fun noConnectivity() {
         val connectivity = mock<Connectivity> {
-            on { hasConnection } doReturn false
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                false,
+                ConnectionMetering.DISCONNECTED,
+                NetworkType.CELL,
+                null,
+            )
         }
-        val delivery = HttpDelivery("http://localhost", "0123456789abcdef0123456789abcdef", connectivity)
+        val delivery =
+            HttpDelivery("http://localhost", "0123456789abcdef0123456789abcdef", connectivity)
 
         val spans = spanFactory.newSpans(5, spanProcessor)
         val result = delivery.deliver(spans, Attributes())

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/LegacyNetworkTypeTest.kt
@@ -43,9 +43,9 @@ class LegacyNetworkTypeTest {
     ) {
         val context = mock<Context>()
         var callbackInvoked = false
-        val connectivity = ConnectivityLegacy(context, mock()) { _, metering, networkType, _ ->
-            assertEquals(expectedNetworkType, networkType)
-            assertEquals(expectedMetering, metering)
+        val connectivity = ConnectivityLegacy(context, mock()) { status ->
+            assertEquals(expectedNetworkType, status.networkType)
+            assertEquals(expectedMetering, status.metering)
             callbackInvoked = true
         }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
@@ -30,7 +30,12 @@ class RetryDeliveryTaskTest {
             on { next() } doReturn tracePayload
         }
         val connectivity = mock<Connectivity> {
-            on { hasConnection } doReturn false
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                false,
+                ConnectionMetering.DISCONNECTED,
+                NetworkType.CELL,
+                null,
+            )
         }
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
 
@@ -49,7 +54,12 @@ class RetryDeliveryTaskTest {
             on { next() } doReturn tracePayload
         }
         val connectivity = mock<Connectivity> {
-            on { hasConnection } doReturn true
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                true,
+                ConnectionMetering.UNMETERED,
+                NetworkType.WIFI,
+                null,
+            )
         }
 
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
@@ -71,7 +81,12 @@ class RetryDeliveryTaskTest {
             on { next() } doReturn tracePayload
         }
         val connectivity = mock<Connectivity> {
-            on { hasConnection } doReturn true
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                true,
+                ConnectionMetering.UNMETERED,
+                NetworkType.WIFI,
+                null,
+            )
         }
 
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
@@ -93,7 +108,12 @@ class RetryDeliveryTaskTest {
             on { next() } doReturn tracePayload
         }
         val connectivity = mock<Connectivity> {
-            on { hasConnection } doReturn true
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                true,
+                ConnectionMetering.UNMETERED,
+                NetworkType.WIFI,
+                null,
+            )
         }
 
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)

--- a/examples/performance-example/app/src/main/AndroidManifest.xml
+++ b/examples/performance-example/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.bugsnag.performance">
 
+    <!-- declare the READ_BASIC_PHONE_STATE so that we can report network information -->
+    <uses-permission android:name="android.permission.READ_BASIC_PHONE_STATE" />
+
     <application
         android:name=".PerformanceApplication"
         android:allowBackup="true"


### PR DESCRIPTION
## Goal
Ensure that the network subtype is reported when available, and of a known type. Simplify the reporting to reduce possible bugs.

## Design
Encapsulated all of the network status into a new immutable `ConnectivityStatus` class. Flattened the `Connectivity` delegation layers, and merged the event-handling logic with the information retrieval such that using `Connectivity.connectionStatus` and receiving a `NetworkChangeCallback` use the exact same construction logic.

## Testing
Relied on existing end-to-end tests, and updated the existing unit tests. Tested the in-app / on-device behaviour manually.