### PR TITLE
Move Android 13 e2e tests to BitBar

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
     commands:
       - make test-fixture
 
-  - label: ':android: Android 9 tests'
+  - label: ':browserstack: Android 9 tests'
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
@@ -50,7 +50,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 10 tests'
+  - label: ':browserstack: Android 10 tests'
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
@@ -70,7 +70,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 11 tests'
+  - label: ':browserstack: Android 11 tests'
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
@@ -90,7 +90,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 12 tests'
+  - label: ':browserstack: Android 12 tests'
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download:
           - "build/test-fixture.apk"
         upload: "maze_output/failed/**/*"
@@ -42,7 +42,6 @@ steps:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "features/"
           - "--app=/app/build/test-fixture.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
@@ -55,7 +54,7 @@ steps:
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download:
           - "build/test-fixture.apk"
         upload: "maze_output/failed/**/*"
@@ -63,7 +62,6 @@ steps:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "features/"
           - "--app=/app/build/test-fixture.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
@@ -76,7 +74,7 @@ steps:
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download:
           - "build/test-fixture.apk"
         upload: "maze_output/failed/**/*"
@@ -84,7 +82,6 @@ steps:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "features/"
           - "--app=/app/build/test-fixture.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
@@ -97,7 +94,7 @@ steps:
     depends_on: 'fixture'
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download:
           - "build/test-fixture.apk"
         upload: "maze_output/failed/**/*"
@@ -105,7 +102,6 @@ steps:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "features/"
           - "--app=/app/build/test-fixture.apk"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
@@ -114,23 +110,26 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 13 tests'
-    depends_on: 'fixture'
+  - label: ':bitbar: Android 13 tests'
+    depends_on: "fixture"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download:
-          - "build/test-fixture.apk"
+          - "build/fixture-r21.apk"
+          - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.8.0:
-        pull: android-maze-runner
-        run: android-maze-runner
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
         command:
-          - "features/"
           - "--app=/app/build/test-fixture.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_13_0"
+          - "--farm=bb"
+          - "--device=ANDROID_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
           - "--fail-fast"
-    concurrency: 24
-    concurrency_group: 'browserstack-app'
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,9 +115,7 @@ steps:
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21.apk"
-          - "build/fixture-r21/*"
+        download: "build/test-fixture.apk"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.8.0:
         pull: android-maze-runner-bitbar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,50 @@
 version: '3.6'
+
+
+x-common-environment: &common-environment
+  DEBUG:
+  BUILDKITE:
+  BUILDKITE_BRANCH:
+  BUILDKITE_BUILD_CREATOR:
+  BUILDKITE_BUILD_NUMBER:
+  BUILDKITE_BUILD_URL:
+  BUILDKITE_LABEL:
+  BUILDKITE_MESSAGE:
+  BUILDKITE_PIPELINE_NAME:
+  BUILDKITE_PIPELINE_SLUG:
+  BUILDKITE_REPO:
+  BUILDKITE_RETRY_COUNT:
+  BUILDKITE_STEP_KEY:
+  MAZE_BUGSNAG_API_KEY:
+  MAZE_REPEATER_API_KEY:
+  TEST_FIXTURE_SYMBOL_DIR:
+
 services:
 
   android-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
     environment:
-      DEBUG:
-      BUILDKITE:
-      BUILDKITE_BRANCH:
-      BUILDKITE_BUILD_CREATOR:
-      BUILDKITE_BUILD_NUMBER:
-      BUILDKITE_BUILD_URL:
-      BUILDKITE_LABEL:
-      BUILDKITE_MESSAGE:
-      BUILDKITE_PIPELINE_NAME:
-      BUILDKITE_REPO:
-      BUILDKITE_RETRY_COUNT:
-      BUILDKITE_STEP_KEY:
-      MAZE_BUGSNAG_API_KEY:
-      MAZE_REPEATER_API_KEY:
+      <<: *common-environment
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
-      TEST_FIXTURE_SYMBOL_DIR:
     volumes:
       - ./build:/app/build
       - ./features/:/app/features/
       - ./maze_output:/app/maze_output
+
+  android-maze-runner-bitbar:
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
+    environment:
+      <<: *common-environment
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+    ports:
+      - "9000-9499:9339"
+    volumes:
+      - ./build:/app/build
+      - ./features/:/app/features/
+      - ./maze_output:/app/maze_output
+      - /var/run/docker.sock:/var/run/docker.sock
 
 networks:
   default:

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -13,6 +13,7 @@
     <ID>MagicNumber:DisabledReleaseStageScenario.kt$DisabledReleaseStageScenario$100L</ID>
     <ID>MagicNumber:DisabledReleaseStageScenario.kt$DisabledReleaseStageScenario$500L</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
+    <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$1000L</ID>
     <ID>MagicNumber:OkhttpSpanScenario.kt$OkhttpSpanScenario$1000L</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -14,10 +14,13 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.PerformanceConfiguration
 import org.json.JSONObject
+import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import kotlin.concurrent.thread
+
+const val CONFIG_FILE_TIMEOUT = 5000
 
 class MainActivity : AppCompatActivity() {
     private val apiKeyKey = "BUGSNAG_API_KEY"
@@ -27,6 +30,7 @@ class MainActivity : AppCompatActivity() {
 
     var scenario: Scenario? = null
     var polling = false
+    var mazeAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -72,6 +76,35 @@ class MainActivity : AppCompatActivity() {
         log("MainActivity.onResume complete")
     }
 
+    private fun setMazeRunnerAddress() {
+        val context = MazeRacerApplication.applicationContext()
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        log("Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    log("Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+
+        // Assume we are running in legacy mode on BrowserStack
+        if (mazeAddress.isNullOrBlank()) {
+            log("Failed to read Maze Runner address from config file, reverting to legacy BrowserStack address")
+            mazeAddress = "bs-local.com:9339"
+        }
+    }
+
     // Checks general internet and secure tunnel connectivity
     private fun checkNetwork() {
         log("Checking network connectivity")
@@ -90,11 +123,17 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // As per JSONObject.getString but returns and empty string rather than throwing if not present
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
     // Starts a thread to poll for Maze Runner actions to perform
     private fun startCommandRunner() {
         // Get the next maze runner command
         polling = true
         thread(start = true) {
+            if (mazeAddress == null) setMazeRunnerAddress()
             checkNetwork()
 
             while (polling) {
@@ -166,7 +205,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun readCommand(): String {
-        val commandUrl = "http://bs-local.com:9339/command"
+        val commandUrl = "http://$mazeAddress/command"
         val urlConnection = URL(commandUrl).openConnection() as HttpURLConnection
         try {
             return urlConnection.inputStream.use { it.reader().readText() }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
@@ -1,12 +1,21 @@
 package com.bugsnag.mazeracer
 
 import android.app.Application
+import android.content.Context
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.internal.InternalDebug
 
 class MazeRacerApplication : Application() {
     init {
         BugsnagPerformance.reportApplicationClassLoaded()
+    }
+
+    companion object {
+        private var instance: MazeRacerApplication? = null
+
+        fun applicationContext(): Context {
+            return instance!!.applicationContext
+        }
     }
 
     override fun onCreate() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
@@ -7,6 +7,7 @@ import com.bugsnag.android.performance.internal.InternalDebug
 
 class MazeRacerApplication : Application() {
     init {
+        instance = this
         BugsnagPerformance.reportApplicationClassLoaded()
     }
 

--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 def execute_command(action, scenario_name = '', scenario_metadata = '')
+
+  address = if Maze.config.farm == :bb
+              if Maze.config.aws_public_ip
+                Maze.public_address
+              else
+                'local:9339'
+              end
+            else
+              'bs-local.com:9339'
+            end
+
   command = {
     action: action,
     scenario_name: scenario_name,
     scenario_metadata: scenario_metadata,
-    endpoint: 'http://bs-local.com:9339/traces',
+    endpoint: "http://#{address}/traces",
   }
   Maze::Server.commands.add command
 


### PR DESCRIPTION
## Goal

Migrates the Android 13 e2e tests to BitBar.

## Design

Follows the pattern used in other repos and in particular takes the test fixture code needed to determine the public AWS address directly from bugsnag-android. 

## Testing

Covered by CI.