### PR TITLE
Discard failed network request spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* `bugsnag-plugin-android-performance-okhttp` will now discard NetworkRequest spans when the request is cancelled or fails
+  [#123](https://github.com/bugsnag/bugsnag-android-performance/pull/123)
+
 ## 0.1.5 (2023-04-25)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -46,7 +46,7 @@ class BugsnagPerformanceOkhttp : EventListener() {
                 Protocol.HTTP_2 -> "2.0"
                 Protocol.QUIC -> "QUIC"
                 else -> "unknown"
-            }
+            },
         )
     }
 
@@ -55,10 +55,12 @@ class BugsnagPerformanceOkhttp : EventListener() {
     }
 
     override fun callFailed(call: Call, ioe: IOException) {
-        spans.remove(call)?.end()
+        // remove the span and discard
+        spans.remove(call)
     }
 
     override fun canceled(call: Call) {
-        spans.remove(call)?.end()
+        // remove the span and discard
+        spans.remove(call)
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpSpanScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpSpanScenario.kt
@@ -11,7 +11,7 @@ import kotlin.concurrent.thread
 
 class OkhttpSpanScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
@@ -25,7 +25,7 @@ class OkhttpSpanScenario(
                 .eventListenerFactory(BugsnagPerformanceOkhttp.EventListenerFactory)
                 .build()
             val request = Request.Builder()
-                .url("https://google.com?test=true")
+                .url(scenarioMetadata.takeUnless { it.isBlank() } ?: "https://google.com?test=true")
                 .build()
 
             client.newCall(request).execute().use { response ->

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -1,6 +1,6 @@
-Feature: Manual creation of spans
+Feature: OkHttp EventListener
 
-  Scenario: Manual spans can be logged
+  Scenario: NetworkRequest spans are logged for requests
     Given I run "OkhttpSpanScenario" and discard the initial p-value request
     And I wait to receive 1 traces
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
@@ -17,3 +17,8 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazeracer"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.android"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" matches the regex "[0-9]+\.[0-9]+\.[0-9]+"
+
+  Scenario: Failed requests do not log spans
+    Given I run "OkhttpSpanScenario" configured as "https://localhost:9876"
+    And I receive and discard the initial p-value request
+    Then I should receive no traces


### PR DESCRIPTION
## Goal
Don't report metrics for failed and cancelled network requests.

## Testing
New end-to-end scenario