### PR TITLE
Attempt to use more reliable clock fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `bugsnag-plugin-android-performance-okhttp` will now discard NetworkRequest spans when the request is cancelled or fails
   [#123](https://github.com/bugsnag/bugsnag-android-performance/pull/123)
+* Default to using the GNSS clock (if available) to attempt to avoid problems with clocks which could lead to negative timestamps on Spans
+  []()
 
 ## 0.1.5 (2023-04-25)
 

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -24,11 +24,13 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
+    <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
@@ -1,10 +1,12 @@
 package com.bugsnag.android.performance.internal
 
+import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
+import java.lang.Long.max
 
 internal object BugsnagClock {
-    private const val NANOS_IN_MILLIS = 1_000_000
+    private const val NANOS_IN_MILLIS = 1_000_000L
 
     /**
      * The nanosecond precise unix time that the device booted at according to
@@ -12,8 +14,39 @@ internal object BugsnagClock {
      * to around a millisecond.
      */
     @VisibleForTesting
-    internal val bootTimeNano =
-        (System.currentTimeMillis() * NANOS_IN_MILLIS) - SystemClock.elapsedRealtimeNanos()
+    internal val bootTimeNano: Long = safeBootTimeNanos()
+
+    @VisibleForTesting
+    internal fun safeBootTimeNanos(): Long {
+        // Start off by trying to use the GNSS clock - as this should be more reliable
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // We can possibly fallback to the location-providers clock
+            // Which should be very nice and accurate - if it's available and has actually synched up
+            try {
+                val gnssInstant = SystemClock.currentGnssTimeClock().instant()
+                val currentNanos = gnssInstant.toEpochMilli() + gnssInstant.nano
+
+                val bootTime = currentNanos - SystemClock.elapsedRealtimeNanos()
+                if (bootTime > 0L) {
+                    return bootTime
+                }
+            } catch (ex: Exception) {
+                // ignore this and fallback
+            }
+        }
+
+        // We couldn't use the GNSS clock, so we try and use the wall clock
+        val bootTime = (System.currentTimeMillis() * NANOS_IN_MILLIS) -
+            SystemClock.elapsedRealtimeNanos()
+
+        // If the elapsedRealtimeNanos is (somehow) longer than the wall clock time, we would
+        // return a negative boot time possibly leading to negative timestamps in the Spans
+        //
+        // If this is detected, we fallback to a zero boot time. In this state we will report
+        // the elapsedRealtimeNanos directly which is not the expected unix-nano time but
+        // will at least remain positive
+        return max(bootTime, 0L)
+    }
 
     /**
      * Covert a given time from [SystemClock.elapsedRealtimeNanos] into Unix time with nanosecond

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/BugsnagClockTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/BugsnagClockTest.kt
@@ -1,10 +1,12 @@
 package com.bugsnag.android.performance.internal
 
 import android.os.SystemClock
+import com.bugsnag.android.performance.test.withStaticMock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -18,5 +20,11 @@ class BugsnagClockTest {
     fun testCurrentTime() {
         val elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
         assertTrue(BugsnagClock.elapsedNanosToUnixTime(elapsedRealtimeNanos) > elapsedRealtimeNanos)
+    }
+
+    @Test
+    fun testSafeBootFallback_Zero() = withStaticMock<SystemClock> { mockedClock ->
+        mockedClock.`when`<Long> { SystemClock.elapsedRealtimeNanos() } doReturn Long.MAX_VALUE
+        assertEquals(0L, BugsnagClock.safeBootTimeNanos())
     }
 }


### PR DESCRIPTION
## Goal
Detect obvious clock problems when calculating the boot time, and work around them

## Design
When starting up attempt to use the GNSS clock source (when available) as a way to fix the boot-time, and fallback to using the wall time. In both cases we detect negatives as invalid, eventually falling back to a `0` boot time.

## Testing
Manual testing for the GNSS clock, and unit tests for the fallback