### PR TITLE
Add `Bugsnag-Sent-At` header to all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ## TBD
 
+### Enhancements
+
+* Each trace reported will include the current clock-time to allow the server-side to adjust device clocks 
+  [#126](https://github.com/bugsnag/bugsnag-android-performance/pull/126)
+
 ### Bug fixes
 
 * `bugsnag-plugin-android-performance-okhttp` will now discard NetworkRequest spans when the request is cancelled or fails
   [#123](https://github.com/bugsnag/bugsnag-android-performance/pull/123)
 * Default to using the GNSS clock (if available) to attempt to avoid problems with clocks which could lead to negative timestamps on Spans
-  []()
+  [#124](https://github.com/bugsnag/bugsnag-android-performance/pull/124)
 
 ## 0.1.5 (2023-04-25)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
@@ -3,7 +3,8 @@ package com.bugsnag.android.performance.internal
 import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
-import java.lang.Long.max
+import java.util.Date
+import kotlin.math.max
 
 internal object BugsnagClock {
     private const val NANOS_IN_MILLIS = 1_000_000L
@@ -47,6 +48,8 @@ internal object BugsnagClock {
         // will at least remain positive
         return max(bootTime, 0L)
     }
+
+    fun toDate(): Date = Date(currentUnixNanoTime() / NANOS_IN_MILLIS)
 
     /**
      * Covert a given time from [SystemClock.elapsedRealtimeNanos] into Unix time with nanosecond

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DateUtils.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DateUtils.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android.performance.internal
+
+import java.text.DateFormat
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+internal object DateUtils {
+    // SimpleDateFormat isn't thread safe, cache one instance per thread as needed.
+    private val iso8601Holder = object : ThreadLocal<DateFormat>() {
+        override fun initialValue(): DateFormat {
+            return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+        }
+    }
+
+    private val iso8601Format: DateFormat
+        get() = requireNotNull(iso8601Holder.get()) { "Unable to find valid dateformatter" }
+
+    @JvmStatic
+    fun toIso8601(date: Date): String {
+        return iso8601Format.format(date)
+    }
+
+    @JvmStatic
+    fun fromIso8601(date: String): Date {
+        return try {
+            iso8601Format.parse(date) ?: throw ParseException("DateFormat.parse returned null", 0)
+        } catch (exc: ParseException) {
+            throw IllegalArgumentException("Failed to parse timestamp", exc)
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
@@ -3,12 +3,23 @@ package com.bugsnag.android.performance.internal
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.test.CollectingSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
-import org.junit.Assert
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.lastValue
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.util.Date
 
 @RunWith(RobolectricTestRunner::class)
 class HttpDeliveryTest {
@@ -25,14 +36,120 @@ class HttpDeliveryTest {
                 null,
             )
         }
-        val delivery =
-            HttpDelivery("http://localhost", "0123456789abcdef0123456789abcdef", connectivity)
+
+        val delivery = HttpDelivery(
+            "http://localhost",
+            "0123456789abcdef0123456789abcdef",
+            connectivity,
+        )
 
         val spans = spanFactory.newSpans(5, spanProcessor)
         val result = delivery.deliver(spans, Attributes())
 
-        Assert.assertTrue(result is DeliveryResult.Failed)
+        assertTrue(result is DeliveryResult.Failed)
         val failed = (result as DeliveryResult.Failed)
-        Assert.assertTrue(failed.canRetry)
+        assertTrue(failed.canRetry)
+    }
+
+    @Test
+    fun headersFromSpans() {
+        val connectivity = mock<Connectivity> {
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                true,
+                ConnectionMetering.POTENTIALLY_METERED,
+                NetworkType.CELL,
+                null,
+            )
+        }
+
+        val connection = mock<HttpURLConnection> {
+            on { responseCode } doReturn 200
+            on { outputStream } doReturn ByteArrayOutputStream()
+        }
+
+        val delivery = object : HttpDelivery(
+            "http://localhost",
+            "0123456789abcdef0123456789abcdef",
+            connectivity,
+        ) {
+            override fun openConnection(): HttpURLConnection = connection
+        }
+
+        val spans = spanFactory.newSpans(5, spanProcessor)
+        val result = delivery.deliver(spans, Attributes())
+
+        assertTrue(result is DeliveryResult.Success)
+
+        verify(connection).setFixedLengthStreamingMode(any())
+        verify(connection).setRequestProperty(eq("Content-Type"), eq("application/json"))
+        verify(connection).setRequestProperty(eq("Content-Encoding"), eq("gzip"))
+        verify(connection).setRequestProperty(eq("Bugsnag-Span-Sampling"), eq("1.0:5"))
+        verify(connection).setRequestProperty(eq("Bugsnag-Sent-At"), any())
+        verify(connection).setRequestProperty(
+            eq("Bugsnag-Api-Key"),
+            eq("0123456789abcdef0123456789abcdef"),
+        )
+    }
+
+    @Test
+    fun headersFromRetry() {
+        val connectivity = mock<Connectivity> {
+            on { connectivityStatus } doReturn ConnectivityStatus(
+                true,
+                ConnectionMetering.POTENTIALLY_METERED,
+                NetworkType.CELL,
+                null,
+            )
+        }
+
+        val connection = mock<HttpURLConnection> {
+            on { responseCode } doReturn 200
+            on { outputStream } doReturn ByteArrayOutputStream()
+        }
+
+        val delivery = object : HttpDelivery(
+            "http://localhost",
+            "0123456789abcdef0123456789abcdef",
+            connectivity,
+        ) {
+            override fun openConnection(): HttpURLConnection = connection
+        }
+
+        // Set our own Bugsnag-Sent-At header as 10 seconds ago, as it should be overwritten by
+        // the HttpDelivery.deliver
+        val datestamp = DateUtils.toIso8601(Date(System.currentTimeMillis() - 10_000L))
+
+        val result = delivery.deliver(
+            TracePayload.createTracePayload(
+                "0123456789abcdef0123456789abcdef",
+                """{"message": "Hello World"}""".toByteArray(),
+                hashMapOf(
+                    "Bugsnag-Sent-At" to datestamp,
+                ),
+            ),
+        )
+
+        assertTrue(result is DeliveryResult.Success)
+
+        val sentAtCaptor = ArgumentCaptor.forClass(String::class.java)
+
+        verify(connection).setFixedLengthStreamingMode(any())
+        verify(connection).setRequestProperty(eq("Content-Type"), eq("application/json"))
+
+        // We expect setRequestProperty to be called twice for this specific request
+        // 1) for the value specified in createTracePayload
+        // 2) for the overwrite in HttpDelivery
+        verify(connection, times(2)).setRequestProperty(
+            eq("Bugsnag-Sent-At"),
+            sentAtCaptor.capture(),
+        )
+
+        verify(connection).setRequestProperty(
+            eq("Bugsnag-Api-Key"),
+            eq("0123456789abcdef0123456789abcdef"),
+        )
+
+        assertNotNull(sentAtCaptor.lastValue)
+        assertNotEquals(datestamp, sentAtCaptor.lastValue)
     }
 }

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -8,6 +8,7 @@ Feature: Manual creation of spans
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     Then I discard the oldest trace
     Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Sent-At" header is not null
     And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"


### PR DESCRIPTION
## Goal
Introduce a `Bugsnag-Sent-At` header to all requests to allow the server to adjust the time (in case of skew device clocks).

## Design
Used the `BugsnagClock` to ensure that the `Bugsnag-Sent-At` header is consistent with the timestamps delivered in the spans.

## Testing
New unit tests added, along with a new check in the existing end-to-end scenarios