### PR TITLE
Reduce flakes in server-response scenario

### DIFF
--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -171,13 +171,26 @@ Feature: Server responses
   # P=0 on second response
 
   Scenario: Update P to 0 on second response: success, fail-permanent, fail-retriable
-    Given I set the HTTP status code for the next requests to "200,200,400,500"
-    Given I set the sampling probability for the next traces to "1,null,0"
-    And I run "ThreeSpansScenario" and discard the initial p-value request
-    And I wait to receive at least 2 traces
+    Given I set the HTTP status code for the next requests to "200,200"
+    Given I set the sampling probability for the next traces to "1,null"
+    And I load scenario "GenerateSpansScenario"
+    And I receive and discard the initial p-value request
+    Then I invoke "sendNextSpan"
+    And I wait to receive 1 trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     And I discard the oldest trace
+
+    Given I set the HTTP status code for the next requests to "400"
+    And I set the sampling probability for the next traces to "0"
+    And I invoke "sendNextSpan"
+    And I wait to receive 1 trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 2"
+    And I discard the oldest trace
+
+    Given I set the HTTP status code for the next requests to "400"
+    And I set the sampling probability for the next traces to "0"
+    And I invoke "sendNextSpan"
+    And I should receive no traces
 
   Scenario: Update P to 0 on second response: success, fail-retriable, fail-permanent
     Given I set the HTTP status code for the next requests to "200,200,500,400"


### PR DESCRIPTION
## Goal
Removed the flake in the "Update P to 0 on second response: success, fail-permanent, fail-retriable" scenario.

## Design
changed the scenario to perform the same test with stepped sending to avoid mis-grouping the batches due to race conditions.

## Testing
CI now passes this test