### PR TITLE
Map "CDMA - 1xRTT" network subtype to the expected "cdma2000_1xrtt" value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#123](https://github.com/bugsnag/bugsnag-android-performance/pull/123)
 * Default to using the GNSS clock (if available) to attempt to avoid problems with clocks which could lead to negative timestamps on Spans
   [#124](https://github.com/bugsnag/bugsnag-android-performance/pull/124)
+* Map "CDMA - 1xRTT" network subtype to the expected "cdma2000_1xrtt" value
+  []()
 
 ## 0.1.5 (2023-04-25)
 
@@ -20,7 +22,7 @@
   [#113](https://github.com/bugsnag/bugsnag-android-performance/pull/113)
 * ViewLoad spans should only be marked "first class" when there are no other ViewLoad spans in the SpanContext
   [#115](https://github.com/bugsnag/bugsnag-android-performance/pull/115)
-* The "first view" reported as part of AppStart spans is based on the first ViewLoad started rather than the first Actvity resumed
+* The "first view" reported as part of AppStart spans is based on the first ViewLoad started rather than the first Activity resumed
   [#119](https://github.com/bugsnag/bugsnag-android-performance/pull/119)
 * Fixed the reporting of cellular network subtypes (when the app has appropriate permissions)
   [#116](https://github.com/bugsnag/bugsnag-android-performance/pull/116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Default to using the GNSS clock (if available) to attempt to avoid problems with clocks which could lead to negative timestamps on Spans
   [#124](https://github.com/bugsnag/bugsnag-android-performance/pull/124)
 * Map "CDMA - 1xRTT" network subtype to the expected "cdma2000_1xrtt" value
-  []()
+  [#134](https://github.com/bugsnag/bugsnag-android-performance/pull/134)
 
 ## 0.1.5 (2023-04-25)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -118,6 +118,7 @@ internal class ConnectivityLegacy(
                 "hsdpa+" -> "hsdpa"
                 "cdma - evdo rev. 0" -> "evdo_0"
                 "cdma - evdo rev. a" -> "evdo_a"
+                "cdma - 1xrtt" -> "cdma2000_1xrtt"
                 else -> subtype
             },
         )

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
@@ -17,6 +17,7 @@ class ConnectivityLegacyTest {
     companion object {
         @JvmStatic
         @Parameterized.Parameters
+        @Suppress("LongMethod") // naturally long method due to the number of permutations
         internal fun createTestNetworkParameters(): Collection<Pair<ExpectedInfo, NetworkInfo>> {
             return listOf(
                 Pair(
@@ -66,6 +67,14 @@ class ConnectivityLegacyTest {
                         "evdo_0",
                     ),
                     mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "CDMA - EvDo rev. 0"),
+                ),
+                Pair(
+                    ExpectedInfo(
+                        ConnectionMetering.POTENTIALLY_METERED,
+                        NetworkType.CELL,
+                        "cdma2000_1xrtt",
+                    ),
+                    mockNetworkInfo(ConnectivityManager.TYPE_MOBILE, "CDMA - 1xRTT"),
                 ),
             )
         }


### PR DESCRIPTION
## Goal
Map "CDMA - 1xRTT" network subtype on legacy devices to the expected "cdma2000_1xrtt" value

## Testing
Added to existing unit tests