### PR TITLE
Discard background AppStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#124](https://github.com/bugsnag/bugsnag-android-performance/pull/124)
 * Map "CDMA - 1xRTT" network subtype to the expected "cdma2000_1xrtt" value
   [#134](https://github.com/bugsnag/bugsnag-android-performance/pull/134)
+* Background AppStart spans (for broadcasts & services) are now discarded to avoid skewing AppStart/Cold metrics
+  []()
 
 ## 0.1.5 (2023-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Map "CDMA - 1xRTT" network subtype to the expected "cdma2000_1xrtt" value
   [#134](https://github.com/bugsnag/bugsnag-android-performance/pull/134)
 * Background AppStart spans (for broadcasts & services) are now discarded to avoid skewing AppStart/Cold metrics
-  []()
+  [#135](https://github.com/bugsnag/bugsnag-android-performance/pull/135)
 
 ## 0.1.5 (2023-04-25)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -274,7 +274,7 @@ object BugsnagPerformance {
     @JvmStatic
     fun reportApplicationClassLoaded() {
         synchronized(this) {
-            instrumentedAppState.platformCallbacks.startAppLoadSpan("Cold")
+            instrumentedAppState.activityCallbacks.startAppLoadSpan("Cold")
         }
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -10,7 +10,7 @@ class InstrumentedAppState {
     val spanTracker = SpanTracker()
 
     val spanFactory = SpanFactory(BugsnagPerformance.tracer, defaultAttributeSource)
-    val platformCallbacks = createLifecycleCallbacks()
+    val activityCallbacks = createLifecycleCallbacks()
 
     lateinit var app: Application
         private set
@@ -20,7 +20,7 @@ class InstrumentedAppState {
 
         configureLifecycleCallbacks(configuration)
 
-        app.registerActivityLifecycleCallbacks(platformCallbacks)
+        app.registerActivityLifecycleCallbacks(activityCallbacks)
         app.registerComponentCallbacks(PerformanceComponentCallbacks(BugsnagPerformance.tracer))
     }
 
@@ -33,7 +33,7 @@ class InstrumentedAppState {
     }
 
     private fun configureLifecycleCallbacks(configuration: ImmutableConfig) {
-        platformCallbacks.apply {
+        activityCallbacks.apply {
             openLoadSpans = configuration.autoInstrumentActivities != AutoInstrument.OFF
             closeLoadSpans = configuration.autoInstrumentActivities == AutoInstrument.FULL
             instrumentAppStart = configuration.autoInstrumentAppStarts

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -73,6 +73,7 @@ class SpanFactory(
             "[AppStart/$startType]",
             SpanKind.INTERNAL,
             SpanCategory.APP_START,
+            SpanOptions.DEFAULTS.within(null)
         ).apply {
             setAttribute("bugsnag.app_start.type", startType.lowercase())
         }

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -7,6 +7,9 @@
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$5</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
+    <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100</ID>
+    <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$1000L</ID>
+    <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100L</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$100</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$250</ID>
     <ID>MagicNumber:BatchTimeoutScenario.kt$BatchTimeoutScenario$30</ID>
@@ -16,16 +19,14 @@
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
-    <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$1000L</ID>
+    <ID>MagicNumber:MazeRacerAlarmReceiver.kt$MazeRacerAlarmReceiver$250L</ID>
+    <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$2000L</ID>
     <ID>MagicNumber:OkhttpSpanScenario.kt$OkhttpSpanScenario$1000L</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$100</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$3</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$30</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$4</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$50</ID>
-    <ID>MagicNumber:RetryScenario.kt$RetryScenario$100</ID>
-    <ID>MagicNumber:RetryScenario.kt$RetryScenario$200</ID>
-    <ID>MagicNumber:RetryScenario.kt$RetryScenario$50L</ID>
     <ID>MagicNumber:SamplingProbabilityZeroScenario.kt$SamplingProbabilityZeroScenario$100</ID>
     <ID>MagicNumber:ThreeSpansScenario.kt$ThreeSpansScenario$300</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
+    <ID>MagicNumber:ActivityLoadInstrumentationScenario.kt$ActivityLoadInstrumentationScenario$5</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>

--- a/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
@@ -29,6 +29,11 @@
 
         <activity android:name=".ActivityViewLoadActivity"/>
         <activity android:name=".NestedSpansActivity"/>
+
+        <receiver
+            android:name=".MazeRacerAlarmReceiver"
+            android:exported="true"
+            />
     </application>
 
 </manifest>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.mazeracer
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.SpanOptions
+
+class MazeRacerAlarmReceiver : BroadcastReceiver() {
+    init {
+        Log.i("MazeRacer", "MazeRacerAlarmReceiver init")
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Log.i("MazeRacer", "MazeRacerAlarmReceiver.onReceive()")
+        BugsnagPerformance.startSpan("AlarmReceiver", SpanOptions.DEFAULTS.setFirstClass(true)).use {
+            Thread.sleep(250L)
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
@@ -2,6 +2,7 @@ package com.bugsnag.mazeracer
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.internal.InternalDebug
 
@@ -9,6 +10,7 @@ class MazeRacerApplication : Application() {
     init {
         instance = this
         BugsnagPerformance.reportApplicationClassLoaded()
+        Log.i("MazeRacer", "MazeRacerApplication static init")
     }
 
     companion object {
@@ -25,7 +27,7 @@ class MazeRacerApplication : Application() {
         // if there is stored "startup" config then we start BugsnagPerformance before the scenario
         // this is used to test things like app-start instrumentation
         readStartupConfig()?.let { config ->
-            InternalDebug.workerSleepMs = 1000L
+            InternalDebug.workerSleepMs = 2000L
             BugsnagPerformance.start(config)
         }
     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.mazeracer.scenarios
 
+import android.os.Build
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
@@ -12,7 +13,11 @@ class ActivityLoadInstrumentationScenario(
     scenarioMetadata: String
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = 2
+        InternalDebug.spanBatchSizeSendTriggerPoint = when {
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.Q -> 2
+            else -> 5
+        }
+
         config.autoInstrumentActivities =
             scenarioMetadata.takeIf { it.isNotBlank() }
             ?.let { AutoInstrument.valueOf(it) }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.mazeracer.scenarios
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.mazeracer.MazeRacerAlarmReceiver
+import com.bugsnag.mazeracer.Scenario
+import com.bugsnag.mazeracer.saveStartupConfig
+import kotlin.system.exitProcess
+
+class BackgroundAppStartScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+
+    override fun startScenario() {
+        config.autoInstrumentAppStarts = true
+        config.autoInstrumentActivities = AutoInstrument.FULL
+        context.saveStartupConfig(config)
+
+        // ask for the entire app to be woken up in 1 second, but with a broadcast (not activity)
+        val alarmService = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmService.set(
+            AlarmManager.ELAPSED_REALTIME_WAKEUP,
+            SystemClock.elapsedRealtime() + 1000L,
+            PendingIntent.getBroadcast(
+                context,
+                100,
+                Intent(context, MazeRacerAlarmReceiver::class.java),
+                PendingIntent.FLAG_IMMUTABLE,
+            ),
+        )
+
+        Thread.sleep(100L)
+        // quit the app to allow for a full restart
+        exitProcess(0)
+    }
+}

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -162,3 +162,12 @@ Feature: Automatic creation of spans
                | bugsnag.span.category   | stringValue | view_load                 |
                | bugsnag.view.type       | stringValue | fragment                  |
                | bugsnag.view.name       | stringValue | LoaderFragment            |
+
+    Scenario: AppStart/Cold is discarded for background starts
+      Given I run "BackgroundAppStartScenario"
+      And I wait for 1 span
+      * a span named "AlarmReceiver" contains the attributes:
+              | attribute                 | type        | value                     |
+              | bugsnag.span.first_class  | boolValue   | true                      |
+      # this is required here to avoid interfering with other scenarios
+      * I force stop the Android app

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -34,12 +34,12 @@ Feature: Automatic creation of spans
 
   Scenario: Activity with no automatic ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "OFF"
-    And I wait to receive a trace
-    Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+    And I wait to receive at least 1 trace
+    Then a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
+              | attribute               | type        | value                    |
+              | bugsnag.span.category   | stringValue | view_load                |
+              | bugsnag.view.type       | stringValue | fragment                 |
+              | bugsnag.view.name       | stringValue | LoaderFragment           |
 
   @skip_below_android_10
   Scenario: AppStart instrumentation

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -61,14 +61,14 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "app_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "view_load_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" is stored as the value "activity_start_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.spanId" is stored as the value "activity_resume_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.spanId" is stored as the value "custom_root_span_id"
 
     # view load span should be nested under AppStart
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.parentSpanId" equals the stored value "app_start_span_id"
 
     # view load phase spans (Create, Start, Resume) should be nested under ViewLoad
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "view_load_span_id"


### PR DESCRIPTION
## Goal
Avoid logging background AppStarts due to broadcasts or service starts that are not user perceivable by discarding any `AppStart` span that doesn't have a nested `Activity` start within a reasonable time limit.

## Changeset
This PR includes the following changes:

- A property rename from `platformCallbacks` to `activityCallbacks` for clarity
- A timeout of 1 second between the start of `AppStart` and the expected `onCreate` of the first `Activity` (after this the `AppStart` is discarded)
- A change to the `AppStart` options to that it never has a parent-span

## Testing
Added a new end-to-end scenario that uses the `AlarmManager` to trigger a broadcast to restart the app without starting an `Activity`.