### PR TITLE
Force test fixture to background to flush

### DIFF
--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -79,6 +79,16 @@ class MainActivity : AppCompatActivity() {
         log("MainActivity.onResume complete")
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == REQUEST_CODE_FINISH_ON_RETURN) {
+            Handler(Looper.getMainLooper()).post {
+                finish()
+            }
+        }
+    }
+
     private fun setMazeRunnerAddress() {
         val context = MazeRacerApplication.applicationContext()
         val externalFilesDir = context.getExternalFilesDir(null)
@@ -192,6 +202,7 @@ class MainActivity : AppCompatActivity() {
                             "invoke" -> {
                                 scenario!!::class.java.getMethod(scenarioName).invoke(scenario)
                             }
+
                             else -> throw IllegalArgumentException("Unknown action: $action")
                         }
                     }
@@ -301,4 +312,8 @@ class MainActivity : AppCompatActivity() {
 
     private val String.width
         get() = lineSequence().fold(0) { maxWidth, line -> kotlin.math.max(maxWidth, line.length) }
+
+    companion object {
+        const val REQUEST_CODE_FINISH_ON_RETURN = 9090
+    }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
@@ -1,15 +1,29 @@
 package com.bugsnag.mazeracer
 
-import android.content.Context
+import android.app.Activity
+import android.content.Intent
 import com.bugsnag.android.performance.PerformanceConfiguration
 
 abstract class Scenario(
     val config: PerformanceConfiguration,
     val scenarioMetadata: String,
 ) {
-    lateinit var context: Context
+    lateinit var context: Activity
 
     abstract fun startScenario()
+
+    /**
+     * Start the Activity specified by the given Intent, and then `finish()` the entire app
+     * once the given Activity closes (ie: wait until `intent` is "finished" before closing the
+     * MainActivity).
+     *
+     * This behaviour is useful in tests that need to flush auto-instrumented spans after the
+     * test is complete. The function causes the entire test fixture to be backgrounded which
+     * naturally triggers a batch flush (after any pending auto-instrumentation is completed).
+     */
+    fun startActivityAndFinish(intent: Intent) {
+        context.startActivityForResult(intent, MainActivity.REQUEST_CODE_FINISH_ON_RETURN)
+    }
 
     companion object Factory {
         fun load(

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
@@ -1,23 +1,16 @@
 package com.bugsnag.mazeracer.scenarios
 
-import android.os.Build
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
-import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.ActivityViewLoadActivity
 import com.bugsnag.mazeracer.Scenario
 
 class ActivityLoadInstrumentationScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = when {
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.Q -> 2
-            else -> 5
-        }
-
         config.autoInstrumentActivities =
             scenarioMetadata.takeIf { it.isNotBlank() }
             ?.let { AutoInstrument.valueOf(it) }
@@ -26,8 +19,11 @@ class ActivityLoadInstrumentationScenario(
 
     override fun startScenario() {
         BugsnagPerformance.start(config)
-        context.startActivity(
-            ActivityViewLoadActivity.intent(context, config.autoInstrumentActivities)
+        startActivityAndFinish(
+            ActivityViewLoadActivity.intent(
+                context,
+                config.autoInstrumentActivities,
+            ),
         )
     }
 }


### PR DESCRIPTION
## Goal
Improve the reliability of the ViewLoad auto instrumentation tests by controlling when the batch is flushed using the instrumentation directly.

## Design
Added a new function that will cause `MainActivity.finish()` when another selected `Activity` finishes (in this case the `ActivityViewLoadActivity` that we use for instrumentation testing).

By `finish`in the `MainActivity` the SDK will trigger a background-flush of the current span batch (after other instrumentation is completed).

## Testing
Instrumentation tests now pass more reliably.