### PR TITLE
Add `device.id` as a resource-level attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+* Report the `device.id` using to the same mechanism used by `bugsnag-android`
+  [#142](https://github.com/bugsnag/bugsnag-android-performance/pull/142)
+
 ## 1.6.0 (2023-06-13)
 
 ### Enhancements

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>ComplexMethod:Connectivity.kt$ConnectivityApi24$private fun nameForDataNetworkType(dataNetworkType: Int): String</ID>
     <ID>ComplexMethod:SpanOptions.kt$SpanOptions$override fun equals(other: Any?): Boolean</ID>
+    <ID>LongMethod:BugsnagPerformance.kt$BugsnagPerformance$private fun startUnderLock(configuration: ImmutableConfig)</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>
     <ID>MagicNumber:Encodings.kt$16</ID>
     <ID>MagicNumber:Encodings.kt$24</ID>
@@ -27,12 +28,14 @@
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: OverlappingFileLockException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Module.kt$Module.Loader$ex: Exception</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DefaultAttributeSource.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 internal class DefaultAttributeSource : AttributeSource {
     internal var currentDefaultAttributes = AtomicReference(
-        DefaultAttributes(NetworkType.UNKNOWN, null, isInForeground())
+        DefaultAttributes(NetworkType.UNKNOWN, null, isInForeground()),
     )
 
     /**
@@ -46,5 +46,5 @@ internal class DefaultAttributeSource : AttributeSource {
 internal data class DefaultAttributes(
     val networkType: NetworkType,
     val networkSubType: String?,
-    val isInForeground: Boolean?
+    val isInForeground: Boolean?,
 )

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
@@ -1,0 +1,149 @@
+package com.bugsnag.android.performance.internal
+
+
+import android.content.Context
+import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.Logger
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.util.UUID
+
+/**
+ * This class is responsible for persisting and retrieving a device ID to a file.
+ *
+ * This class is made multi-process safe through the use of a [FileLock], and thread safe
+ * through the use of a [ReadWriteLock] in [SynchronizedStreamableStore].
+ *
+ * This file mirrors the `DeviceIdFilePersistence` class in `bugsnag-android`.
+ */
+class DeviceIdFilePersistence(
+    private val file: File,
+    private val deviceIdGenerator: () -> UUID,
+) {
+
+    /**
+     * Loads the device ID from its file system location.
+     * If no value is present then a UUID will be generated and persisted.
+     */
+    fun loadDeviceId(requestCreateIfDoesNotExist: Boolean): String? {
+        return try {
+            // optimistically read device ID without a lock - the majority of the time
+            // the device ID will already be present so no synchronization is required.
+
+            loadDeviceIdInternal()
+                ?: return if (requestCreateIfDoesNotExist) persistNewDeviceUuid(deviceIdGenerator()) else null
+        } catch (exc: Throwable) {
+            Logger.w("Failed to load device ID", exc)
+            null
+        }
+    }
+
+    /**
+     * Loads the device ID from the file.
+     *
+     * If the file has zero length it can't contain device ID, so reading will be skipped.
+     */
+    private fun loadDeviceIdInternal(): String? {
+        if (file.length() > 0) {
+            try {
+                val obj = JSONObject(file.readText())
+                return obj.getString(KEY_ID)
+            } catch (exc: Throwable) {
+                // catch AssertionError which can be thrown by JsonReader
+                // on Android 8.0/8.1. see https://issuetracker.google.com/issues/79920590
+                Logger.w("Failed to load device ID", exc)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Write a new Device ID to the file.
+     */
+    private fun persistNewDeviceUuid(uuid: UUID): String? {
+        return try {
+            // acquire a FileLock to prevent Clients in different processes writing
+            // to the same file concurrently
+            file.outputStream().channel.use { channel ->
+                persistNewDeviceIdWithLock(channel, uuid)
+            }
+        } catch (exc: IOException) {
+            Logger.w("Failed to persist device ID", exc)
+            null
+        }
+    }
+
+    private fun persistNewDeviceIdWithLock(
+        channel: FileChannel,
+        uuid: UUID,
+    ): String? {
+        val lock = waitForFileLock(channel) ?: return null
+
+        return try {
+            // read the device ID again as it could have changed
+            // between the last read and when the lock was acquired
+
+            // the device ID may have changed between the last read
+            // and acquiring the lock, so return the generated value
+            loadDeviceIdInternal() ?: persistDeviceIdUnderLock(uuid, channel)
+        } finally {
+            lock.release()
+        }
+    }
+
+    private fun persistDeviceIdUnderLock(uuid: UUID, channel: FileChannel): String {
+        val id = uuid.toString()
+        val json = JSONObject()
+        json.put(KEY_ID, id)
+        channel.write(ByteBuffer.wrap(json.toString().toByteArray()))
+        return id
+    }
+
+    /**
+     * Attempt to acquire a file lock. If [OverlappingFileLockException] is thrown
+     * then the method will wait for 50ms then try again, for a maximum of 10 attempts.
+     */
+    private fun waitForFileLock(channel: FileChannel): FileLock? {
+        repeat(MAX_FILE_LOCK_ATTEMPTS) {
+            try {
+                return channel.tryLock()
+            } catch (exc: OverlappingFileLockException) {
+                Thread.sleep(FILE_LOCK_WAIT_MS)
+            }
+        }
+        return null
+    }
+
+    companion object {
+        private const val MAX_FILE_LOCK_ATTEMPTS = 20
+        private const val FILE_LOCK_WAIT_MS = 25L
+        private const val KEY_ID = "id"
+
+        fun forContext(context: Context) = DeviceIdFilePersistence(
+            File(context.filesDir, "device-id"),
+            UUID::randomUUID,
+        )
+    }
+}
+
+/**
+ * Load the device.id into a given [DefaultAttributeSource], this is a `Runnable` so that it can
+ * be used as a [Worker] startup task.
+ */
+internal class LoadDeviceId(
+    private val context: Context,
+    private val resourceAttributes: Attributes,
+) : Runnable {
+    override fun run() {
+        val deviceIdFilePersistence = DeviceIdFilePersistence.forContext(context)
+        val deviceId = deviceIdFilePersistence.loadDeviceId(true)
+
+        // no synchronization required as all startup tasks are run on the worker thread
+        resourceAttributes["device.id"] = deviceId
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
@@ -22,7 +22,7 @@ class WorkerTest {
     fun testWaitAndWake() {
         val count1 = CountingTask(1)
         val count2 = CountingTask(5)
-        val worker = Worker(count1, count2)
+        val worker = Worker(emptyList(), listOf(count1, count2))
 
         worker.start()
         try {
@@ -40,7 +40,7 @@ class WorkerTest {
     fun testWaitAndAwake() {
         val count1 = CountingTask(1)
         val count2 = CountingTask(5)
-        val worker = Worker(count1, count2)
+        val worker = Worker(emptyList(), listOf(count1, count2))
 
         worker.start()
         try {
@@ -70,17 +70,20 @@ class WorkerTest {
     fun testExceptionHandling() {
         val latch = CountDownLatch(1)
         val worker = Worker(
-            object : Task {
-                override fun execute(): Boolean {
-                    throw NullPointerException()
-                }
-            },
-            object : Task {
-                override fun execute(): Boolean {
-                    latch.countDown()
-                    return false
-                }
-            },
+            emptyList(),
+            listOf(
+                object : Task {
+                    override fun execute(): Boolean {
+                        throw NullPointerException()
+                    }
+                },
+                object : Task {
+                    override fun execute(): Boolean {
+                        latch.countDown()
+                        return false
+                    }
+                },
+            ),
         )
 
         // this test succeeds if the latch releases, as it means that the exception in the first

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -30,6 +30,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals "linux"
     * the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals "android"
     * the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" is one of:


### PR DESCRIPTION
## Goal
Report an app-unique `device.id` as a resource level attribute. Where possible it should be the same as `bugsnag-android` will report.

## Changeset
Introduced the `DeviceIdFilePersistence` largely mirrored from `bugsnag-android` which runs 

## Testing
Added a check for the attribute on an existing end-to-end test. Manually tested `bugsnag-android` & `bugsnag-android-performance` reporting the same ID in a single app.