### PR TITLE
Restructured ViewLoadPhase spans to use SpanFactory

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -207,24 +207,13 @@ class PerformanceLifecycleCallbacks internal constructor(
         val viewLoadSpan = spanTracker[activity]
         if (openLoadSpans && viewLoadSpan != null) {
             spanTracker.associate(activity, phase) {
-                spanFactory.createCustomSpan(
-                    spanNameForPhase(activity, phase),
-                    SpanOptions.DEFAULTS.within(viewLoadSpan),
-                ).apply {
-                    setAttribute("bugsnag.span.category", "view_load_phase")
-                    setAttribute("bugsnag.view.name", activity::class.java.simpleName)
-                    setAttribute("bugsnag.phase", phase.phaseName)
-                }
+                spanFactory.createViewLoadPhaseSpan(activity, phase, viewLoadSpan)
             }
         }
     }
 
     private fun endViewLoadPhase(activity: Activity, phase: ViewLoadPhase) {
         spanTracker.endSpan(activity, phase)
-    }
-
-    private fun spanNameForPhase(activity: Activity, phase: ViewLoadPhase): String {
-        return "[ViewLoadPhase/${phase.phaseName}]${activity::class.java.simpleName}"
     }
 
     override fun onActivityPaused(activity: Activity) = Unit

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.performance.internal
 enum class SpanCategory(val category: String?) {
     CUSTOM(null),
     VIEW_LOAD("view_load"),
+    VIEW_LOAD_PHASE("view_load_phase"),
     NETWORK("network"),
     APP_START("app_start"),
 }


### PR DESCRIPTION
## Goal
Normalise the creation of ViewLoadPhase spans by adding a new function to `SpanFactory` instead of using `createCustomSpan`.

## Testing
Relied on existing tests