### PR TITLE
General Span cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Report the `device.id` using to the same mechanism used by `bugsnag-android`
   [#142](https://github.com/bugsnag/bugsnag-android-performance/pull/142)
 
+### Bug fixes
+
+* Activities that call finish() from onCreate() will no longer leak ViewLoad spans
+  [#144](https://github.com/bugsnag/bugsnag-android-performance/pull/144)
+
 ## 1.6.0 (2023-06-13)
 
 ### Enhancements

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -91,6 +91,8 @@ object BugsnagPerformance {
         if (configuration.autoInstrumentAppStarts) {
             // mark the app as "starting" (if it isn't already)
             reportApplicationClassLoaded()
+        } else {
+            instrumentedAppState.activityCallbacks.discardAppStart()
         }
 
         val application = configuration.application

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -8,7 +8,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import com.bugsnag.android.performance.Logger
-import com.bugsnag.android.performance.SpanOptions
 import kotlin.math.max
 
 typealias InForegroundCallback = (inForeground: Boolean) -> Unit
@@ -77,10 +76,12 @@ class PerformanceLifecycleCallbacks internal constructor(
     }
 
     override fun onActivityPreStarted(activity: Activity) {
+        endViewLoadPhase(activity, ViewLoadPhase.CREATE)
         startViewLoadPhase(activity, ViewLoadPhase.START)
     }
 
     override fun onActivityPreResumed(activity: Activity) {
+        endViewLoadPhase(activity, ViewLoadPhase.START)
         startViewLoadPhase(activity, ViewLoadPhase.RESUME)
     }
 
@@ -105,6 +106,21 @@ class PerformanceLifecycleCallbacks internal constructor(
             handler.sendEmptyMessageDelayed(MSG_SEND_BACKGROUND, BACKGROUND_TIMEOUT_MS)
         }
 
+        handleViewLoadLeak(activity)
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // make sure we never drop below 0, this can happen if BugsnagPerformance.start was
+        // called *after* the first Activity was started
+        activityInstanceCount = max(0, activityInstanceCount - 1)
+
+        // while leak detection usually triggers in onActivityStopped, if an Activity calls finish()
+        // from it's onCreate method then it is never started (and so never gets stopped), we handle
+        // those cases from here
+        handleViewLoadLeak(activity)
+    }
+
+    private fun handleViewLoadLeak(activity: Activity) {
         if (spanTracker.markSpanLeaked(activity)) {
             Logger.w(
                 "${activity::class.java.name} appears to have leaked a ViewLoad Span. " +
@@ -113,28 +129,12 @@ class PerformanceLifecycleCallbacks internal constructor(
         }
     }
 
-    override fun onActivityDestroyed(activity: Activity) {
-        // make sure we never drop below 0, this can happen if BugsnagPerformance.start was
-        // called *after* the first Activity was started
-        activityInstanceCount = max(0, activityInstanceCount - 1)
-    }
-
     override fun handleMessage(msg: Message): Boolean {
         when (msg.what) {
-            MSG_SEND_BACKGROUND -> {
-                inForegroundCallback(false)
-                backgroundSent = true
-                appStartSpan = null
-            }
-
-            MSG_APP_CLASS_COMPLETE -> {
-                handler.sendEmptyMessageDelayed(MSG_DISCARD_APP_START, APP_START_TIMEOUT_MS)
-            }
-
-            MSG_DISCARD_APP_START -> {
-                // this means we timed out waiting for an Activity to be started
-                appStartSpan = null
-            }
+            MSG_SEND_BACKGROUND -> sendBackgroundCallback()
+            MSG_APP_CLASS_COMPLETE -> onApplicationPostCreated()
+            MSG_CHECK_FINISHED -> (msg.obj as? Activity)?.let { checkActivityFinished(it) }
+            MSG_DISCARD_APP_START -> discardAppStart()
 
             else -> return false
         }
@@ -142,11 +142,32 @@ class PerformanceLifecycleCallbacks internal constructor(
         return true
     }
 
+    private fun checkActivityFinished(activity: Activity) {
+        if (activity.isFinishing) {
+            endViewLoad(activity)
+        }
+    }
+
+    private fun onApplicationPostCreated() {
+        handler.sendEmptyMessageDelayed(MSG_DISCARD_APP_START, APP_START_TIMEOUT_MS)
+    }
+
+    private fun sendBackgroundCallback() {
+        inForegroundCallback(false)
+        backgroundSent = true
+        discardAppStart()
+    }
+
     fun startAppLoadSpan(startType: String) {
         if (appStartSpan == null && instrumentAppStart) {
             appStartSpan = spanFactory.createAppStartSpan(startType)
             handler.sendEmptyMessageDelayed(MSG_APP_CLASS_COMPLETE, 1)
         }
+    }
+
+    fun discardAppStart() {
+        appStartSpan?.discard()
+        appStartSpan = null
     }
 
     private fun maybeStartAppLoad(savedInstanceState: Bundle?) {
@@ -185,6 +206,8 @@ class PerformanceLifecycleCallbacks internal constructor(
                 spanTracker.associate(activity) {
                     spanFactory.createViewLoadSpan(activity)
                 }
+
+                handler.sendMessage(handler.obtainMessage(MSG_CHECK_FINISHED, activity))
             }
         } finally {
             activityInstanceCount++
@@ -193,7 +216,8 @@ class PerformanceLifecycleCallbacks internal constructor(
 
     private fun endViewLoad(activity: Activity) {
         if (closeLoadSpans) {
-            spanTracker.endSpan(activity)
+            // close any pending spans associated with the Activity
+            spanTracker.endAllSpans(activity)
         } else {
             spanTracker.markSpanAutomaticEnd(activity)
         }
@@ -236,6 +260,15 @@ class PerformanceLifecycleCallbacks internal constructor(
          * `removeMessages(MSG_DISCARD_APP_START)`.
          */
         private const val MSG_DISCARD_APP_START = 3
+
+        /**
+         * Message ID used to check whether an Activity is finishing or has been finished at a
+         * time we cannot otherwise detect (for example when running on <Q devices we have no
+         * onActivityPostCreated hook). The [Message.obj] is expected to be the Activity to check,
+         * and if it is finished or finishing all of it's associated ViewLoad / ViewLoadPhase
+         * spans will be closed.
+         */
+        private const val MSG_CHECK_FINISHED = 4
 
         /**
          * Same as `androidx.lifecycle.ProcessLifecycleOwner` and is used to avoid reporting

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -265,7 +265,7 @@ class PerformanceLifecycleCallbacks internal constructor(
          * Message ID used to check whether an Activity is finishing or has been finished at a
          * time we cannot otherwise detect (for example when running on <Q devices we have no
          * onActivityPostCreated hook). The [Message.obj] is expected to be the Activity to check,
-         * and if it is finished or finishing all of it's associated ViewLoad / ViewLoadPhase
+         * and if it is finished or finishing all of its associated ViewLoad / ViewLoadPhase
          * spans will be closed.
          */
         private const val MSG_CHECK_FINISHED = 4

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -104,21 +104,19 @@ class PerformanceLifecycleCallbacks internal constructor(
             backgroundSent = false
             handler.sendEmptyMessageDelayed(MSG_SEND_BACKGROUND, BACKGROUND_TIMEOUT_MS)
         }
+
+        if (spanTracker.markSpanLeaked(activity)) {
+            Logger.w(
+                "${activity::class.java.name} appears to have leaked a ViewLoad Span. " +
+                        "This is probably because BugsnagPerformance.endViewLoad was not called.",
+            )
+        }
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        try {
-            if (spanTracker.markSpanLeaked(activity)) {
-                Logger.w(
-                    "${activity::class.java.name} appears to have leaked a ViewLoad Span. " +
-                        "This is probably because BugsnagPerformance.endViewLoad was not called.",
-                )
-            }
-        } finally {
-            // make sure we never drop below 0, this can happen if BugsnagPerformance.start was
-            // called *after* the first Activity was started
-            activityInstanceCount = max(0, activityInstanceCount - 1)
-        }
+        // make sure we never drop below 0, this can happen if BugsnagPerformance.start was
+        // called *after* the first Activity was started
+        activityInstanceCount = max(0, activityInstanceCount - 1)
     }
 
     override fun handleMessage(msg: Message): Boolean {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -123,5 +123,5 @@ class SpanFactory(
         return span
     }
 
-    private fun UUID.isValidTraceId() = mostSignificantBits != 0L && leastSignificantBits != 0L
+    private fun UUID.isValidTraceId() = mostSignificantBits != 0L || leastSignificantBits != 0L
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -67,13 +67,7 @@ class SpanImpl internal constructor(
 
     init {
         category.category?.let { attributes["bugsnag.span.category"] = it }
-
-        // Our "random" sampling value is actually derived from the traceId
-        val msw = traceId.mostSignificantBits ushr 1
-        samplingValue = when (msw) {
-            0L -> 0.0
-            else -> msw.toDouble() / Long.MAX_VALUE.toDouble()
-        }
+        samplingValue = samplingValueFor(traceId)
 
         // Starting a Span should cause it to become the current context
         if (makeContext) SpanContext.attach(this)
@@ -174,6 +168,14 @@ class SpanImpl internal constructor(
                 id = spanIdRandom.nextLong()
             } while (id == INVALID_ID)
             return id
+        }
+
+        // Our "random" sampling value is actually derived from the traceId
+        private fun samplingValueFor(traceId: UUID): Double {
+            return when (val msw = traceId.mostSignificantBits ushr 1) {
+                0L -> 0.0
+                else -> msw.toDouble() / Long.MAX_VALUE.toDouble()
+            }
         }
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -80,6 +80,16 @@ class SpanImpl internal constructor(
         }
     }
 
+    /**
+     * Deliberately discard this `SpanImpl`. This will mark the span as ended, but not record
+     * a valid end time. It will also (if required) detach the Span from the SpanContext
+     */
+    fun discard() {
+        if (END_TIME_UPDATER.compareAndSet(this, NO_END_TIME, DISCARDED)) {
+            if (makeContext) SpanContext.detach(this)
+        }
+    }
+
     override fun end() = end(SystemClock.elapsedRealtimeNanos())
 
     override fun isEnded() = endTime != NO_END_TIME
@@ -104,7 +114,6 @@ class SpanImpl internal constructor(
             }
         }
     }
-
 
     override fun toString(): String {
         return buildString {
@@ -159,6 +168,7 @@ class SpanImpl internal constructor(
         private const val INVALID_ID = 0L
 
         const val NO_END_TIME = -1L
+        const val DISCARDED = -2L
 
         private val spanIdRandom = Random(SecureRandom().nextLong())
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -78,6 +78,13 @@ class SpanTracker {
         }
     }
 
+    fun removeAllAssociations(tag: Any?): Collection<SpanImpl> {
+        return lock.write {
+            val associatedSpans = backingStore.remove(tag)
+            associatedSpans?.values?.map { it.span } ?: emptyList<SpanImpl>()
+        }
+    }
+
     /**
      * Mark when a `Span` would have been ended automatically. *If* the associated `Span` is later
      * marked as [leaked](markSpanLeaked) then its `endTime` will be set to [autoEndTime]. Otherwise
@@ -124,10 +131,24 @@ class SpanTracker {
         }
     }
 
+    /**
+     * End all spans associated with the given `token` or any `subToken`s. This will attempt to
+     * use autoEndTimes where they are available, but will otherwise fallback to using [endTime]
+     * for each of the spans that get closed.
+     */
+    fun endAllSpans(token: Any, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
+        lock.write {
+            val associatedSpans = backingStore[token]
+            associatedSpans?.values?.forEach { it.markLeaked(endTime) }
+
+            backingStore.remove(token)
+        }
+    }
+
     private class SpanBinding(val span: SpanImpl) {
         var autoEndTime: Long = NO_END_TIME
 
-        fun markLeaked(): Boolean {
+        fun markLeaked(fallbackEndTime: Long = SystemClock.elapsedRealtimeNanos()): Boolean {
             // this span has not leaked, ignore and return
             if (span.endTime != NO_END_TIME) {
                 return false
@@ -136,7 +157,7 @@ class SpanTracker {
             if (autoEndTime != NO_END_TIME) {
                 span.end(autoEndTime)
             } else {
-                span.end()
+                span.end(fallbackEndTime)
             }
 
             return true

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -78,17 +78,10 @@ class SpanTracker {
         }
     }
 
-    fun removeAllAssociations(tag: Any?): Collection<SpanImpl> {
-        return lock.write {
-            val associatedSpans = backingStore.remove(tag)
-            associatedSpans?.values?.map { it.span } ?: emptyList<SpanImpl>()
-        }
-    }
-
     /**
      * Mark when a `Span` would have been ended automatically. *If* the associated `Span` is later
-     * marked as [leaked](markSpanLeaked) then its `endTime` will be set to [autoEndTime]. Otherwise
-     * this value will be discarded.
+     * marked as [leaked](markSpanLeaked) then its `endTime` will be set to the time that this
+     * function was last called. Otherwise this value will be discarded.
      */
     fun markSpanAutomaticEnd(token: Any, subToken: Enum<*>? = null) {
         backingStore[token]?.get(subToken)?.autoEndTime = SystemClock.elapsedRealtimeNanos()

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -246,6 +246,7 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals(3, spanProcessor.toList().size)
 
         // end view load span
+        callbacks.onActivityStopped(activity)
         callbacks.onActivityDestroyed(activity)
 
         val spans = spanProcessor.toList()

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacksTest.kt
@@ -99,8 +99,6 @@ class PerformanceLifecycleCallbacksTest {
         SystemClock.setCurrentTimeMillis(300L)
         callbacks.onActivityPaused(activity)
         callbacks.onActivityStopped(activity)
-        SystemClock.setCurrentTimeMillis(400L)
-        callbacks.onActivityDestroyed(activity)
 
         val spans = spanProcessor.toList()
         assertEquals(1, spans.size)
@@ -109,6 +107,40 @@ class PerformanceLifecycleCallbacksTest {
         assertEquals("[ViewLoad/Activity]Activity", span.name)
         assertEquals(100_000_000L, span.startTime)
         assertEquals(200_000_000L, span.endTime)
+        assertEquals(SpanKind.INTERNAL, span.kind)
+        assertTrue(span.isEnded())
+    }
+
+    @Test
+    fun startOnlyActivityTrackingWithLeak_CreateAndDestroy() {
+        // this is actually the default initial value for Robolectric, but we set it manually
+        // just as a form of documentation
+        SystemClock.setCurrentTimeMillis(100L)
+
+        val callbacks = PerformanceLifecycleCallbacks(
+            spanTracker = spanTracker,
+            spanFactory = spanFactory,
+            inForegroundCallback = {},
+        ).apply {
+            openLoadSpans = true
+            closeLoadSpans = false
+            instrumentAppStart = false
+        }
+
+        callbacks.onActivityCreated(activity, null)
+        assertEquals(0, spanProcessor.toList().size)
+
+        // the Activity has called finish() from onCreate
+        SystemClock.setCurrentTimeMillis(300L)
+        callbacks.onActivityDestroyed(activity)
+
+        val spans = spanProcessor.toList()
+        assertEquals(1, spans.size)
+
+        val span = spans.first()
+        assertEquals("[ViewLoad/Activity]Activity", span.name)
+        assertEquals(100_000_000L, span.startTime)
+        assertEquals(300_000_000L, span.endTime)
         assertEquals(SpanKind.INTERNAL, span.kind)
         assertTrue(span.isEnded())
     }
@@ -245,9 +277,8 @@ class PerformanceLifecycleCallbacksTest {
         // the parent view load span is still open
         assertEquals(3, spanProcessor.toList().size)
 
-        // end view load span
+        // end view load span (using the leak detection)
         callbacks.onActivityStopped(activity)
-        callbacks.onActivityDestroyed(activity)
 
         val spans = spanProcessor.toList()
         assertEquals(4, spans.size)

--- a/examples/performance-example/app/src/main/java/com/example/bugsnag/performance/MainActivity.kt
+++ b/examples/performance-example/app/src/main/java/com/example/bugsnag/performance/MainActivity.kt
@@ -7,7 +7,6 @@ import android.os.Looper
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.bugsnag.android.performance.BugsnagPerformance
-import kotlin.random.Random
 
 class MainActivity : AppCompatActivity() {
     private val network = ExampleNetworkCalls(this)

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -2,7 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>MagicNumber:ActivityLoadInstrumentationScenario.kt$ActivityLoadInstrumentationScenario$5</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
@@ -19,6 +18,7 @@
     <ID>MagicNumber:DisabledReleaseStageScenario.kt$DisabledReleaseStageScenario$500L</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
+    <ID>MagicNumber:MainActivity.kt$MainActivity$250L</ID>
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerAlarmReceiver.kt$MazeRacerAlarmReceiver$250L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$2000L</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
@@ -42,7 +42,7 @@ class ActivityViewLoadActivity : AppCompatActivity() {
 
         handler.postDelayed(
             {
-                if (autoInstrument != AutoInstrument.FULL) {
+                if (intent.getBooleanExtra(END_VIEW_LOAD_SPAN, false)) {
                     BugsnagPerformance.endViewLoadSpan(this)
                 }
 
@@ -64,10 +64,16 @@ class ActivityViewLoadActivity : AppCompatActivity() {
 
     companion object {
         const val AUTO_INSTRUMENT_EXTRA = "com.bugsnag.android.performance.extra.autoInstrument"
+        const val END_VIEW_LOAD_SPAN = "com.bugsnag.android.performance.extra.endViewLoadSpan"
 
-        fun intent(context: Context, autoInstrument: AutoInstrument): Intent {
+        fun intent(
+            context: Context,
+            autoInstrument: AutoInstrument,
+            endViewLoadSpan: Boolean = autoInstrument != AutoInstrument.FULL,
+        ): Intent {
             return Intent(context, ActivityViewLoadActivity::class.java)
                 .putExtra(AUTO_INSTRUMENT_EXTRA, autoInstrument.name)
+                .putExtra(END_VIEW_LOAD_SPAN, endViewLoadSpan)
         }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/DebugLogger.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/DebugLogger.kt
@@ -1,0 +1,41 @@
+package com.bugsnag.mazeracer
+
+import android.util.Log
+import com.bugsnag.android.performance.Logger
+
+object DebugLogger : Logger {
+
+    private const val TAG = "Bugsnag"
+
+    override fun e(msg: String) {
+        Log.e(TAG, msg)
+    }
+
+    override fun e(msg: String, throwable: Throwable) {
+        Log.e(TAG, msg, throwable)
+    }
+
+    override fun w(msg: String) {
+        Log.w(TAG, msg)
+    }
+
+    override fun w(msg: String, throwable: Throwable) {
+        Log.w(TAG, msg, throwable)
+    }
+
+    override fun i(msg: String) {
+        Log.i(TAG, msg)
+    }
+
+    override fun i(msg: String, throwable: Throwable) {
+        Log.i(TAG, msg, throwable)
+    }
+
+    override fun d(msg: String) {
+        Log.d(TAG, msg)
+    }
+
+    override fun d(msg: String, throwable: Throwable) {
+        Log.d(TAG, msg, throwable)
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -262,6 +262,7 @@ class MainActivity : AppCompatActivity() {
             config.endpoint = endpoint
             config.autoInstrumentAppStarts = false
             config.autoInstrumentActivities = AutoInstrument.OFF
+            config.logger = DebugLogger
         }
     }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -84,9 +84,7 @@ class MainActivity : AppCompatActivity() {
 
         if (requestCode == REQUEST_CODE_FINISH_ON_RETURN) {
             log("Activity requested shutdown of the test fixture - will call finish()")
-            Handler(Looper.getMainLooper()).post {
-                finish()
-            }
+            Handler(Looper.getMainLooper()).postDelayed({ finish() }, 250L)
         }
     }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -83,6 +83,7 @@ class MainActivity : AppCompatActivity() {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == REQUEST_CODE_FINISH_ON_RETURN) {
+            log("Activity requested shutdown of the test fixture - will call finish()")
             Handler(Looper.getMainLooper()).post {
                 finish()
             }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ViewLoadLeakScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ViewLoadLeakScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.mazeracer.scenarios
+
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.mazeracer.ActivityViewLoadActivity
+import com.bugsnag.mazeracer.Scenario
+
+class ViewLoadLeakScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    override fun startScenario() {
+        BugsnagPerformance.start(config)
+        startActivityAndFinish(
+            ActivityViewLoadActivity.intent(
+                context,
+                config.autoInstrumentActivities,
+                endViewLoadSpan = false
+            ),
+        )
+    }
+}

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -174,7 +174,7 @@ Feature: Automatic creation of spans
 
     Scenario: ViewLoad spans can be safely leaked
       Given I run "ViewLoadLeakScenario"
-      And I wait for 1 span
+      And I wait to receive a trace
       Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
         | attribute               | type        | value                    |
         | bugsnag.span.category   | stringValue | view_load                |

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -171,3 +171,12 @@ Feature: Automatic creation of spans
               | bugsnag.span.first_class  | boolValue   | true                      |
       # this is required here to avoid interfering with other scenarios
       * I force stop the Android app
+
+    Scenario: ViewLoad spans can be safely leaked
+      Given I run "ViewLoadLeakScenario"
+      And I wait for 1 span
+      Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
+        | attribute               | type        | value                    |
+        | bugsnag.span.category   | stringValue | view_load                |
+        | bugsnag.view.type       | stringValue | activity                 |
+        | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |


### PR DESCRIPTION
## Goal
Generally cleanup some of the Span creation & tracking to reduce the possibility of bugs or edge cases.

## Changeset

- `Activity` associated `ViewLoad` spans are now considered "leaked" if `onStop` is called before they are ended
- The trace id validity check in `SpanFactory` has been fixed to only consider `0` as invalid
- `SpanImpl` objects can be formally "discarded" (marking them as ended without enqueuing them) which helps ensure that they don't leak
- `Activity` lifecycle is now tracked more effectively
  - calls to `finish()` in `onCreate` no longer leak ViewLoad spans
  - each ViewLoadPhase will ensure it's predecessor is closed

## Testing
- Added an end-to-end test for the ViewLoad span leaking behavior.