### PR TITLE
Allow apiKey + enabledReleaseStages to be configured in Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * *Breaking change*: removed the `samplingProbability` configuration option
   [#149](https://github.com/bugsnag/bugsnag-android-performance/pull/149)
 
+### Enhancements
+
+* ApiKey can be read from "com.bugsnag.performance.android.API_KEY" so that `bugsnag-android` and `bugsnag-android-performance` can have different ApiKeys in the manifest.
+  [#152](https://github.com/bugsnag/bugsnag-android-performance/pull/152)
+
 ### Bug fixes
 
 * More reliably report the response Content-Length of HTTP requests

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.performance
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
-import androidx.annotation.FloatRange
 import androidx.annotation.VisibleForTesting
 
 class PerformanceConfiguration private constructor(val context: Context) {
@@ -32,37 +31,40 @@ class PerformanceConfiguration private constructor(val context: Context) {
 
     override fun toString(): String =
         "PerformanceConfiguration(" +
-            "context=$context, " +
-            "apiKey=$apiKey, " +
-            "endpoint='$endpoint', " +
-            "autoInstrumentAppStarts=$autoInstrumentAppStarts, " +
-            "autoInstrumentActivities=$autoInstrumentActivities, " +
-            "releaseStage=$releaseStage, " +
-            "versionCode=$versionCode, " +
-            "appVersion=$appVersion, " +
-            "enabledReleaseStages=$enabledReleaseStages " +
-            ")"
+                "context=$context, " +
+                "apiKey=$apiKey, " +
+                "endpoint='$endpoint', " +
+                "autoInstrumentAppStarts=$autoInstrumentAppStarts, " +
+                "autoInstrumentActivities=$autoInstrumentActivities, " +
+                "releaseStage=$releaseStage, " +
+                "versionCode=$versionCode, " +
+                "appVersion=$appVersion, " +
+                "enabledReleaseStages=$enabledReleaseStages " +
+                ")"
 
     companion object Loader {
 
         // mandatory
         private const val BUGSNAG_NS = "com.bugsnag.android"
         private const val BUGSNAG_PERF_NS = "com.bugsnag.performance.android"
-        private const val API_KEY = "$BUGSNAG_NS.API_KEY"
 
+        private const val API_KEY = "$BUGSNAG_PERF_NS.API_KEY"
         private const val ENDPOINT_KEY = "$BUGSNAG_PERF_NS.ENDPOINT"
         private const val AUTO_INSTRUMENT_APP_STARTS_KEY =
             "$BUGSNAG_PERF_NS.AUTO_INSTRUMENT_APP_STARTS"
         private const val AUTO_INSTRUMENT_ACTIVITIES_KEY =
             "$BUGSNAG_PERF_NS.AUTO_INSTRUMENT_ACTIVITIES"
         private const val RELEASE_STAGE_KEY = "$BUGSNAG_PERF_NS.RELEASE_STAGE"
+        private const val ENABLED_RELEASE_STAGES = "$BUGSNAG_PERF_NS.ENABLED_RELEASE_STAGES"
         private const val VERSION_CODE_KEY = "$BUGSNAG_PERF_NS.VERSION_CODE"
         private const val APP_VERSION_KEY = "$BUGSNAG_PERF_NS.APP_VERSION"
 
         // Bugsnag Notifier keys that we can read
+        private const val BSG_API_KEY = "$BUGSNAG_NS.API_KEY"
         private const val BSG_RELEASE_STAGE_KEY = "$BUGSNAG_NS.RELEASE_STAGE"
         private const val BSG_VERSION_CODE_KEY = "$BUGSNAG_NS.VERSION_CODE"
         private const val BSG_APP_VERSION_KEY = "$BUGSNAG_NS.APP_VERSION"
+        private const val BSG_ENABLED_RELEASE_STAGES = "$BUGSNAG_NS.ENABLED_RELEASE_STAGES"
 
         @JvmStatic
         @JvmOverloads
@@ -88,7 +90,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
             apiKeyOverride: String?,
         ): PerformanceConfiguration {
             return PerformanceConfiguration(ctx).apply {
-                (apiKeyOverride ?: data?.getString(API_KEY))
+                (apiKeyOverride ?: data?.getString(API_KEY, data.getString(BSG_API_KEY)))
                     ?.also { apiKey = it }
 
                 data?.getString(ENDPOINT_KEY)
@@ -98,8 +100,11 @@ class PerformanceConfiguration private constructor(val context: Context) {
                 data?.getString(AUTO_INSTRUMENT_ACTIVITIES_KEY)
                     ?.also { autoInstrumentActivities = AutoInstrument.valueOf(it) }
 
+                // releaseStage / enabledReleaseStage
                 data?.getString(RELEASE_STAGE_KEY, data.getString(BSG_RELEASE_STAGE_KEY))
                     ?.also { releaseStage = it }
+                data?.getString(ENABLED_RELEASE_STAGES, data.getString(BSG_ENABLED_RELEASE_STAGES))
+                    ?.also { enabledReleaseStages = it.splitToSequence(',').toSet() }
 
                 if (data?.containsKey(VERSION_CODE_KEY) == true) {
                     versionCode = data.getInt(VERSION_CODE_KEY).toLong()


### PR DESCRIPTION
## Goal
Allow `apiKey` and `enabledReleaseStages` to be configured in the manifest file, separately to the options used by `bugsnag-android`.

## Testing
New unit tests for both namespaces, and the overrides