### PR TITLE
Moved the end of AppStart spans to the end of the first ViewLoad span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * ApiKey can be read from "com.bugsnag.performance.android.API_KEY" so that `bugsnag-android` and `bugsnag-android-performance` can have different ApiKeys in the manifest.
   [#152](https://github.com/bugsnag/bugsnag-android-performance/pull/152)
+* AppStart spans now end strictly when the first ViewLoad ends, allowing manual control of the AppStart end (when combined with `PerformanceConfiguration.autoInstrumentActivities`)
+  [#154](https://github.com/bugsnag/bugsnag-android-performance/pull/154)
 
 ### Bug fixes
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -232,9 +232,7 @@ object BugsnagPerformance {
         options: SpanOptions = SpanOptions.DEFAULTS,
     ): Span {
         // create & track Activity referenced ViewLoad spans
-        return instrumentedAppState.spanTracker.associate(activity) {
-            spanFactory.createViewLoadSpan(activity, options)
-        }
+        return instrumentedAppState.activityCallbacks.startViewLoadSpan(activity, options)
     }
 
     /**

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -61,14 +61,18 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "app_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.endTimeUnixNano" is stored as the value "app_start_end_time"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "view_load_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" is stored as the value "activity_start_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.spanId" is stored as the value "activity_resume_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.spanId" is stored as the value "custom_root_span_id"
 
+    # ViewLoad & AppStart should have identical end times
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.endTimeUnixNano" equals the stored value "app_start_end_time"
+
     # view load span should be nested under AppStart
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.parentSpanId" equals the stored value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "app_start_span_id"
 
     # view load phase spans (Create, Start, Resume) should be nested under ViewLoad
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "view_load_span_id"


### PR DESCRIPTION
## Goal
The `AppStart` span should be ended when the first `ViewLoad` span is ended.

## Design
We only track this against `ViewLoad` spans associated with `Activity` objects, as these are the only `ViewLoad` spans we can reasonably track against `AppStart` without risking leaking the `AppStart` spans.

## Testing
Modified the end-to-end tests to check the span end times.