### PR TITLE
Fragment ViewLoads should not nest unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Fragments added in the same FragmentTransaction won't unexpectedly nest their ViewLoad spans
+  [#159](https://github.com/bugsnag/bugsnag-android-performance/pull/159)
+
 ## 0.1.8 (2023-06-26)
 
 ### Changes

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
@@ -47,13 +47,11 @@ interface SpanContext {
         }
 
         @get:JvmSynthetic
-        internal val contextStack: Deque<SpanContext>
+        internal var contextStack: Deque<SpanContext>
             get() = threadLocalStorage.get() as Deque<SpanContext>
-
-        @JvmSynthetic
-        internal fun setContextStackUnsafe(stack: Deque<SpanContext>)  {
-            threadLocalStorage.set(stack)
-        }
+            set(value) {
+                threadLocalStorage.set(value)
+            }
 
         /**
          * Retrieve the current [SpanContext] for this thread (or [invalid] if not available).
@@ -100,7 +98,7 @@ interface SpanContext {
         }
 
         private fun removeClosedContexts() {
-            while((contextStack.peekFirst() as? Span)?.isEnded() == true) {
+            while ((contextStack.peekFirst() as? Span)?.isEnded() == true) {
                 contextStack.pollFirst()
             }
         }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
@@ -1,15 +1,7 @@
 package com.bugsnag.android.performance.internal
 
+import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.SpanContext
-
-/**
- * Allows getting/setting the Span Context stack for the current thread.
- *
- * This is intended for internal use only.
- */
-var SpanContext.Storage.currentStack
-    get() = contextStack
-    set(value) = setContextStackUnsafe(value)
 
 /**
  * Test that no [SpanImpl] objects within the current [SpanContext] match the given [predicate].
@@ -21,4 +13,9 @@ internal inline fun SpanContext.Storage.noSpansMatch(predicate: (SpanImpl) -> Bo
 
 internal inline fun SpanContext.Storage.findSpan(predicate: (SpanImpl) -> Boolean): SpanImpl? {
     return contextStack.find { it is SpanImpl && predicate(it) } as? SpanImpl
+}
+
+object BugsnagPerformanceInternals {
+    var currentSpanContextStack by SpanContext.Storage::contextStack
+    val spanFactory get() = BugsnagPerformance.instrumentedAppState.spanFactory
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -257,7 +257,11 @@ class PerformanceLifecycleCallbacks internal constructor(
         val viewLoadSpan = spanTracker[activity]
         if (openLoadSpans && viewLoadSpan != null) {
             spanTracker.associate(activity, phase) {
-                spanFactory.createViewLoadPhaseSpan(activity, phase, viewLoadSpan)
+                spanFactory.createViewLoadPhaseSpan(
+                    activity,
+                    phase,
+                    SpanOptions.DEFAULTS.within(viewLoadSpan),
+                )
             }
         }
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -54,7 +54,8 @@ class SpanFactory(
     }
 
     fun createViewLoadSpan(
-        viewType: ViewType, viewName: String,
+        viewType: ViewType,
+        viewName: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
         spanProcessor: SpanProcessor = this.spanProcessor,
     ): SpanImpl {
@@ -83,23 +84,41 @@ class SpanFactory(
     }
 
     fun createViewLoadPhaseSpan(
-        activity: Activity,
+        viewName: String,
+        viewType: ViewType,
         phase: ViewLoadPhase,
-        parentContext: SpanContext,
+        options: SpanOptions,
         spanProcessor: SpanProcessor = this.spanProcessor,
     ): SpanImpl {
+        val phaseName = phase.phaseNameFor(viewType)
         val span = createSpan(
-            "[ViewLoadPhase/${phase.phaseName}]${activity::class.java.simpleName}",
+            "[ViewLoadPhase/$phaseName]$viewName",
             SpanKind.INTERNAL,
             SpanCategory.VIEW_LOAD_PHASE,
-            SpanOptions.DEFAULTS.within(parentContext),
+            options,
             spanProcessor,
         )
 
-        span.setAttribute("bugsnag.view.name", activity::class.java.simpleName)
-        span.setAttribute("bugsnag.phase", phase.phaseName)
+        span.setAttribute("bugsnag.view.name", viewName)
+        span.setAttribute("bugsnag.view.type", viewType.typeName)
+        span.setAttribute("bugsnag.phase", phaseName)
 
         return span
+    }
+
+    fun createViewLoadPhaseSpan(
+        activity: Activity,
+        phase: ViewLoadPhase,
+        options: SpanOptions,
+        spanProcessor: SpanProcessor = this.spanProcessor,
+    ): SpanImpl {
+        return createViewLoadPhaseSpan(
+            activity::class.java.simpleName,
+            ViewType.ACTIVITY,
+            phase,
+            options,
+            spanProcessor,
+        )
     }
 
     fun createAppStartSpan(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -21,7 +21,7 @@ class SpanImpl internal constructor(
     internal val startTime: Long,
     override val traceId: UUID,
     override val spanId: Long = nextSpanId(),
-    internal val parentSpanId: Long,
+    val parentSpanId: Long,
     private val processor: SpanProcessor,
     private val makeContext: Boolean,
 ) : Span, HasAttributes {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
@@ -1,7 +1,13 @@
 package com.bugsnag.android.performance.internal
 
-enum class ViewLoadPhase(internal val phaseName: String) {
-    CREATE("ActivityCreate"),
-    START("ActivityStart"),
-    RESUME("ActivityResume"),
+import com.bugsnag.android.performance.ViewType
+
+enum class ViewLoadPhase(private val phaseName: String) {
+    CREATE("Create"),
+    START("Start"),
+    RESUME("Resume");
+
+    internal fun phaseNameFor(viewType: ViewType): String {
+        return viewType.spanName + phaseName
+    }
 }

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/AppCompatModule.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/AppCompatModule.kt
@@ -8,8 +8,10 @@ class AppCompatModule : Module {
     private lateinit var fragmentActivityLifecycleCallbacks: FragmentActivityLifecycleCallbacks
     override fun load(instrumentedAppState: InstrumentedAppState) {
         this.instrumentedAppState = instrumentedAppState
-        this.fragmentActivityLifecycleCallbacks =
-            FragmentActivityLifecycleCallbacks(instrumentedAppState.spanTracker)
+        this.fragmentActivityLifecycleCallbacks = FragmentActivityLifecycleCallbacks(
+            instrumentedAppState.spanTracker,
+            instrumentedAppState.spanFactory,
+        )
 
         instrumentedAppState.app.registerActivityLifecycleCallbacks(
             fragmentActivityLifecycleCallbacks,

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformanceExt.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformanceExt.kt
@@ -1,10 +1,30 @@
 package com.bugsnag.android.performance
 
 import androidx.fragment.app.Fragment
+import com.bugsnag.android.performance.internal.BugsnagPerformanceInternals
+import com.bugsnag.android.performance.internal.SpanFactory
 import com.bugsnag.android.performance.internal.SpanImpl
 
-private fun spanNameForFragment(fragment: Fragment): String {
+internal fun viewNameForFragment(fragment: Fragment): String {
     return fragment.javaClass.simpleName
+}
+
+internal fun SpanFactory.createViewLoadSpan(
+    fragment: Fragment,
+    options: SpanOptions = SpanOptions.DEFAULTS,
+): SpanImpl {
+    val span = createViewLoadSpan(
+        ViewType.FRAGMENT,
+        viewNameForFragment(fragment),
+        options,
+    )
+
+    val tag = fragment.tag
+    if (tag != null) {
+        span.setAttribute("bugsnag.view.fragment_tag", tag)
+    }
+
+    return span
 }
 
 /**
@@ -18,16 +38,8 @@ fun BugsnagPerformance.startViewLoadSpan(
     fragment: Fragment,
     options: SpanOptions = SpanOptions.DEFAULTS,
 ): Span {
-    val span = startViewLoadSpan(
-        ViewType.FRAGMENT,
-        spanNameForFragment(fragment),
+    return BugsnagPerformanceInternals.spanFactory.createViewLoadSpan(
+        fragment,
         options,
     )
-
-    val tag = fragment.tag
-    if (tag != null && span is SpanImpl) {
-        span.setAttribute("bugsnag.view.fragment_tag", tag)
-    }
-
-    return span
 }

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
@@ -3,16 +3,37 @@ package com.bugsnag.android.performance
 import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
+import android.os.SystemClock
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
-import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.internal.SpanFactory
 import com.bugsnag.android.performance.internal.SpanTracker
+import com.bugsnag.android.performance.internal.ViewLoadPhase
 
 class FragmentActivityLifecycleCallbacks(
     private val spanTracker: SpanTracker,
+    private val spanFactory: SpanFactory,
 ) : ActivityLifecycleCallbacks, FragmentLifecycleCallbacks() {
+
+    /**
+     * ViewLoad for Fragments is not a context Span because Fragment lifecycles can be interleaved:
+     * - Fragment1 PreCreate
+     * - Fragment1 Create
+     * - Fragment2 PreCreate
+     * - Fragment2 Create
+     * - Fragment1 Started
+     * - Fragment2 Started
+     * - Fragment1 Resumed
+     * - Fragment2 Resumed
+     *
+     * As such we don't want Fragment2 spans to nest under the Fragment1 ViewLoad. Instead we
+     * measure ViewLoad from PreCreate -> Resume, and use a ViewLoadPhase/FragmentCreate
+     * as the context for [Fragment.onCreate] which does not interleave with other fragments.
+     */
+    private val viewLoadOpts = SpanOptions.DEFAULTS.makeCurrentContext(false)
+
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity !is FragmentActivity) return
 
@@ -25,11 +46,40 @@ class FragmentActivityLifecycleCallbacks(
         f: Fragment,
         savedInstanceState: Bundle?,
     ) {
-        spanTracker.associate(f) { BugsnagPerformance.startViewLoadSpan(f) as SpanImpl }
+        // we start both ViewLoad & ViewLoadPhase/Create at exactly the same timestamp
+        val timestamp = SystemClock.elapsedRealtimeNanos()
+        val viewLoad = spanTracker.associate(f) {
+            spanFactory.createViewLoadSpan(
+                ViewType.FRAGMENT,
+                viewNameForFragment(f),
+                viewLoadOpts.startTime(timestamp),
+            )
+        }
+
+        spanTracker.associate(f, ViewLoadPhase.CREATE) {
+            spanFactory.createViewLoadPhaseSpan(
+                viewNameForFragment(f),
+                ViewType.FRAGMENT,
+                ViewLoadPhase.CREATE,
+                SpanOptions.DEFAULTS
+                    .within(viewLoad)
+                    .startTime(timestamp),
+            )
+        }
+    }
+
+    override fun onFragmentCreated(fm: FragmentManager, f: Fragment, savedInstanceState: Bundle?) {
+        if (!f.isAdded) {
+            // remove & discard the Fragment span
+            spanTracker.removeAssociation(f, ViewLoadPhase.CREATE)?.discard()
+            spanTracker.removeAssociation(f)?.discard()
+        } else {
+            spanTracker.endSpan(f, ViewLoadPhase.CREATE)
+        }
     }
 
     override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
-        spanTracker.endSpan(f)
+        spanTracker.endAllSpans(f)
     }
 
     override fun onActivityStarted(activity: Activity) = Unit

--- a/bugsnag-plugin-android-performance-appcompat/src/test/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacksTest.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/test/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacksTest.kt
@@ -1,0 +1,90 @@
+package com.bugsnag.android.performance
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import com.bugsnag.android.performance.internal.BugsnagPerformanceInternals
+import com.bugsnag.android.performance.internal.SpanFactory
+import com.bugsnag.android.performance.internal.SpanTracker
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FragmentActivityLifecycleCallbacksTest {
+    private lateinit var spanCollector: MutableList<Span>
+
+    private lateinit var spanTracker: SpanTracker
+
+    private lateinit var lifecycleCallbacks: FragmentActivityLifecycleCallbacks
+
+    private lateinit var fm: FragmentManager
+    private lateinit var fragment1: Fragment
+    private lateinit var fragment2: Fragment
+
+    @Before
+    fun setup() {
+        spanCollector = ArrayList()
+        spanTracker = SpanTracker()
+        lifecycleCallbacks = FragmentActivityLifecycleCallbacks(
+            spanTracker,
+            SpanFactory(spanCollector::add),
+        )
+
+        fm = object : FragmentManager() {}
+        fragment1 = mock {
+            whenever(it.isAdded) doReturn true
+        }
+        fragment2 = mock {
+            whenever(it.isAdded) doReturn true
+        }
+    }
+
+    @After
+    fun shutdown() {
+        BugsnagPerformanceInternals.currentSpanContextStack.clear()
+    }
+
+    /**
+     * Test that when two fragments are being started interleaved within the same transaction,
+     * the SpanContext is what we expect it to be
+     */
+    @Test
+    fun testInterleavedLifecycles() {
+        lifecycleCallbacks.onFragmentPreCreated(fm, fragment1, null)
+        assertNotEquals(
+            "Fragment.onCreate should have a valid SpanContext",
+            SpanContext.invalid,
+            SpanContext.current,
+        )
+        lifecycleCallbacks.onFragmentCreated(fm, fragment1, null)
+
+        lifecycleCallbacks.onFragmentPreCreated(fm, fragment2, null)
+        assertNotEquals(
+            "Fragment.onCreate should have a valid SpanContext",
+            SpanContext.invalid,
+            SpanContext.current,
+        )
+        lifecycleCallbacks.onFragmentCreated(fm, fragment2, null)
+
+        assertEquals(
+            "Once completed Fragment.onCreate should leave no SpanContext",
+            SpanContext.invalid,
+            SpanContext.current,
+        )
+
+        lifecycleCallbacks.onFragmentStarted(fm, fragment1)
+        lifecycleCallbacks.onFragmentStarted(fm, fragment2)
+
+        lifecycleCallbacks.onFragmentResumed(fm, fragment1)
+        lifecycleCallbacks.onFragmentResumed(fm, fragment2)
+
+        assertEquals(4, spanCollector.size)
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
@@ -57,9 +57,10 @@ class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerfor
 
             // end the custom span
             customRootSpan.end()
-        }
 
-        finish()
+            // finish after we end the last span
+            finish()
+        }
     }
 
     class FirstFragment : Fragment() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
@@ -4,24 +4,20 @@ import android.content.Intent
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
-import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.NestedSpansActivity
 import com.bugsnag.mazeracer.Scenario
-
-const val BATCH_SIZE = 10
 
 class NestedSpansScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = BATCH_SIZE
         config.autoInstrumentAppStarts = true
         config.autoInstrumentActivities = AutoInstrument.FULL
     }
 
     override fun startScenario() {
         BugsnagPerformance.start(config)
-        context.startActivity(Intent(context, NestedSpansActivity::class.java))
+        startActivityAndFinish(Intent(context, NestedSpansActivity::class.java))
     }
 }

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -23,11 +23,25 @@ Feature: Nested spans
                 | bugsnag.view.type                 | stringValue | fragment            |
                 | bugsnag.view.name                 | stringValue | FirstFragment       |
 
+    * a span named "[ViewLoadPhase/FragmentCreate]FirstFragment" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load_phase     |
+                | bugsnag.view.type                 | stringValue | fragment            |
+                | bugsnag.view.name                 | stringValue | FirstFragment       |
+                | bugsnag.phase                     | stringValue | FragmentCreate      |
+
     * a span named "[ViewLoad/Fragment]SecondFragment" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | view_load           |
                 | bugsnag.view.type                 | stringValue | fragment            |
                 | bugsnag.view.name                 | stringValue | SecondFragment      |
+
+    * a span named "[ViewLoadPhase/FragmentCreate]SecondFragment" contains the attributes:
+                | attribute                         | type        | value               |
+                | bugsnag.span.category             | stringValue | view_load_phase     |
+                | bugsnag.view.type                 | stringValue | fragment            |
+                | bugsnag.view.name                 | stringValue | SecondFragment      |
+                | bugsnag.phase                     | stringValue | FragmentCreate      |
 
     * a span named "[ViewLoadPhase/ActivityResume]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |
@@ -61,32 +75,32 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.spanId" is stored as the value "app_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.endTimeUnixNano" is stored as the value "app_start_end_time"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" is stored as the value "activity_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.spanId" is stored as the value "activity_resume_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.spanId" is stored as the value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.spanId" is stored as the value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.endTimeUnixNano" is stored as the value "app_start_end_time"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.spanId" is stored as the value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.spanId" is stored as the value "custom_root_span_id"
 
     # ViewLoad & AppStart should have identical end times
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.endTimeUnixNano" equals the stored value "app_start_end_time"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.endTimeUnixNano" equals the stored value "app_start_end_time"
 
     # view load span should be nested under AppStart
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.parentSpanId" equals the stored value "app_start_span_id"
 
     # view load phase spans (Create, Start, Resume) should be nested under ViewLoad
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "view_load_span_id"
 
     # FirstFragment should be nested under ViewLoadPhase/Start
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.parentSpanId" equals the stored value "activity_start_span_id"
 
     # CustomRoot should be nested under ViewLoadPhase/Resume
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.parentSpanId" equals the stored value "activity_resume_span_id"
 
     # Remaining spans (SecondFragment, DoStuff, LoadData) should be nested under CustomRoot
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.parentSpanId" equals the stored value "custom_root_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.parentSpanId" equals the stored value "custom_root_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.10.parentSpanId" equals the stored value "custom_root_span_id"
 


### PR DESCRIPTION
## Goal
When adding more than one `Fragment` in a single transaction the `ViewLoad` spans should not nest when the `Fragments` are "parallel" (ie: not parent/child).

## Design
`ViewLoad` spans for `Fragment` are no longer set as the current context, and instead a new `ViewLoadPhase/FragmentCreate` is created to encapsulate the creation spans.

The `ViewLoad` still runs from pre-create -> post-resume.

## Testing
Manual testing and a new unit test