### PR TITLE
Introduce AppStartPhase/Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+* AppStartPhase/Framework introduced to mark the time between class loading & Application.onCreate
+  [#163](https://github.com/bugsnag/bugsnag-android-performance/pull/163)
+
 ## 1.0.0 (2023-07-17)
 
 ### Bug fixes

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -235,7 +235,7 @@ object BugsnagPerformance {
         options: SpanOptions = SpanOptions.DEFAULTS,
     ): Span {
         // create & track Activity referenced ViewLoad spans
-        return instrumentedAppState.activityCallbacks.startViewLoadSpan(activity, options)
+        return instrumentedAppState.lifecycleCallbacks.startViewLoadSpan(activity, options)
     }
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.SystemClock
 import com.bugsnag.android.performance.BugsnagPerformance.start
+import com.bugsnag.android.performance.internal.AppStartPhase
 import com.bugsnag.android.performance.internal.Connectivity
 import com.bugsnag.android.performance.internal.DiscardingSampler
 import com.bugsnag.android.performance.internal.HttpDelivery
@@ -90,9 +91,11 @@ object BugsnagPerformance {
 
         if (configuration.autoInstrumentAppStarts) {
             // mark the app as "starting" (if it isn't already)
-            reportApplicationClassLoaded()
+            synchronized(this) {
+                instrumentedAppState.markBugsnagPerformanceStart()
+            }
         } else {
-            instrumentedAppState.activityCallbacks.discardAppStart()
+            instrumentedAppState.lifecycleCallbacks.discardAppStart()
         }
 
         val application = configuration.application
@@ -281,7 +284,8 @@ object BugsnagPerformance {
     @JvmStatic
     fun reportApplicationClassLoaded() {
         synchronized(this) {
-            instrumentedAppState.activityCallbacks.startAppLoadSpan("Cold")
+            instrumentedAppState.startAppStartSpan("Cold")
+            instrumentedAppState.startAppStartPhase(AppStartPhase.FRAMEWORK)
         }
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -21,7 +21,6 @@ import com.bugsnag.android.performance.internal.RetryDeliveryTask
 import com.bugsnag.android.performance.internal.SamplerTask
 import com.bugsnag.android.performance.internal.SendBatchTask
 import com.bugsnag.android.performance.internal.Task
-import com.bugsnag.android.performance.internal.processing.Tracer
 import com.bugsnag.android.performance.internal.Worker
 import com.bugsnag.android.performance.internal.createResourceAttributes
 import com.bugsnag.android.performance.internal.isInForeground
@@ -34,8 +33,6 @@ import java.net.URL
  */
 object BugsnagPerformance {
     const val VERSION: String = "1.0.0"
-
-    internal val tracer = Tracer()
 
     internal val instrumentedAppState = InstrumentedAppState()
 
@@ -87,7 +84,7 @@ object BugsnagPerformance {
 
     private fun startUnderLock(configuration: ImmutableConfig) {
         Logger.delegate = configuration.logger
-        instrumentedAppState.configure(configuration)
+        val tracer = instrumentedAppState.configure(configuration)
 
         if (configuration.autoInstrumentAppStarts) {
             // mark the app as "starting" (if it isn't already)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
@@ -1,0 +1,5 @@
+package com.bugsnag.android.performance.internal
+
+enum class AppStartPhase(internal val phaseName: String) {
+    FRAMEWORK("Framework")
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -10,9 +10,9 @@ import android.os.Message
 import android.os.SystemClock
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.Logger
-import com.bugsnag.android.performance.internal.InstrumentedAppState.Companion.applicationToken
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanOptions
+import com.bugsnag.android.performance.internal.InstrumentedAppState.Companion.applicationToken
 import kotlin.math.max
 
 typealias InForegroundCallback = (inForeground: Boolean) -> Unit
@@ -227,7 +227,7 @@ class PerformanceLifecycleCallbacks internal constructor(
         val span = spanTracker.associate(activity) {
             // if this is still part of the AppStart span, then the first ViewLoad to end should
             // also end the AppStart span
-            if (appStartSpan != null) {
+            if (spanTracker[applicationToken] != null) {
                 spanFactory.createViewLoadSpan(activity, spanOptions) { span ->
                     // we end the AppStart span at the same timestamp as the ViewLoad span ended
                     maybeEndAppStartSpan(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/PerformanceLifecycleCallbacks.kt
@@ -8,7 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.os.SystemClock
-import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.BugsnagPerformance.instrumentedAppState
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanOptions
@@ -234,7 +234,7 @@ class PerformanceLifecycleCallbacks internal constructor(
                         (span as? SpanImpl)?.endTime ?: SystemClock.elapsedRealtimeNanos(),
                     )
 
-                    BugsnagPerformance.tracer.onEnd(span)
+                    instrumentedAppState.spanProcessor.onEnd(span)
                 }
             } else {
                 spanFactory.createViewLoadSpan(activity, spanOptions)
@@ -248,9 +248,10 @@ class PerformanceLifecycleCallbacks internal constructor(
     }
 
     private fun endViewLoad(activity: Activity) {
+        val endTime = SystemClock.elapsedRealtimeNanos()
         if (closeLoadSpans) {
             // close any pending spans associated with the Activity
-            spanTracker.endAllSpans(activity)
+            spanTracker.endAllSpans(activity, endTime)
         } else {
             spanTracker.markSpanAutomaticEnd(activity)
         }
@@ -258,7 +259,7 @@ class PerformanceLifecycleCallbacks internal constructor(
         // if we do not automatically open spans, we always close the AppStart span when we
         // would end ViewLoad for an Activity
         if (!openLoadSpans) {
-            maybeEndAppStartSpan(SystemClock.elapsedRealtimeNanos())
+            maybeEndAppStartSpan(endTime)
         }
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -6,4 +6,5 @@ enum class SpanCategory(val category: String?) {
     VIEW_LOAD_PHASE("view_load_phase"),
     NETWORK("network"),
     APP_START("app_start"),
+    APP_START_PHASE("app_start_phase"),
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 internal typealias AttributeSource = (target: HasAttributes) -> Unit
 
 class SpanFactory(
-    private val spanProcessor: SpanProcessor,
+    var spanProcessor: SpanProcessor,
     val spanAttributeSource: AttributeSource = {},
 ) {
     fun createCustomSpan(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -138,6 +138,19 @@ class SpanFactory(
         return span
     }
 
+    fun createAppStartPhaseSpan(phase: AppStartPhase, appStartContext: SpanContext): SpanImpl {
+        val span = createSpan(
+            "[AppStartPhase/${phase.phaseName}]",
+            SpanKind.INTERNAL,
+            SpanCategory.APP_START_PHASE,
+            SpanOptions.DEFAULTS.within(appStartContext)
+        )
+
+        span.setAttribute("bugsnag.phase", "FrameworkLoad")
+
+        return span
+    }
+
     private fun createSpan(
         name: String,
         kind: SpanKind,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -138,12 +138,17 @@ class SpanFactory(
         return span
     }
 
-    fun createAppStartPhaseSpan(phase: AppStartPhase, appStartContext: SpanContext): SpanImpl {
+    fun createAppStartPhaseSpan(
+        phase: AppStartPhase,
+        appStartContext: SpanContext,
+        spanProcessor: SpanProcessor = this.spanProcessor,
+    ): SpanImpl {
         val span = createSpan(
             "[AppStartPhase/${phase.phaseName}]",
             SpanKind.INTERNAL,
             SpanCategory.APP_START_PHASE,
-            SpanOptions.DEFAULTS.within(appStartContext)
+            SpanOptions.DEFAULTS.within(appStartContext),
+            spanProcessor,
         )
 
         span.setAttribute("bugsnag.phase", "FrameworkLoad")

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -78,6 +78,13 @@ class SpanTracker {
         }
     }
 
+    fun removeAllAssociations(tag: Any?): Collection<SpanImpl> {
+        return lock.write {
+            val associatedSpans = backingStore.remove(tag)
+            associatedSpans.orEmpty().values.map { it.span }
+        }
+    }
+
     /**
      * Mark when a `Span` would have been ended automatically. *If* the associated `Span` is later
      * marked as [leaked](markSpanLeaked) then its `endTime` will be set to the time that this

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
@@ -1,0 +1,40 @@
+package com.bugsnag.android.performance.internal.processing
+
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.internal.SpanProcessor
+
+/**
+ * SpanProcessor implementation which can be made to forward to another SpanProcessor.
+ * ForwardingSpanProcessors initially batch their spans using a [BatchingSpanProcessor] but when
+ * [forwardTo] is called, any batched spans are forwarded to the new processor (along with any
+ * in-flight spans that end with the `ForwardingSpanProcessor`).
+ */
+class ForwardingSpanProcessor : SpanProcessor {
+    @Volatile
+    private var backingProcessor: SpanProcessor = BatchingSpanProcessor()
+
+    fun forwardTo(processor: SpanProcessor) {
+        // replace the backingProcessor *first*, any in-flight spans will be relayed to processor
+        // instead of the BatchingSpanProcessor
+        val oldProcessor = backingProcessor
+        backingProcessor = processor
+
+        val batch = (oldProcessor as? BatchingSpanProcessor)?.takeBatch().orEmpty()
+        batch.forEach(processor::onEnd)
+    }
+
+    /**
+     * Discard all Spans targeting this ForwardingSpanProcessor. This is the same as using
+     * [forwardTo] with a SpanProcessor that discards all of its Spans.
+     */
+    fun discard() {
+        forwardTo { span ->
+            (span as? SpanImpl)?.discard()
+        }
+    }
+
+    override fun onEnd(span: Span) {
+        backingProcessor.onEnd(span)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessorTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessorTest.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.android.performance.internal.processing
+
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.test.TestSpanFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class ForwardingSpanProcessorTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    private lateinit var spanProcessor: ForwardingSpanProcessor
+
+    private lateinit var collectedSpans: MutableList<Span>
+
+    @Before
+    fun setup() {
+        spanFactory = TestSpanFactory()
+        spanProcessor = ForwardingSpanProcessor()
+        collectedSpans = ArrayList()
+    }
+
+    @Test
+    fun endAfterForwarding() {
+        // one opened-and-closed Span
+        val span1 = spanFactory.newSpan(processor = spanProcessor)
+
+        // one "in-flight" span
+        val span2 = spanFactory.newSpan(processor = spanProcessor, endTime = null)
+
+        // forward the closed span (and any future spans)
+        spanProcessor.forwardTo(collectedSpans::add)
+
+        // end the "in-flight" span (it should be forwarded to collectedSpans)
+        span2.end(endTime = 10L)
+
+        // open and close another span for safe-measure (it should by forwarded to collectedSpans)
+        val span3 = spanFactory.newSpan(processor = spanProcessor)
+
+        assertEquals(3, collectedSpans.size)
+        assertSame(span1, collectedSpans[0])
+        assertSame(span2, collectedSpans[1])
+        assertSame(span3, collectedSpans[2])
+    }
+}

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -5,7 +5,7 @@
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
-    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$5</ID>
+    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$6</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$1000L</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
@@ -12,7 +12,7 @@ class AppStartScenario(
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = 5
+        InternalDebug.spanBatchSizeSendTriggerPoint = 6
         InternalDebug.workerSleepMs = 1000L
     }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/PreStartSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/PreStartSpansScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.mazeracer.scenarios
 
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
-import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.android.performance.measureSpan
 import com.bugsnag.mazeracer.Scenario
 import kotlin.concurrent.thread
@@ -12,7 +11,7 @@ class PreStartSpansScenario(
     scenarioMetadata: String
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = 4
+        config.autoInstrumentAppStarts = true
     }
 
     override fun startScenario() {
@@ -33,5 +32,8 @@ class PreStartSpansScenario(
         }
 
         Thread.sleep(50)
+
+        // background the app and flush the spans
+        context.finish()
     }
 }

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -46,12 +46,17 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait for 5 spans
+    And I wait for 6 spans
     * a span named "[AppStart/Cold]" contains the attributes:
                 | attribute                         | type        | value          |
                 | bugsnag.span.category             | stringValue | app_start      |
                 | bugsnag.app_start.type            | stringValue | cold           |
                 | bugsnag.app_start.first_view_name | stringValue | MainActivity   |
+
+    * a span named "[AppStartPhase/Framework]" contains the attributes:
+                | attribute                         | type        | value           |
+                | bugsnag.span.category             | stringValue | app_start_phase |
+                | bugsnag.phase                     | stringValue | FrameworkLoad   |
 
     * a span named "[ViewLoad/Activity]MainActivity" contains the attributes:
                 | attribute               | type        | value                    |

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -75,32 +75,32 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.spanId" is stored as the value "app_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.endTimeUnixNano" is stored as the value "app_start_end_time"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.spanId" is stored as the value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.spanId" is stored as the value "activity_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.spanId" is stored as the value "activity_resume_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.spanId" is stored as the value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.spanId" is stored as the value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.spanId" is stored as the value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.spanId" is stored as the value "app_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.endTimeUnixNano" is stored as the value "app_start_end_time"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.spanId" is stored as the value "custom_root_span_id"
 
-    # ViewLoad & AppStart should have identical end times
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.endTimeUnixNano" equals the stored value "app_start_end_time"
+    # ViewLoad/Activity & AppStart should have identical end times
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.endTimeUnixNano" equals the stored value "app_start_end_time"
 
-    # view load span should be nested under AppStart
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.parentSpanId" equals the stored value "app_start_span_id"
+    # ViewLoad/Activity span should be nested under AppStart
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "app_start_span_id"
 
-    # view load phase spans (Create, Start, Resume) should be nested under ViewLoad
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "view_load_span_id"
+    # ViewLoadPhase phase spans (Create, Start, Resume) should be nested under ViewLoad
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.7.parentSpanId" equals the stored value "view_load_span_id"
 
     # FirstFragment should be nested under ViewLoadPhase/Start
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.parentSpanId" equals the stored value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.parentSpanId" equals the stored value "activity_start_span_id"
 
     # CustomRoot should be nested under ViewLoadPhase/Resume
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.parentSpanId" equals the stored value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.parentSpanId" equals the stored value "activity_resume_span_id"
 
     # Remaining spans (SecondFragment, DoStuff, LoadData) should be nested under CustomRoot
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.5.parentSpanId" equals the stored value "custom_root_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "custom_root_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.10.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.parentSpanId" equals the stored value "custom_root_span_id"
 


### PR DESCRIPTION
## Goal
Introduce `AppStartPhase/Framework` as the time between class-loading and `Application.onCreate`

## Changeset
`BugsnagPerformance.reportApplicationClassLoaded` will now open a secondary `AppStartPhase/Framework` nested span under `AppStart` which will be closed when `BugsnagPerformance.start` is called.

This is not a perfect measurement as:
- `reportApplicationClassLoaded` may not be called
- `reportApplicationClassLoaded` does not exactly represent when the process started
- `BugsnagPerformance.start` may be called late in `Application.onCreate`
- `BugsnagPerformance.start` may be called from an `Activity` or similar

As such the measurement does not currently exactly match its description, however our next step will be 

## Testing
Modified the existing end-to-end tests to cover the new span.