### PR TITLE
Extracted AppStart logic from PerformanceLifecycleCallbacks

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -24,6 +24,7 @@ import com.bugsnag.android.performance.internal.Task
 import com.bugsnag.android.performance.internal.Worker
 import com.bugsnag.android.performance.internal.createResourceAttributes
 import com.bugsnag.android.performance.internal.isInForeground
+import com.bugsnag.android.performance.internal.processing.Tracer
 import java.net.URL
 
 /**
@@ -89,10 +90,10 @@ object BugsnagPerformance {
         if (configuration.autoInstrumentAppStarts) {
             // mark the app as "starting" (if it isn't already)
             synchronized(this) {
-                instrumentedAppState.markBugsnagPerformanceStart()
+                instrumentedAppState.onBugsnagPerformanceStart()
             }
         } else {
-            instrumentedAppState.lifecycleCallbacks.discardAppStart()
+            instrumentedAppState.startupTracker.discardAppStart()
         }
 
         val application = configuration.application
@@ -281,8 +282,7 @@ object BugsnagPerformance {
     @JvmStatic
     fun reportApplicationClassLoaded() {
         synchronized(this) {
-            instrumentedAppState.startAppStartSpan("Cold")
-            instrumentedAppState.startAppStartPhase(AppStartPhase.FRAMEWORK)
+            instrumentedAppState.startupTracker.onFirstClassLoadReported()
         }
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartTracker.kt
@@ -1,0 +1,124 @@
+package com.bugsnag.android.performance.internal
+
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+
+class AppStartTracker(
+    private val spanTracker: SpanTracker,
+    private val spanFactory: SpanFactory,
+) : Handler.Callback {
+
+    /**
+     * Track whether this is a full Cold start or not. This is `false` by default and is set
+     * to `true`
+     */
+    private var processStarted = false
+
+    internal var isInBackground = true
+
+    private val handler = Handler(Looper.getMainLooper(), this)
+
+    fun onFirstClassLoadReported() {
+        if (processStarted) return
+        val appStart = startAppStart("Cold")
+
+        spanTracker.associate(appStartToken, AppStartPhase.FRAMEWORK) {
+            spanFactory.createAppStartPhaseSpan(AppStartPhase.FRAMEWORK, appStart)
+        }
+
+        handler.sendMessageAtFrontOfQueue(handler.obtainMessage(MSG_APP_CLASS_COMPLETE))
+
+        processStarted = true
+    }
+
+    fun onBugsnagPerformanceStart() {
+        if (processStarted) return
+
+        spanTracker.endSpan(appStartToken, AppStartPhase.FRAMEWORK)
+
+        startAppStart("Cold")
+        handler.sendMessageAtFrontOfQueue(handler.obtainMessage(MSG_APP_CLASS_COMPLETE))
+
+        processStarted = true
+    }
+
+    fun startAppStart(startType: String): SpanImpl {
+        return spanTracker.associate(appStartToken) {
+            spanFactory.createAppStartSpan(startType)
+        }
+    }
+
+    fun onApplicationPostCreated() {
+        spanTracker.endSpan(appStartToken, AppStartPhase.FRAMEWORK)
+
+        // if the process is being started in the background, we want to discard the AppStart
+        handler.sendEmptyMessageDelayed(MSG_DISCARD_APP_START, APP_START_TIMEOUT_MS)
+    }
+
+    fun onActivityCreate(hasSavedInstanceState: Boolean) {
+        if (isInBackground) {
+            if (hasSavedInstanceState) {
+                startAppStart("Hot")
+            } else {
+                startAppStart("Warm")
+            }
+        }
+
+        if (spanTracker[appStartToken] == null) {
+            // if there is no AppStart span being tracked, we can save a bit of work
+            return
+        }
+
+        // the app is launching with an Activity, so we remove these messages to ensure
+        // that the AppStart span is not discarded for being a background start
+        handler.removeMessages(MSG_APP_CLASS_COMPLETE)
+        handler.removeMessages(MSG_DISCARD_APP_START)
+    }
+
+    fun onViewLoadComplete(timestamp: Long) {
+        // end the AppStart since the app is now considered "visible"
+        spanTracker.endAllSpans(appStartToken, timestamp)
+    }
+
+    override fun handleMessage(msg: Message): Boolean {
+        when (msg.what) {
+            MSG_APP_CLASS_COMPLETE -> onApplicationPostCreated()
+            MSG_DISCARD_APP_START -> discardAppStart()
+            else -> return false
+        }
+
+        return true
+    }
+
+    fun discardAppStart() {
+        spanTracker.discardAllSpans(appStartToken)
+    }
+
+    internal companion object {
+        val appStartToken = Any()
+
+        /**
+         * Message ID sent directly after opening an AppStart span. This begins a second timeout
+         * tracking the time between the end of the `Application.onCreate` and the first
+         * `Activity.onCreate` (tracked by [MSG_DISCARD_APP_START]).
+         */
+        private const val MSG_APP_CLASS_COMPLETE = 1
+
+        /**
+         * Message ID sent delayed (after [APP_START_TIMEOUT_MS]) to force-discard any AppStart
+         * span still in-progress. This is used to avoid skewing metrics due to background starts
+         * triggered by things like broadcasts, service starts or content providers being accessed.
+         *
+         * This message is negated by any `Activity.onCreate` which will
+         * `removeMessages(MSG_DISCARD_APP_START)`.
+         */
+        private const val MSG_DISCARD_APP_START = 3
+
+        /**
+         * How long to wait between the Application class loading and the first Activity.onCreate before
+         * discarding the AppStart span (and assuming the app-start is for a Service or Broadcast).
+         */
+        private const val APP_START_TIMEOUT_MS = 1000L
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -132,7 +132,7 @@ class SpanTracker {
     }
 
     /**
-     * End all spans associated with the given `token` or any `subToken`s. This will attempt to
+     * End all spans associated with the given [token] or any `subToken`s. This will attempt to
      * use autoEndTimes where they are available, but will otherwise fallback to using [endTime]
      * for each of the spans that get closed.
      */
@@ -140,6 +140,20 @@ class SpanTracker {
         lock.write {
             val associatedSpans = backingStore[token]
             associatedSpans?.values?.forEach { it.markLeaked(endTime) }
+
+            backingStore.remove(token)
+        }
+    }
+
+    /**
+     * Discard & remove all spans associated with the given [token]. This will result in any
+     * associated spans being discarded, any of their child spans that have already been closed
+     * will have no valid parent span and will also be discarded by the server-side.
+     */
+    fun discardAllSpans(token: Any) {
+        lock.write {
+            val associatedSpans = backingStore[token]
+            associatedSpans?.values?.forEach { it.span.discard() }
 
             backingStore.remove(token)
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AppStartTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AppStartTest.kt
@@ -1,0 +1,130 @@
+package com.bugsnag.android.performance.internal
+
+import android.os.SystemClock
+import com.bugsnag.android.performance.Logger
+import com.bugsnag.android.performance.SpanContext
+import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.test.CollectingSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPausedSystemClock
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowPausedSystemClock::class])
+class AppStartTest {
+    private lateinit var spanFactory: SpanFactory
+    private lateinit var spanTracker: SpanTracker
+    private lateinit var startupTracker: AppStartTracker
+
+    private lateinit var spanProcessor: CollectingSpanProcessor
+
+    @Before
+    fun configureSafeLogger() {
+        Logger.delegate = NoopLogger
+    }
+
+    @Before
+    fun setupDependencies() {
+        spanProcessor = CollectingSpanProcessor()
+        spanFactory = SpanFactory(spanProcessor)
+        spanTracker = SpanTracker()
+        startupTracker = AppStartTracker(spanTracker, spanFactory)
+    }
+
+    @Test
+    fun testColdStart() {
+        coldStart()
+
+        val spans = spanProcessor.toList()
+        assertEquals(2, spans.size)
+
+        val frameworkStart = spans[0]
+        assertEquals("[AppStartPhase/Framework]", frameworkStart.name)
+        // start and end time are in nanoseconds, not milliseconds
+        assertEquals(100_000_000L, frameworkStart.startTime)
+        assertEquals(200_000_000L, frameworkStart.endTime)
+        assertEquals(SpanKind.INTERNAL, frameworkStart.kind)
+        assertTrue(frameworkStart.isEnded())
+
+        val appStart = spans[1]
+        assertEquals("[AppStart/Cold]", appStart.name)
+        // start and end time are in nanoseconds, not milliseconds
+        assertEquals(100_000_000L, appStart.startTime)
+        assertEquals(400_000_000L, appStart.endTime)
+        assertEquals(SpanKind.INTERNAL, appStart.kind)
+        assertTrue(appStart.isEnded())
+    }
+
+    @Test
+    fun testWarmStart() {
+        coldStart()
+
+        // discard the ColdStart spans
+        spanProcessor.clear()
+
+        startupTracker.isInBackground = true
+
+        SystemClock.setCurrentTimeMillis(500L)
+        startupTracker.onActivityCreate(false)
+        SystemClock.setCurrentTimeMillis(600L)
+        startupTracker.onViewLoadComplete(SystemClock.elapsedRealtimeNanos())
+
+        val spans = spanProcessor.toList()
+        assertEquals(1, spans.size)
+
+        val appStart = spans.first()
+        assertEquals("[AppStart/Warm]", appStart.name)
+        // start and end time are in nanoseconds, not milliseconds
+        assertEquals(500_000_000L, appStart.startTime)
+        assertEquals(600_000_000L, appStart.endTime)
+        assertEquals(SpanKind.INTERNAL, appStart.kind)
+        assertTrue(appStart.isEnded())
+    }
+
+    @Test
+    fun backgroundStart() {
+        SystemClock.setCurrentTimeMillis(100L)
+        startupTracker.onFirstClassLoadReported()
+        SystemClock.setCurrentTimeMillis(200L)
+        startupTracker.onBugsnagPerformanceStart()
+        // Application.onCreate completes
+        Robolectric.flushForegroundThreadScheduler()
+
+        // no Activity is started
+        Robolectric.flushForegroundThreadScheduler()
+
+        assertEquals(SpanContext.invalid, SpanContext.current)
+
+        val spans = spanProcessor.toList()
+        assertEquals(1, spans.size)
+
+        // we will still produce a Framework start span
+        val frameworkStart = spans.first()
+        assertEquals("[AppStartPhase/Framework]", frameworkStart.name)
+        // start and end time are in nanoseconds, not milliseconds
+        assertEquals(100_000_000L, frameworkStart.startTime)
+        assertEquals(200_000_000L, frameworkStart.endTime)
+        assertEquals(SpanKind.INTERNAL, frameworkStart.kind)
+        assertTrue(frameworkStart.isEnded())
+    }
+
+    private fun coldStart() {
+        SystemClock.setCurrentTimeMillis(100L)
+        startupTracker.onFirstClassLoadReported()
+        SystemClock.setCurrentTimeMillis(200L)
+        startupTracker.onBugsnagPerformanceStart()
+        // Application.onCreate completes
+        Robolectric.flushForegroundThreadScheduler()
+
+        SystemClock.setCurrentTimeMillis(300L)
+        startupTracker.onActivityCreate(false)
+        SystemClock.setCurrentTimeMillis(400L)
+        startupTracker.onViewLoadComplete(SystemClock.elapsedRealtimeNanos())
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/CollectingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/CollectingSpanProcessor.kt
@@ -8,6 +8,10 @@ import java.util.concurrent.ConcurrentLinkedQueue
 class CollectingSpanProcessor : SpanProcessor {
     private val spans = ConcurrentLinkedQueue<SpanImpl>()
 
+    fun clear() {
+        spans.clear()
+    }
+
     fun toList(): List<SpanImpl> = spans.sortedBy { it.startTime }
 
     override fun onEnd(span: Span) {

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -49,11 +49,11 @@ Feature: Nested spans
                 | bugsnag.phase                     | stringValue | ActivityResume      |
                 | bugsnag.view.name                 | stringValue | NestedSpansActivity |
 
-    * a span named "[AppStart/Cold]" contains the attributes:
+    * a span named "[AppStart/Warm]" contains the attributes:
                 | attribute                         | type        | value               |
                 | bugsnag.span.category             | stringValue | app_start           |
                 | bugsnag.app_start.first_view_name | stringValue | NestedSpansActivity |
-                | bugsnag.app_start.type            | stringValue | cold                |
+                | bugsnag.app_start.type            | stringValue | warm                |
 
     * a span named "[ViewLoad/Activity]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |


### PR DESCRIPTION
## Goal
Reduce the complexity of our startup tracking.

## Design
The startup & Activity tracking logic have become intertwined in ways that make it difficult to determine what is actually going on. This PR extracts all of the startup tracking logic into a new `AppStartTracker`, allowing the `PerformanceLifecycleCallbacks` to focus on creating `ViewLoad`s and phases for activities.

## Testing
Updated existing tests to follow new process. Includes changing some "Cold" starts to expect "Warm" starts as the logic now takes configuration changes into account.