### PR TITLE
Support okhttp 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AppStartPhase/Framework introduced to mark the time between class loading & Application.onCreate
   [#163](https://github.com/bugsnag/bugsnag-android-performance/pull/163)
+* Support for OkHttp 5.0.0 in [bugsnag-plugin-android-performance-okhttp](bugsnag-plugin-android-performance-okhttp)
+  [#167](https://github.com/bugsnag/bugsnag-android-performance/pull/167)
 
 ## 1.0.0 (2023-07-17)
 

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -9,7 +9,6 @@ import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.Protocol
 import okhttp3.Response
-import okhttp3.internal.headersContentLength
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
@@ -43,7 +42,7 @@ class BugsnagPerformanceOkhttp : EventListener() {
     override fun responseHeadersEnd(call: Call, response: Response) {
         val span = spans[call] ?: return
         NetworkRequestAttributes.setResponseCode(span, response.code)
-        val contentLength = response.headersContentLength()
+        val contentLength = response.headers["Content-Length"]?.toLongOrNull() ?: -1L
         if (contentLength != -1L) {
             NetworkRequestAttributes.setResponseContentLength(span, contentLength)
         }

--- a/features/fixtures/mazeracer/app/build.gradle
+++ b/features/fixtures/mazeracer/app/build.gradle
@@ -51,14 +51,18 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
+
+    implementation 'com.squareup.okhttp3:okhttp:5.0.0-alpha.11'
+
     implementation "com.bugsnag:bugsnag-android:5.+"
+
     implementation 'com.bugsnag:bugsnag-android-performance:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-okhttp:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-appcompat:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-coroutines:9.9.9'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.1'
 }


### PR DESCRIPTION
## Goal
Support okhttp 5.0.0

## Changeset
Replaced the use of the internal okhttp `headersContentLength()` utility function with a direct implementation

## Testing
Modified the test fixture to use okhttp 5.0.0-alpha11 (latest version at time of writing).