### PR TITLE
Fix connectivity / retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Support for OkHttp 5.0.0 in [bugsnag-plugin-android-performance-okhttp](bugsnag-plugin-android-performance-okhttp)
   [#167](https://github.com/bugsnag/bugsnag-android-performance/pull/167)
 
+### Bug fixes
+
+* Traces are now correctly enqueued for retry when there is no active network (instead of being swallowed by the `UnknownHostException`)
+  [#170](https://github.com/bugsnag/bugsnag-android-performance/pull/170)
+
 ## 1.0.0 (2023-07-17)
 
 ### Bug fixes

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -31,6 +31,8 @@
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: OverlappingFileLockException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
+    <ID>SwallowedException:HttpDelivery.kt$HttpDelivery$e: Exception</ID>
+    <ID>SwallowedException:HttpDelivery.kt$HttpDelivery$e: IOException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
@@ -38,6 +40,7 @@
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:ForegroundTracker.kt$exc: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:HttpDelivery.kt$HttpDelivery$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
@@ -45,5 +48,6 @@
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:Attributes.kt$Attributes : Collection</ID>
     <ID>TooManyFunctions:BugsnagPerformance.kt$BugsnagPerformance$BugsnagPerformance</ID>
+    <ID>TooManyFunctions:Connectivity.kt$ConnectivityApi24 : NetworkCallbackConnectivity</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -31,7 +31,7 @@ internal open class HttpDelivery(
             return DeliveryResult.Failed(tracePayload, true)
         }
 
-        try {
+        return try {
             val connection = openConnection()
             with(connection) {
                 requestMethod = "POST"
@@ -47,11 +47,12 @@ internal open class HttpDelivery(
             val newP = connection.getHeaderField("Bugsnag-Sampling-Probability")?.toDoubleOrNull()
             connection.disconnect()
             newP?.let { newProbabilityCallback?.onNewProbability(it) }
-            return result
+
+            result
         } catch (e: IOException) {
-            return DeliveryResult.Failed(tracePayload, true)
+            DeliveryResult.Failed(tracePayload, true)
         } catch (e: Exception) {
-            return DeliveryResult.Failed(tracePayload, false)
+            DeliveryResult.Failed(tracePayload, false)
         }
     }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/Api24NetworkTypeTest.kt
@@ -37,6 +37,8 @@ class Api24NetworkTypeTest {
             callbackInvoked = true
         }
 
+        whenever(connectivityManager.activeNetwork).thenReturn(mock())
+
         val networkCapabilities = mock<NetworkCapabilities>()
         whenever(networkCapabilities.hasTransport(transportType))
             .thenReturn(true)
@@ -48,7 +50,6 @@ class Api24NetworkTypeTest {
         whenever(connectivityManager.getNetworkCapabilities(any()))
             .thenReturn(networkCapabilities)
 
-        connectivity.onAvailable(mock()) // first event is always ignored
         connectivity.onAvailable(mock())
 
         assertTrue("Network callback not invoked", callbackInvoked)

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ConnectivityLegacyTest.kt
@@ -2,6 +2,7 @@
 
 package com.bugsnag.android.performance.internal
 
+import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import org.junit.Assert.assertEquals
@@ -9,12 +10,20 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @RunWith(Parameterized::class)
 class ConnectivityLegacyTest {
     companion object {
+        internal val noNetwork = ConnectivityStatus(
+            false,
+            ConnectionMetering.DISCONNECTED,
+            NetworkType.UNAVAILABLE,
+            null,
+        )
+
         @JvmStatic
         @Parameterized.Parameters
         @Suppress("LongMethod") // naturally long method due to the number of permutations
@@ -99,6 +108,24 @@ class ConnectivityLegacyTest {
         }
 
         val connectivity = ConnectivityLegacy(mock(), connectivityManager, null)
+        val status = connectivity.connectivityStatus
+
+        assertEquals(expected.metering, status.metering)
+        assertEquals(expected.networkType, status.networkType)
+        assertEquals(expected.networkSubType, status.networkSubType)
+    }
+
+    @Test
+    fun testBroadcastNetworkProperties() {
+        val (expected, networkInfo) = testCase
+        val connectivityManager = mock<ConnectivityManager> {
+            whenever(it.activeNetworkInfo) doReturnConsecutively listOf(null, networkInfo)
+        }
+
+        val connectivity = ConnectivityLegacy(mock(), connectivityManager, null)
+        assertEquals(noNetwork, connectivity.connectivityStatus)
+
+        connectivity.onReceive(mock(), Intent())
         val status = connectivity.connectivityStatus
 
         assertEquals(expected.metering, status.metering)


### PR DESCRIPTION
## Goal
When there is no active network traces should be queued and retried as expected.

## Changeset
Categorize `IOException` as failed-with-retry instead of propagating the exception.

Categorize a lack of network connectivity as "UNAVAILABLE" instead of "UNKNOWN" to avoid infinite retries when there is no active network.

All connectivity changed events now update the connectivity state based on the "active" network instead of the network that is changing status.

## Testing
Updated unit tests and manually tested.