### PR TITLE
[PLAT-10773] Add support for network span URL customization via callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+* Network request spans can now be controlled/modified via configurable callback.
+  [#171](https://github.com/bugsnag/bugsnag-android-performance/pull/171)
 * AppStartPhase/Framework introduced to mark the time between class loading & Application.onCreate
   [#163](https://github.com/bugsnag/bugsnag-android-performance/pull/163)
 * Support for OkHttp 5.0.0 in [bugsnag-plugin-android-performance-okhttp](bugsnag-plugin-android-performance-okhttp)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -197,7 +197,7 @@ object BugsnagPerformance {
         url: URL,
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
-    ): Span = spanFactory.createNetworkSpan(url.toString(), verb, options)
+    ): Span? = spanFactory.createNetworkSpan(url.toString(), verb, options)
 
     /**
      * Open a network span for a given url and HTTP [verb] to measure the time taken for an HTTP request.
@@ -212,7 +212,7 @@ object BugsnagPerformance {
         uri: Uri,
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
-    ): Span = spanFactory.createNetworkSpan(uri.toString(), verb, options)
+    ): Span? = spanFactory.createNetworkSpan(uri.toString(), verb, options)
 
     /**
      * Open a ViewLoad span to measure the time taken to load and render a UI element (typically a screen).

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInfo.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInfo.kt
@@ -1,0 +1,9 @@
+package com.bugsnag.android.performance
+
+class NetworkRequestInfo(
+    /**
+     * The URL that will be reported in this network request's span.
+     * If null, no span will be created.
+     */
+    var url: String? = null,
+)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
@@ -5,6 +5,8 @@ fun interface NetworkRequestInstrumentationCallback {
      * Use this callback to filter network request URLs when generating spans.
      *
      * For example:
+     *
+     * ```kotlin
      * config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
      *   val url = reqInfo.url ?: return@NetworkRequestInstrumentationCallback
      *   if (url.startsWith("http://my-api.com/uninteresting/")) {
@@ -16,6 +18,7 @@ fun interface NetworkRequestInstrumentationCallback {
      *   }
      *   // Otherwise, just create a span with the given URL
      * }
+     * ```
      */
     fun onNetworkRequest(info: NetworkRequestInfo)
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.performance
+
+fun interface NetworkRequestInstrumentationCallback {
+    /**
+     * Use this callback to filter network request URLs when generating spans.
+     *
+     * For example:
+     * config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
+     *   val url = reqInfo.url ?: return@NetworkRequestInstrumentationCallback
+     *   if (url.startsWith("http://my-api.com/uninteresting/")) {
+     *     // Don't generate spans for these
+     *     reqInfo.url = null
+     *   } else if (url.endsWith("/changeme")) {
+     *     // Generate a span, but report a different URL
+     *     reqInfo.url = url.dropLast(9) + "/changed"
+     *   }
+     *   // Otherwise, just create a span with the given URL
+     * }
+     */
+    fun onNetworkRequest(info: NetworkRequestInfo)
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.internal.NetworkRequestInfo
 
 class PerformanceConfiguration private constructor(val context: Context) {
 
@@ -30,7 +29,11 @@ class PerformanceConfiguration private constructor(val context: Context) {
 
     var logger: Logger? = null
 
-    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)? = null
+    /**
+     * Callback to be invoked on every network request that would generate a span.
+     * Use this to filter what URLs will generate spans and how.
+     */
+    var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
 
     override fun toString(): String =
         "PerformanceConfiguration(" +

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
+import com.bugsnag.android.performance.internal.NetworkRequestInfo
 
 class PerformanceConfiguration private constructor(val context: Context) {
 
@@ -28,6 +29,8 @@ class PerformanceConfiguration private constructor(val context: Context) {
     var appVersion: String? = null
 
     var logger: Logger? = null
+
+    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)? = null
 
     override fun toString(): String =
         "PerformanceConfiguration(" +

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
@@ -19,6 +19,7 @@ internal data class ImmutableConfig(
     val versionCode: Long?,
     val appVersion: String?,
     val logger: Logger,
+    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)?,
 ) {
     val isReleaseStageEnabled =
         enabledReleaseStages == null || enabledReleaseStages.contains(releaseStage)
@@ -37,6 +38,7 @@ internal data class ImmutableConfig(
         configuration.logger
             ?: if (getReleaseStage(configuration) == RELEASE_STAGE_PRODUCTION) NoopLogger
             else DebugLogger,
+        configuration.networkRequestCallback,
     )
 
     companion object {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ImmutableConfig.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.Logger
+import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
 import com.bugsnag.android.performance.PerformanceConfiguration
 
 internal data class ImmutableConfig(
@@ -19,7 +20,7 @@ internal data class ImmutableConfig(
     val versionCode: Long?,
     val appVersion: String?,
     val logger: Logger,
-    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)?,
+    var networkRequestCallback: NetworkRequestInstrumentationCallback?,
 ) {
     val isReleaseStageEnabled =
         enabledReleaseStages == null || enabledReleaseStages.contains(releaseStage)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -54,6 +54,7 @@ class InstrumentedAppState {
 
         spanProcessor = tracer
         spanFactory.spanProcessor = tracer
+        spanFactory.networkRequestCallback = configuration.networkRequestCallback
 
         if (configuration.autoInstrumentAppStarts) {
             // redirect existing spanProcessor -> new Tracer

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkRequestInfo.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkRequestInfo.kt
@@ -1,0 +1,6 @@
+package com.bugsnag.android.performance.internal
+
+class NetworkRequestInfo(
+    var url: String? = null
+) {
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkRequestInfo.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkRequestInfo.kt
@@ -1,6 +1,0 @@
-package com.bugsnag.android.performance.internal
-
-class NetworkRequestInfo(
-    var url: String? = null
-) {
-}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -2,7 +2,8 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Activity
 import com.bugsnag.android.performance.HasAttributes
-import com.bugsnag.android.performance.Logger
+import com.bugsnag.android.performance.NetworkRequestInfo
+import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
 import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.SpanOptions
@@ -15,7 +16,7 @@ class SpanFactory(
     var spanProcessor: SpanProcessor,
     val spanAttributeSource: AttributeSource = {},
 ) {
-    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)? = null
+    var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
     fun createCustomSpan(
         name: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -34,7 +35,7 @@ class SpanFactory(
         spanProcessor: SpanProcessor = this.spanProcessor,
     ): SpanImpl? {
         val reqInfo = NetworkRequestInfo(url)
-        networkRequestCallback?.let { it(reqInfo) }
+        networkRequestCallback?.onNetworkRequest(reqInfo)
         reqInfo.url?.let {resultUrl ->
             val verbUpper = verb.uppercase()
             val span = createSpan(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Activity
 import com.bugsnag.android.performance.HasAttributes
+import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.SpanOptions
@@ -14,6 +15,7 @@ class SpanFactory(
     var spanProcessor: SpanProcessor,
     val spanAttributeSource: AttributeSource = {},
 ) {
+    var networkRequestCallback: ((NetworkRequestInfo) -> Unit)? = null
     fun createCustomSpan(
         name: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -30,18 +32,23 @@ class SpanFactory(
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
         spanProcessor: SpanProcessor = this.spanProcessor,
-    ): SpanImpl {
-        val verbUpper = verb.uppercase()
-        val span = createSpan(
-            "[HTTP/$verbUpper]",
-            SpanKind.CLIENT,
-            SpanCategory.NETWORK,
-            options,
-            spanProcessor,
-        )
-        span.setAttribute("http.url", url)
-        span.setAttribute("http.method", verbUpper)
-        return span
+    ): SpanImpl? {
+        val reqInfo = NetworkRequestInfo(url)
+        networkRequestCallback?.let { it(reqInfo) }
+        reqInfo.url?.let {resultUrl ->
+            val verbUpper = verb.uppercase()
+            val span = createSpan(
+                "[HTTP/$verbUpper]",
+                SpanKind.CLIENT,
+                SpanCategory.NETWORK,
+                options,
+                spanProcessor,
+            )
+            span.setAttribute("http.url", resultUrl)
+            span.setAttribute("http.method", verbUpper)
+            return span
+        }
+        return null
     }
 
     fun createViewLoadSpan(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -32,6 +32,7 @@ class ResourceAttributesTest {
             321L,
             "6.5.4",
             NoopLogger,
+            null,
         )
 
         val attributes = createResourceAttributes(configuration).toList().toMap()
@@ -65,6 +66,7 @@ class ResourceAttributesTest {
             123L,
             "5.4.3",
             NoopLogger,
+            null,
         )
 
         val attributes = createResourceAttributes(configuration).toList().toMap()

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -31,12 +31,14 @@ class BugsnagPerformanceOkhttp : EventListener() {
             networkSpanOptions,
         )
 
-        val contentLength = call.request().body?.contentLength()
-        if (contentLength != null) {
-            NetworkRequestAttributes.setRequestContentLength(span, contentLength)
-        }
+        if (span != null) {
+            val contentLength = call.request().body?.contentLength()
+            if (contentLength != null) {
+                NetworkRequestAttributes.setRequestContentLength(span, contentLength)
+            }
 
-        spans[call] = span
+            spans[call] = span
+        }
     }
 
     override fun responseHeadersEnd(call: Call, response: Response) {

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -5,8 +5,8 @@
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
-    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$6</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
+    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$6</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$1000L</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100L</ID>
@@ -22,13 +22,15 @@
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerAlarmReceiver.kt$MazeRacerAlarmReceiver$250L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$2000L</ID>
+    <ID>MagicNumber:OkhttpAutoInstrumentNetworkCallbackScenario.kt$OkhttpAutoInstrumentNetworkCallbackScenario$1000L</ID>
+    <ID>MagicNumber:OkhttpAutoInstrumentNetworkCallbackScenario.kt$OkhttpAutoInstrumentNetworkCallbackScenario$9</ID>
+    <ID>MagicNumber:OkhttpManualNetworkCallbackScenario.kt$OkhttpManualNetworkCallbackScenario$1000L</ID>
+    <ID>MagicNumber:OkhttpManualNetworkCallbackScenario.kt$OkhttpManualNetworkCallbackScenario$9</ID>
     <ID>MagicNumber:OkhttpSpanScenario.kt$OkhttpSpanScenario$1000L</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$100</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$3</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$30</ID>
-    <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$4</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$50</ID>
-    <ID>MagicNumber:SamplingProbabilityZeroScenario.kt$SamplingProbabilityZeroScenario$100</ID>
     <ID>MagicNumber:ThreeSpansScenario.kt$ThreeSpansScenario$300</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>
     <ID>TooManyFunctions:MainActivity.kt$MainActivity : AppCompatActivity</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.mazeracer.scenarios
 
 import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.android.performance.okhttp.BugsnagPerformanceOkhttp
@@ -19,15 +20,14 @@ class OkhttpAutoInstrumentNetworkCallbackScenario(
     }
 
     override fun startScenario() {
-        config.networkRequestCallback = {reqInfo ->
-            reqInfo.url?.let { url ->
-                if (url.startsWith("http://bs-local.com")) {
-                    reqInfo.url = null
-                } else if (url == "https://google.com/") {
-                    reqInfo.url = null
-                } else if (url.endsWith("/changeme")) {
-                    reqInfo.url = url.dropLast(9) + "/changed"
-                }
+        config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
+            val url = reqInfo.url ?: return@NetworkRequestInstrumentationCallback
+            if (url.startsWith("http://bs-local.com")) {
+                reqInfo.url = null
+            } else if (url == "https://google.com/") {
+                reqInfo.url = null
+            } else if (url.endsWith("/changeme")) {
+                reqInfo.url = url.dropLast(9) + "/changed"
             }
         }
 
@@ -42,7 +42,6 @@ class OkhttpAutoInstrumentNetworkCallbackScenario(
             makeCall(client, "https://bugsnag.com/changeme")
             makeCall(client, "https://google.com/")
         }
-        Thread.sleep(1000L)
     }
 
     fun makeCall(client: OkHttpClient, url: String) {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
@@ -1,0 +1,57 @@
+package com.bugsnag.mazeracer.scenarios
+
+import android.util.Log
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.internal.InternalDebug
+import com.bugsnag.android.performance.okhttp.BugsnagPerformanceOkhttp
+import com.bugsnag.mazeracer.Scenario
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.concurrent.thread
+
+class OkhttpAutoInstrumentNetworkCallbackScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    init {
+        InternalDebug.spanBatchSizeSendTriggerPoint = 1
+    }
+
+    override fun startScenario() {
+        config.networkRequestCallback = {reqInfo ->
+            reqInfo.url?.let { url ->
+                if (url.startsWith("http://bs-local.com")) {
+                    reqInfo.url = null
+                } else if (url == "https://google.com/") {
+                    reqInfo.url = null
+                } else if (url.endsWith("/changeme")) {
+                    reqInfo.url = url.dropLast(9) + "/changed"
+                }
+            }
+        }
+
+        BugsnagPerformance.start(config)
+
+        thread {
+            val client = OkHttpClient.Builder()
+                .eventListenerFactory(BugsnagPerformanceOkhttp)
+                .build()
+
+            makeCall(client, "https://bugsnag.com/")
+            makeCall(client, "https://bugsnag.com/changeme")
+            makeCall(client, "https://google.com/")
+        }
+        Thread.sleep(1000L)
+    }
+
+    fun makeCall(client: OkHttpClient, url: String) {
+        val request = Request.Builder().url(url).build()
+
+        client.newCall(request).execute().use { response ->
+            // Consume and discard the response body.
+            val size = response.body?.byteString()?.size?.toString() ?: "no"
+            Log.i("OkhttpAutoInstrument", "Read $size bytes from ${request.url}")
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
@@ -1,0 +1,59 @@
+package com.bugsnag.mazeracer.scenarios
+
+import android.util.Log
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.android.performance.internal.InternalDebug
+import com.bugsnag.android.performance.okhttp.BugsnagPerformanceOkhttp
+import com.bugsnag.mazeracer.Scenario
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URL
+import kotlin.concurrent.thread
+
+class OkhttpManualNetworkCallbackScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    init {
+        InternalDebug.spanBatchSizeSendTriggerPoint = 1
+    }
+
+    override fun startScenario() {
+        config.networkRequestCallback = {reqInfo ->
+            reqInfo.url?.let { url ->
+                if (url.startsWith("http://bs-local.com")) {
+                    reqInfo.url = null
+                } else if (url == "https://google.com/") {
+                    reqInfo.url = null
+                } else if (url.endsWith("/changeme")) {
+                    reqInfo.url = url.dropLast(9) + "/changed"
+                }
+            }
+        }
+
+        BugsnagPerformance.start(config)
+
+        thread {
+            val client = OkHttpClient.Builder()
+                .build()
+
+            makeCall(client, "https://bugsnag.com/")
+            makeCall(client, "https://bugsnag.com/changeme")
+            makeCall(client, "https://google.com/")
+        }
+        Thread.sleep(1000L)
+    }
+
+    fun makeCall(client: OkHttpClient, url: String) {
+        val request = Request.Builder().url(url).build()
+
+        val span = BugsnagPerformance.startNetworkRequestSpan(URL(url), "GET")
+        client.newCall(request).execute().use { response ->
+            span?.end()
+            // Consume and discard the response body.
+            val size = response.body?.byteString()?.size?.toString() ?: "no"
+            Log.i("OkhttpAutoInstrument", "Read $size bytes from ${request.url}")
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
@@ -2,9 +2,9 @@ package com.bugsnag.mazeracer.scenarios
 
 import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
-import com.bugsnag.android.performance.okhttp.BugsnagPerformanceOkhttp
 import com.bugsnag.mazeracer.Scenario
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -20,7 +20,7 @@ class OkhttpManualNetworkCallbackScenario(
     }
 
     override fun startScenario() {
-        config.networkRequestCallback = {reqInfo ->
+        config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
             reqInfo.url?.let { url ->
                 if (url.startsWith("http://bs-local.com")) {
                     reqInfo.url = null
@@ -42,7 +42,6 @@ class OkhttpManualNetworkCallbackScenario(
             makeCall(client, "https://bugsnag.com/changeme")
             makeCall(client, "https://google.com/")
         }
-        Thread.sleep(1000L)
     }
 
     fun makeCall(client: OkHttpClient, url: String) {

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -23,3 +23,29 @@ Feature: OkHttp EventListener
     Given I run "OkhttpSpanScenario" configured as "https://localhost:9876"
     And I wait to receive a sampling request
     Then I should receive no traces
+
+  Scenario: Auto-Instrument Network with Callback
+    Given I run "OkhttpAutoInstrumentNetworkCallbackScenario"
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "http.url" equals "https://bugsnag.com/"
+    * a span string attribute "http.url" equals "https://bugsnag.com/changed"
+
+  Scenario: Manual-Instrument Network with Callback
+    Given I run "OkhttpManualNetworkCallbackScenario"
+    And I wait for 2 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * every span field "name" equals "[HTTP/GET]"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * a span string attribute "http.url" equals "https://bugsnag.com/"
+    * a span string attribute "http.url" equals "https://bugsnag.com/changed"


### PR DESCRIPTION
## Goal

URLs in network request spans can now be customized via configurable callback.

## Design

Per ED

## Testing

New e2e tests to verify automatic and manual span creation.
