### PR TITLE
Send/Retry tasks should only be successful on delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * Traces are now correctly enqueued for retry when there is no active network (instead of being swallowed by the `UnknownHostException`)
   [#170](https://github.com/bugsnag/bugsnag-android-performance/pull/170)
+* Delivery and retry are only considered to have done work if the payload was delivered successfully
+  [#172](https://github.com/bugsnag/bugsnag-android-performance/pull/172)
 
 ## 1.0.0 (2023-07-17)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDeliveryTask.kt
@@ -22,7 +22,8 @@ internal class RetryDeliveryTask(
         ) {
             retryQueue.remove(nextPayload.timestamp)
         }
-        return true
+
+        return result is DeliveryResult.Success
     }
 
     override fun toString(): String = "RetryDeliveryTask"

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -16,8 +16,8 @@ internal class SendBatchTask(
         if (nextBatch.isNotEmpty()) {
             Logger.d("Sending a batch of ${nextBatch.size} spans to $delivery")
         }
-        delivery.deliver(nextBatch, resourceAttributes)
-        return nextBatch.isNotEmpty()
+        val result = delivery.deliver(nextBatch, resourceAttributes)
+        return nextBatch.isNotEmpty() && result is DeliveryResult.Success
     }
 
     override fun toString(): String = "SendBatch[$delivery]"

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Worker.kt
@@ -11,8 +11,8 @@ internal interface Task {
     fun onDetach(worker: Worker) = Unit
 
     /**
-     * Run the task and return `true` if any work was done (and more work is likely to be available
-     * on the next call to `execute`).
+     * Run the task and return `true` if work was done successfully (and more work is likely to be
+     * available on the next call to `execute`).
      */
     fun execute(): Boolean
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTaskTest.kt
@@ -92,7 +92,7 @@ class RetryDeliveryTaskTest {
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
 
         delivery.nextResult = DeliveryResult.Failed(tracePayload, false)
-        assertTrue(retryDeliveryTask.execute())
+        assertFalse(retryDeliveryTask.execute())
 
         verify(retryQueue).remove(tracePayload.timestamp)
     }
@@ -119,7 +119,7 @@ class RetryDeliveryTaskTest {
         val retryDeliveryTask = RetryDeliveryTask(retryQueue, delivery, connectivity)
 
         delivery.nextResult = DeliveryResult.Failed(tracePayload, true)
-        assertTrue(retryDeliveryTask.execute())
+        assertFalse(retryDeliveryTask.execute())
 
         verify(retryQueue, never()).remove(any())
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
@@ -37,7 +37,9 @@ class SendBatchTaskTest {
             on { collectNextBatch() } doReturn spanFactory.newSpans(10, NoopSpanProcessor)
         }
 
-        val delivery = mock<Delivery>()
+        val delivery = mock<Delivery> {
+            on { deliver(any(), any()) } doReturn DeliveryResult.Success
+        }
 
         val resourceAttributes = Attributes()
         val sendBatchTask = SendBatchTask(delivery, tracer, resourceAttributes)


### PR DESCRIPTION
## Goal
Send and retry should only be considered to have "done work" if a payload was successfully delivered.

## Design
If a send or retry failed to deliver a payload, the worker should go back to its idle state rather that immediately cycling around. This prevents the worker from immediately retrying failed deliveries.

## Testing
Manual testing & modified existing tests