### PR TITLE
Implement instrumentation configuration cache

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -25,6 +25,7 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CLIENT$3</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
+    <ID>NewLineAtEndOfFile:AutoInstrumentationCache.kt$com.bugsnag.android.performance.AutoInstrumentationCache.kt</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ActivityControl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ActivityControl.kt
@@ -6,7 +6,7 @@ package com.bugsnag.android.performance
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class DoesNotEndAppStart
+annotation class DoNotEndAppStart
 
 /**
  * Annotation Activities and Fragments are ignored by automatic instrumentation.

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/AutoInstrumentationCache.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/AutoInstrumentationCache.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android.performance
+
+import android.app.Activity
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AutoInstrumentationCache {
+    private val appStartActivitiesCache = HashMap<Class<out Activity>, Boolean>()
+    private val autoInstrumentCache = HashMap<Class<*>, Boolean>()
+
+    /**
+     * Class does not need instrumentation.
+     */
+    fun isInstrumentationEnabled(jclass: Class<*>): Boolean {
+        return autoInstrumentCache.getOrPut(jclass) {
+            !jclass.isAnnotationPresent(DoNotInstrument::class.java)
+        }
+    }
+
+    /**
+     * Activities do not need to be ended.
+     */
+    fun isAppStartActivity(jclass: Class<out Activity>): Boolean {
+        return appStartActivitiesCache.getOrPut(jclass) {
+            jclass.isAnnotationPresent(DoNotEndAppStart::class.java)
+        }
+    }
+
+    fun configuration(
+        appStartActivities: Collection<Class<out Activity>>,
+        autoInstrument: Collection<Class<*>>
+    ) {
+        appStartActivities.forEach { appStartActivitiesCache[it] = true }
+        autoInstrument.forEach { autoInstrumentCache[it] = true }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AutoInstrumentationCacheTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AutoInstrumentationCacheTest.kt
@@ -1,0 +1,197 @@
+package com.bugsnag.android.performance.internal
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.bugsnag.android.performance.AutoInstrumentationCache
+import com.bugsnag.android.performance.DoNotEndAppStart
+import com.bugsnag.android.performance.DoNotInstrument
+import com.bugsnag.android.performance.PerformanceConfiguration
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+
+internal class AutoInstrumentationCacheTest {
+
+    @DoNotInstrument
+    class DoNotInstrumentActivity : Activity()
+
+    @DoNotEndAppStart
+    class DoNotEndAppStartActivity : Activity()
+
+    @DoNotInstrument
+    @DoNotEndAppStart
+    class NoInstrumentationAppStartActivity : Activity()
+
+    class NoAnnotatedActivity : Activity()
+
+    private val perfConfig =
+        PerformanceConfiguration(mockedContext(), TEST_API_KEY)
+
+    @Test
+    fun testIsInstrumentationEnabled() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isInstrumentationEnabled(DoNotInstrumentActivity::class.java)
+        assertFalse(result)
+    }
+
+    @Test
+    fun testIsAppStartActivity() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isAppStartActivity(DoNotEndAppStartActivity::class.java)
+        assertTrue(result)
+    }
+
+    @Test
+    fun testInstrumentationIsEnabled() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isInstrumentationEnabled(NoAnnotatedActivity::class.java)
+        assertTrue(result)
+    }
+
+    @Test
+    fun testAppStartActivityIsEnabled() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isAppStartActivity(NoAnnotatedActivity::class.java)
+        assertFalse(result)
+    }
+
+    @Test
+    fun testInstrumentationNotEnabled() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isInstrumentationEnabled(NoInstrumentationAppStartActivity::class.java)
+        assertFalse(result)
+    }
+
+    @Test
+    fun testAppStartActivityNotEnabled() {
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+        val result =
+            autoInstrumentationCache.isAppStartActivity(NoInstrumentationAppStartActivity::class.java)
+        assertTrue(result)
+    }
+
+    @Test
+    fun testDoNotInstrumentActivities() {
+        val doNotInstrumentActivities = hashSetOf<Class<Any>>()
+        doNotInstrumentActivities.add(DoNotInstrumentActivity::class.java as Class<Any>)
+        doNotInstrumentActivities.add(DoNotEndAppStartActivity::class.java as Class<Any>)
+        perfConfig.doNotAutoInstrument = doNotInstrumentActivities
+
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+
+        val isInstrumentationResult1 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotAutoInstrument.last())
+        assertTrue(isInstrumentationResult1)
+
+        val isInstrumentationResult2 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotAutoInstrument.first())
+        assertTrue(isInstrumentationResult2)
+    }
+
+    @Test
+    fun testDoNotEndAppStartActivities() {
+        val doNotEndAppStartActivities = hashSetOf<Class<out Activity>>()
+        doNotEndAppStartActivities.add(DoNotEndAppStartActivity::class.java as Class<out Activity>)
+        perfConfig.doNotEndAppStart = doNotEndAppStartActivities
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+
+        val isEndAppStartResult1 =
+            autoInstrumentationCache.isAppStartActivity(perfConfig.doNotEndAppStart.first())
+        assertTrue(isEndAppStartResult1)
+
+        val isEndAppStartResult2 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotEndAppStart.first())
+        assertTrue(isEndAppStartResult2)
+    }
+
+    @Test
+    fun testMixedActivities() {
+        val doNotInstrumentActivities = hashSetOf<Class<Any>>()
+        val doNotEndAppStartActivities = hashSetOf<Class<out Activity>>()
+
+        doNotInstrumentActivities.add(DoNotInstrumentActivity::class.java as Class<Any>)
+        doNotInstrumentActivities.add(NoInstrumentationAppStartActivity::class.java as Class<Any>)
+
+        doNotEndAppStartActivities.add(DoNotEndAppStartActivity::class.java as Class<out Activity>)
+        doNotEndAppStartActivities.add(NoInstrumentationAppStartActivity::class.java as Class<out Activity>)
+
+        perfConfig.doNotAutoInstrument = doNotInstrumentActivities
+        perfConfig.doNotEndAppStart = doNotEndAppStartActivities
+
+        val autoInstrumentationCache =
+            AutoInstrumentationCache()
+        autoInstrumentationCache.configuration(perfConfig.doNotEndAppStart, perfConfig.doNotAutoInstrument)
+
+        val isInstrumentationResult1 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotAutoInstrument.last())
+        assertTrue(isInstrumentationResult1)
+
+        val isInstrumentationResult2 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotAutoInstrument.first())
+        assertTrue(isInstrumentationResult2)
+
+        val isEndAppStartResult1 =
+            autoInstrumentationCache.isAppStartActivity(perfConfig.doNotEndAppStart.last())
+        assertTrue(isEndAppStartResult1)
+
+        val isEndAppStartResult2 =
+            autoInstrumentationCache.isInstrumentationEnabled(perfConfig.doNotEndAppStart.first())
+        assertTrue(isEndAppStartResult2)
+    }
+
+    private fun mockedContext(): Context {
+        val packageInfo = mock<PackageInfo> { info ->
+            // versionCode is a Java field, not a getter
+            @Suppress("DEPRECATION")
+            info.versionCode = TEST_VERSION_CODE
+            info.versionName = TEST_VERSION_NAME
+
+            on { info.longVersionCode } doReturn TEST_VERSION_CODE.toLong()
+        }
+
+        val packageManager = mock<PackageManager> { pm ->
+            on { (pm.getPackageInfo(eq(TEST_PACKAGE_NAME), any())) } doReturn packageInfo
+        }
+
+        return mock<Application> { ctx ->
+            on { ctx.packageName } doReturn TEST_PACKAGE_NAME
+            on { ctx.applicationContext } doReturn ctx
+            on { ctx.packageManager } doReturn packageManager
+        }
+    }
+
+    companion object {
+        const val TEST_PACKAGE_NAME = "com.test.pckname"
+        const val TEST_API_KEY = "decafbaddecafbaddecafbaddecafbad"
+        const val TEST_VERSION_CODE = 987654321
+        const val TEST_VERSION_NAME = "7.6.5"
+    }
+}


### PR DESCRIPTION
## Goal

An automation to tell if the fragment or activity needs to ended instrumentation or ended app start


## Changeset

Add automation class to tell if the fragment or activity needs to ended instrumentation or ended app start by the cache

## Testing

Introducing new unit tests