### PR TITLE
End to end tests for DoNotEndAppStart class

### DIFF
--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -22,15 +22,14 @@
     <ID>MagicNumber:ManualSpanScenario.kt$ManualSpanScenario$100L</ID>
     <ID>MagicNumber:MazeRacerAlarmReceiver.kt$MazeRacerAlarmReceiver$250L</ID>
     <ID>MagicNumber:MazeRacerApplication.kt$MazeRacerApplication$2000L</ID>
-    <ID>MagicNumber:OkhttpAutoInstrumentNetworkCallbackScenario.kt$OkhttpAutoInstrumentNetworkCallbackScenario$1000L</ID>
     <ID>MagicNumber:OkhttpAutoInstrumentNetworkCallbackScenario.kt$OkhttpAutoInstrumentNetworkCallbackScenario$9</ID>
-    <ID>MagicNumber:OkhttpManualNetworkCallbackScenario.kt$OkhttpManualNetworkCallbackScenario$1000L</ID>
     <ID>MagicNumber:OkhttpManualNetworkCallbackScenario.kt$OkhttpManualNetworkCallbackScenario$9</ID>
     <ID>MagicNumber:OkhttpSpanScenario.kt$OkhttpSpanScenario$1000L</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$100</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$3</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$30</ID>
     <ID>MagicNumber:PreStartSpansScenario.kt$PreStartSpansScenario$50</ID>
+    <ID>MagicNumber:SplashScreenActivity.kt$SplashScreenActivity$250L</ID>
     <ID>MagicNumber:ThreeSpansScenario.kt$ThreeSpansScenario$300</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>
     <ID>TooManyFunctions:MainActivity.kt$MainActivity : AppCompatActivity</ID>

--- a/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
@@ -18,22 +18,22 @@
             android:value="project_apikeyapikeyapikeyapikey" />
 
         <activity
-            android:name=".MainActivity"
+            android:name=".SplashScreenActivity"
             android:exported="true">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <activity android:name=".ActivityViewLoadActivity"/>
-        <activity android:name=".NestedSpansActivity"/>
+        <activity android:name=".MainActivity" />
+
+        <activity android:name=".ActivityViewLoadActivity" />
+        <activity android:name=".NestedSpansActivity" />
 
         <receiver
             android:name=".MazeRacerAlarmReceiver"
-            android:exported="true"
-            />
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/SplashScreenActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/SplashScreenActivity.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.mazeracer
+
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import com.bugsnag.android.performance.DoNotEndAppStart
+
+@DoNotEndAppStart
+class SplashScreenActivity : AppCompatActivity() {
+    override fun onResume() {
+        super.onResume()
+        Handler(Looper.getMainLooper()).postDelayed(
+            {
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            },
+            250L,
+        )
+    }
+}

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -5,41 +5,41 @@ Feature: Automatic creation of spans
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
     And I wait to receive a trace
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load                |
+      | bugsnag.view.type     | stringValue | activity                 |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | fragment                 |
-                | bugsnag.view.name       | stringValue | LoaderFragment           |
+      | attribute             | type        | value          |
+      | bugsnag.span.category | stringValue | view_load      |
+      | bugsnag.view.type     | stringValue | fragment       |
+      | bugsnag.view.name     | stringValue | LoaderFragment |
 
   @skip_above_android_9
   Scenario: Activity with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
     And I wait to receive a trace
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load                |
+      | bugsnag.view.type     | stringValue | activity                 |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
-               | attribute               | type        | value                    |
-               | bugsnag.span.category   | stringValue | view_load                |
-               | bugsnag.view.type       | stringValue | fragment                 |
-               | bugsnag.view.name       | stringValue | LoaderFragment           |
+      | attribute             | type        | value          |
+      | bugsnag.span.category | stringValue | view_load      |
+      | bugsnag.view.type     | stringValue | fragment       |
+      | bugsnag.view.name     | stringValue | LoaderFragment |
 
   Scenario: Activity with no automatic ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "OFF"
     And I wait to receive at least 1 trace
     Then a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
-              | attribute               | type        | value                    |
-              | bugsnag.span.category   | stringValue | view_load                |
-              | bugsnag.view.type       | stringValue | fragment                 |
-              | bugsnag.view.name       | stringValue | LoaderFragment           |
+      | attribute             | type        | value          |
+      | bugsnag.span.category | stringValue | view_load      |
+      | bugsnag.view.type     | stringValue | fragment       |
+      | bugsnag.view.name     | stringValue | LoaderFragment |
 
   @skip_below_android_10
   Scenario: AppStart instrumentation
@@ -48,39 +48,39 @@ Feature: Automatic creation of spans
     * I load scenario "AppStartScenario"
     And I wait for 6 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
-                | attribute                         | type        | value          |
-                | bugsnag.span.category             | stringValue | app_start      |
-                | bugsnag.app_start.type            | stringValue | cold           |
-                | bugsnag.app_start.first_view_name | stringValue | MainActivity   |
+      | attribute                         | type        | value                |
+      | bugsnag.span.category             | stringValue | app_start            |
+      | bugsnag.app_start.type            | stringValue | cold                 |
+      | bugsnag.app_start.first_view_name | stringValue | SplashScreenActivity |
 
     * a span named "[AppStartPhase/Framework]" contains the attributes:
-                | attribute                         | type        | value           |
-                | bugsnag.span.category             | stringValue | app_start_phase |
-                | bugsnag.phase                     | stringValue | FrameworkLoad   |
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | app_start_phase |
+      | bugsnag.phase         | stringValue | FrameworkLoad   |
 
     * a span named "[ViewLoad/Activity]MainActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | MainActivity             |
+      | attribute             | type        | value        |
+      | bugsnag.span.category | stringValue | view_load    |
+      | bugsnag.view.type     | stringValue | activity     |
+      | bugsnag.view.name     | stringValue | MainActivity |
 
     * a span named "[ViewLoadPhase/ActivityCreate]MainActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityCreate            |
-               | bugsnag.view.name       | stringValue | MainActivity              |
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityCreate  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
 
     * a span named "[ViewLoadPhase/ActivityStart]MainActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityStart             |
-               | bugsnag.view.name       | stringValue | MainActivity              |
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityStart   |
+      | bugsnag.view.name     | stringValue | MainActivity    |
 
     * a span named "[ViewLoadPhase/ActivityResume]MainActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityResume            |
-               | bugsnag.view.name       | stringValue | MainActivity              |
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityResume  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
 
   @skip_above_android_9
   Scenario: AppStart instrumentation
@@ -89,99 +89,158 @@ Feature: Automatic creation of spans
     * I load scenario "AppStartScenario"
     And I wait for 2 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
-                | attribute                         | type        | value          |
-                | bugsnag.span.category             | stringValue | app_start      |
-                | bugsnag.app_start.type            | stringValue | cold           |
-                | bugsnag.app_start.first_view_name | stringValue | MainActivity   |
+      | attribute                         | type        | value                |
+      | bugsnag.span.category             | stringValue | app_start            |
+      | bugsnag.app_start.type            | stringValue | cold                 |
+      | bugsnag.app_start.first_view_name | stringValue | SplashScreenActivity |
 
     * a span named "[ViewLoad/Activity]MainActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | MainActivity             |
+      | attribute             | type        | value        |
+      | bugsnag.span.category | stringValue | view_load    |
+      | bugsnag.view.type     | stringValue | activity     |
+      | bugsnag.view.name     | stringValue | MainActivity |
 
   @skip_below_android_10
   Scenario: Activity load breakdown with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
     And I wait for 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load                |
+      | bugsnag.view.type     | stringValue | activity                 |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityCreate]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityCreate            |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityCreate           |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityStart]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityStart             |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityStart            |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityResume]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityResume            |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityResume           |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load                 |
-               | bugsnag.view.type       | stringValue | fragment                  |
-               | bugsnag.view.name       | stringValue | LoaderFragment            |
+      | attribute             | type        | value          |
+      | bugsnag.span.category | stringValue | view_load      |
+      | bugsnag.view.type     | stringValue | fragment       |
+      | bugsnag.view.name     | stringValue | LoaderFragment |
 
   @skip_below_android_10
   Scenario: Activity load breakdown with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
     And I wait for 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-                | attribute               | type        | value                    |
-                | bugsnag.span.category   | stringValue | view_load                |
-                | bugsnag.view.type       | stringValue | activity                 |
-                | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load                |
+      | bugsnag.view.type     | stringValue | activity                 |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityCreate]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityCreate            |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityCreate           |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityStart]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityStart             |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityStart            |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoadPhase/ActivityResume]ActivityViewLoadActivity" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load_phase           |
-               | bugsnag.phase           | stringValue | ActivityResume            |
-               | bugsnag.view.name       | stringValue | ActivityViewLoadActivity  |
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load_phase          |
+      | bugsnag.phase         | stringValue | ActivityResume           |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
 
     * a span named "[ViewLoad/Fragment]LoaderFragment" contains the attributes:
-               | attribute               | type        | value                     |
-               | bugsnag.span.category   | stringValue | view_load                 |
-               | bugsnag.view.type       | stringValue | fragment                  |
-               | bugsnag.view.name       | stringValue | LoaderFragment            |
+      | attribute             | type        | value          |
+      | bugsnag.span.category | stringValue | view_load      |
+      | bugsnag.view.type     | stringValue | fragment       |
+      | bugsnag.view.name     | stringValue | LoaderFragment |
 
-    Scenario: AppStart/AndroidCold is discarded for background starts
-      Given I run "BackgroundAppStartScenario"
-      And I wait for 1 span
-      * a span named "AlarmReceiver" contains the attributes:
-              | attribute                 | type        | value                     |
-              | bugsnag.span.first_class  | boolValue   | true                      |
+  Scenario: AppStart/AndroidCold is discarded for background starts
+    Given I run "BackgroundAppStartScenario"
+    And I wait for 1 span
+    * a span named "AlarmReceiver" contains the attributes:
+      | attribute                | type      | value |
+      | bugsnag.span.first_class | boolValue | true  |
       # this is required here to avoid interfering with other scenarios
-      * I force stop the Android app
+    * I force stop the Android app
 
-    Scenario: ViewLoad spans can be safely leaked
-      Given I run "ViewLoadLeakScenario"
-      And I wait to receive a trace
-      Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
-        | attribute               | type        | value                    |
-        | bugsnag.span.category   | stringValue | view_load                |
-        | bugsnag.view.type       | stringValue | activity                 |
-        | bugsnag.view.name       | stringValue | ActivityViewLoadActivity |
+  Scenario: ViewLoad spans can be safely leaked
+    Given I run "ViewLoadLeakScenario"
+    And I wait to receive a trace
+    Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
+      | attribute             | type        | value                    |
+      | bugsnag.span.category | stringValue | view_load                |
+      | bugsnag.view.type     | stringValue | activity                 |
+      | bugsnag.view.name     | stringValue | ActivityViewLoadActivity |
+
+  @skip_below_android_10
+  Scenario: AppStart instrumentation with splash screen
+    Given I run "AppStartScenario"
+    Then I relaunch the app after shutdown
+    * I load scenario "AppStartScenario"
+    And I wait for 9 spans
+    * a span named "[AppStart/AndroidCold]" contains the attributes:
+      | attribute                         | type        | value                |
+      | bugsnag.span.category             | stringValue | app_start            |
+      | bugsnag.app_start.type            | stringValue | cold                 |
+      | bugsnag.app_start.first_view_name | stringValue | SplashScreenActivity |
+
+    * a span named "[AppStartPhase/Framework]" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | app_start_phase |
+      | bugsnag.phase         | stringValue | FrameworkLoad   |
+
+    * a span named "[ViewLoad/Activity]MainActivity" contains the attributes:
+      | attribute             | type        | value        |
+      | bugsnag.span.category | stringValue | view_load    |
+      | bugsnag.view.type     | stringValue | activity     |
+      | bugsnag.view.name     | stringValue | MainActivity |
+
+    * a span named "[ViewLoadPhase/ActivityCreate]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityCreate  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+
+    * a span named "[ViewLoadPhase/ActivityStart]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityStart   |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+
+    * a span named "[ViewLoadPhase/ActivityResume]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityResume  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+    * a span named "[ViewLoadPhase/ActivityCreate]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityCreate  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+
+    * a span named "[ViewLoadPhase/ActivityStart]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityStart   |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+
+    * a span named "[ViewLoadPhase/ActivityResume]MainActivity" contains the attributes:
+      | attribute             | type        | value           |
+      | bugsnag.span.category | stringValue | view_load_phase |
+      | bugsnag.phase         | stringValue | ActivityResume  |
+      | bugsnag.view.name     | stringValue | MainActivity    |
+

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -226,21 +226,21 @@ Feature: Automatic creation of spans
       | bugsnag.span.category | stringValue | view_load_phase |
       | bugsnag.phase         | stringValue | ActivityResume  |
       | bugsnag.view.name     | stringValue | MainActivity    |
-    * a span named "[ViewLoadPhase/ActivityCreate]MainActivity" contains the attributes:
-      | attribute             | type        | value           |
-      | bugsnag.span.category | stringValue | view_load_phase |
-      | bugsnag.phase         | stringValue | ActivityCreate  |
-      | bugsnag.view.name     | stringValue | MainActivity    |
+    * a span named "[ViewLoadPhase/ActivityCreate]SplashScreenActivity" contains the attributes:
+      | attribute             | type        | value                |
+      | bugsnag.span.category | stringValue | view_load_phase      |
+      | bugsnag.phase         | stringValue | ActivityCreate       |
+      | bugsnag.view.name     | stringValue | SplashScreenActivity |
 
-    * a span named "[ViewLoadPhase/ActivityStart]MainActivity" contains the attributes:
-      | attribute             | type        | value           |
-      | bugsnag.span.category | stringValue | view_load_phase |
-      | bugsnag.phase         | stringValue | ActivityStart   |
-      | bugsnag.view.name     | stringValue | MainActivity    |
+    * a span named "[ViewLoadPhase/ActivityStart]SplashScreenActivity" contains the attributes:
+      | attribute             | type        | value                |
+      | bugsnag.span.category | stringValue | view_load_phase      |
+      | bugsnag.phase         | stringValue | ActivityStart        |
+      | bugsnag.view.name     | stringValue | SplashScreenActivity |
 
-    * a span named "[ViewLoadPhase/ActivityResume]MainActivity" contains the attributes:
-      | attribute             | type        | value           |
-      | bugsnag.span.category | stringValue | view_load_phase |
-      | bugsnag.phase         | stringValue | ActivityResume  |
-      | bugsnag.view.name     | stringValue | MainActivity    |
+    * a span named "[ViewLoadPhase/ActivityResume]SplashScreenActivity" contains the attributes:
+      | attribute             | type        | value                |
+      | bugsnag.span.category | stringValue | view_load_phase      |
+      | bugsnag.phase         | stringValue | ActivityResume       |
+      | bugsnag.view.name     | stringValue | SplashScreenActivity |
 

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -74,24 +74,23 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage (nested under NestedSpansActivity)
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.spanId" is stored as the value "activity_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.16.spanId" is stored as the value "activity_resume_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.17.spanId" is stored as the value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.20.spanId" is stored as the value "custom_root_span_id"
+    * the "[ViewLoadPhase/ActivityStart]NestedSpansActivity" span field "spanId" is stored as the value "activity_start_span_id"
+    * the "[ViewLoadPhase/ActivityResume]NestedSpansActivity" span field "spanId" is stored as the value "activity_resume_span_id"
+    * the "[ViewLoad/Activity]NestedSpansActivity" span field "spanId" is stored as the value "view_load_span_id"
+    * the "CustomRoot" span field "spanId" is stored as the value "custom_root_span_id"
 
     # ViewLoadPhase phase spans (Create, Start, Resume) should be nested under ViewLoad
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.10.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.16.parentSpanId" equals the stored value "view_load_span_id"
+    * the "[ViewLoadPhase/ActivityCreate]NestedSpansActivity" span field "parentSpanId" equals the stored value "view_load_span_id"
+    * the "[ViewLoadPhase/ActivityStart]NestedSpansActivity" span field "parentSpanId" equals the stored value "view_load_span_id"
+    * the "[ViewLoadPhase/ActivityResume]NestedSpansActivity" span field "parentSpanId" equals the stored value "view_load_span_id"
 
     # FirstFragment should be nested under ViewLoadPhase/Start
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.13.parentSpanId" equals the stored value "activity_start_span_id"
+    * the "[ViewLoad/Fragment]FirstFragment" span field "parentSpanId" equals the stored value "activity_start_span_id"
 
     # CustomRoot should be nested under ViewLoadPhase/Resume
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.21.parentSpanId" equals the stored value "activity_resume_span_id"
+    * the "CustomRoot" span field "parentSpanId" equals the stored value "activity_resume_span_id"
 
     # Remaining spans (SecondFragment, DoStuff, LoadData) should be nested under CustomRoot
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.15.parentSpanId" equals the stored value "custom_root_span_id"
-    # DoStuff is not reliably reported in the same location - so we don't check it for now
-    # * the trace payload field "resourceSpans.0.scopeSpans.0.spans.18.parentSpanId" equals the stored value "custom_root_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.19.parentSpanId" equals the stored value "custom_root_span_id"
+    * the "[ViewLoad/Fragment]SecondFragment" span field "parentSpanId" equals the stored value "custom_root_span_id"
+    * the "DoStuff" span field "parentSpanId" equals the stored value "custom_root_span_id"
+    * the "LoadData" span field "parentSpanId" equals the stored value "custom_root_span_id"

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -74,24 +74,24 @@ Feature: Nested spans
                 | bugsnag.span.first_class          | boolValue   | true                |
 
     # Check span parentage (nested under NestedSpansActivity)
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.spanId" is stored as the value "activity_start_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.spanId" is stored as the value "activity_resume_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.13.spanId" is stored as the value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.17.spanId" is stored as the value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.spanId" is stored as the value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.16.spanId" is stored as the value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.17.spanId" is stored as the value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.20.spanId" is stored as the value "custom_root_span_id"
 
     # ViewLoadPhase phase spans (Create, Start, Resume) should be nested under ViewLoad
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.6.parentSpanId" equals the stored value "view_load_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.8.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.10.parentSpanId" equals the stored value "view_load_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.12.parentSpanId" equals the stored value "view_load_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.16.parentSpanId" equals the stored value "view_load_span_id"
 
     # FirstFragment should be nested under ViewLoadPhase/Start
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.9.parentSpanId" equals the stored value "activity_start_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.13.parentSpanId" equals the stored value "activity_start_span_id"
 
     # CustomRoot should be nested under ViewLoadPhase/Resume
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.17.parentSpanId" equals the stored value "activity_resume_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.21.parentSpanId" equals the stored value "activity_resume_span_id"
 
     # Remaining spans (SecondFragment, DoStuff, LoadData) should be nested under CustomRoot
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.11.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.15.parentSpanId" equals the stored value "custom_root_span_id"
     # DoStuff is not reliably reported in the same location - so we don't check it for now
-    # * the trace payload field "resourceSpans.0.scopeSpans.0.spans.15.parentSpanId" equals the stored value "custom_root_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.16.parentSpanId" equals the stored value "custom_root_span_id"
+    # * the trace payload field "resourceSpans.0.scopeSpans.0.spans.18.parentSpanId" equals the stored value "custom_root_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.19.parentSpanId" equals the stored value "custom_root_span_id"


### PR DESCRIPTION
## Testing

End to end tests for a splash activity which is annotated as DoesNotEndAppStart and ensure that the end time of the AppStart is equal to the end of ViewLoad from a main activity.