### PR TITLE
Make the server_response_pvalue tests pass more reliably

### DIFF
--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -143,8 +143,8 @@ class MainActivity : AppCompatActivity() {
     private fun startBugsnag() {
         val config = Configuration.load(this).apply {
             endpoints = EndpointConfiguration(
-                "http://$mazeAddress/session",
-                "http://$mazeAddress/notify",
+                notify = "http://$mazeAddress/notify",
+                sessions = "http://$mazeAddress/session",
             )
         }
         Bugsnag.start(this, config)
@@ -158,6 +158,7 @@ class MainActivity : AppCompatActivity() {
             if (mazeAddress == null) setMazeRunnerAddress()
             checkNetwork()
             startBugsnag()
+            @Suppress("LoopWithTooManyJumpStatements")
             while (polling) {
                 Thread.sleep(1000)
                 try {
@@ -172,6 +173,13 @@ class MainActivity : AppCompatActivity() {
                     log("Received command: $commandStr")
                     val command = JSONObject(commandStr)
                     val action = command.getString("action")
+
+                    if (action == "noop") {
+                        log("noop - doing nothing and looping around for another poll()")
+                        // immediately loop around
+                        continue
+                    }
+
                     val scenarioName = command.getString("scenario_name")
                     val scenarioMetadata = command.getString("scenario_metadata")
                     val endpointUrl = command.getString("endpoint")

--- a/features/server_response_pvalue.feature
+++ b/features/server_response_pvalue.feature
@@ -188,7 +188,6 @@ Feature: Server responses P value
     And I should receive no traces
 
   Scenario: Update P to 0 on second response: fail-retriable, fail-permanent, success
-#    Given I set the HTTP status code for the next requests to 200,500,400,200
     Given I set the HTTP status code for the next requests to 200,500
     And I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
@@ -196,6 +195,7 @@ Feature: Server responses P value
     And I wait to receive at least 1 trace
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "span 1"
     Then I discard the oldest trace
+
     Given I set the HTTP status code for the next request to 400
     Then I invoke "sendNextSpan"
     And I wait to receive 2 traces
@@ -203,13 +203,13 @@ Feature: Server responses P value
     * a span named "span 2" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
+    Then I discard the oldest trace
 
     * a span named "span 2" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
+    Then I discard the oldest trace
 
-    Then I discard the oldest trace
-    Then I discard the oldest trace
     Given I set the HTTP status code for the next request to 200
     Then I invoke "sendNextSpan"
     And I wait to receive 1 trace


### PR DESCRIPTION
## Goal
Make the server_response_pvalue tests pass more reliably.

## Changeset
- Corrected the `notify` / `sessions` endpoint config for the `bugsnag-android` config in the end-to-end fixture
- Slightly adjusted the "Update P to 0 on second response: fail-retriable, fail-permanent, success" test scenario

## Testing
Tests should pass more reliably now.