### PR TITLE
Fix child coroutine span nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Coroutines forked from other coroutines within a `BugsnagPerformanceScope` will now have spans that nest naturally
+  [#193](https://github.com/bugsnag/bugsnag-android-performance/pull/193)
+
 ## 1.2.0 (2023-11-22)
 
 ### Enhancements

--- a/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
+++ b/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
@@ -10,18 +10,18 @@ import kotlinx.coroutines.ThreadContextElement
 import java.util.ArrayDeque
 import java.util.Deque
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
-private class ContextAwareCoroutineContextElement(spanContext: SpanContext) :
-    ThreadContextElement<Deque<SpanContext>> {
+private class ContextAwareCoroutineContextElement(
+    private val coroutineContextStack: Deque<SpanContext> = ArrayDeque(),
+) : ThreadContextElement<Deque<SpanContext>> {
+
+    constructor(spanContext: SpanContext) : this(ArrayDeque<SpanContext>().apply { push(spanContext) })
 
     override val key: CoroutineContext.Key<ContextAwareCoroutineContextElement>
         get() = Key
 
-    private val coroutineContextStack: Deque<SpanContext> = ArrayDeque()
-
-    init {
-        coroutineContextStack.push(spanContext)
-    }
+    fun copy() = ContextAwareCoroutineContextElement(ArrayDeque(coroutineContextStack))
 
     override fun updateThreadContext(context: CoroutineContext): Deque<SpanContext> {
         // coroutine starting/resuming - grab the current SpanContext stack for this thread
@@ -69,11 +69,56 @@ operator fun CoroutineContext.plus(context: SpanContext): CoroutineContext {
 }
 
 /**
+ * Each time a child coroutine is created (and this `CoroutineContext` is added to) we make
+ * a clone of the [ContextAwareCoroutineContextElement] which includes a full copy of the
+ * `SpanContext` stack. This means that span parentage tracks logically across child /
+ * forked coroutines.
+ *
+ * This behaviour is similar to `CopyableThreadContextElement` but does not depend on an
+ * experimental API. Once `CopyableThreadContextElement` is stable we should consider removing
+ * this class.
+ */
+private class BugsnagCoroutineContext(
+    private val baseContext: CoroutineContext,
+    private val baseSpanContext: ContextAwareCoroutineContextElement,
+) : CoroutineContext {
+
+    override fun plus(context: CoroutineContext): CoroutineContext {
+        if (context === EmptyCoroutineContext) return this
+        return BugsnagCoroutineContext(baseContext + context, baseSpanContext.copy())
+    }
+
+    override fun <R> fold(initial: R, operation: (R, CoroutineContext.Element) -> R): R {
+        return baseContext.fold(operation(initial, baseSpanContext), operation)
+    }
+
+    override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? {
+        return if (key === ContextAwareCoroutineContextElement.Key) {
+            baseSpanContext as E
+        } else {
+            baseContext[key]
+        }
+    }
+
+    override fun minusKey(key: CoroutineContext.Key<*>): CoroutineContext {
+        return if (key === ContextAwareCoroutineContextElement.Key) {
+            baseContext
+        } else {
+            BugsnagCoroutineContext(baseContext.minusKey(key), baseSpanContext.copy())
+        }
+    }
+}
+
+
+/**
  * A Coroutine Scope to automatically create context-aware coroutines
  */
 class BugsnagPerformanceScope(dispatcher: CoroutineDispatcher = Dispatchers.Main) : CoroutineScope {
     private val baseContext = SupervisorJob() + dispatcher
 
     override val coroutineContext: CoroutineContext
-        get() = baseContext + SpanContext.current.asCoroutineElement()
+        get() = BugsnagCoroutineContext(
+            baseContext,
+            ContextAwareCoroutineContextElement(SpanContext.current),
+        )
 }

--- a/bugsnag-plugin-android-performance-coroutines/src/test/java/com/bugsnag/android/performance/coroutines/ContextAwareCoroutineContextElementTest.kt
+++ b/bugsnag-plugin-android-performance-coroutines/src/test/java/com/bugsnag/android/performance/coroutines/ContextAwareCoroutineContextElementTest.kt
@@ -1,0 +1,91 @@
+package com.bugsnag.android.performance.coroutines
+
+import com.bugsnag.android.performance.internal.SpanFactory
+import com.bugsnag.android.performance.internal.SpanImpl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Collections
+
+@RunWith(RobolectricTestRunner::class)
+class ContextAwareCoroutineContextElementTest {
+
+    private lateinit var collectedSpans: MutableList<SpanImpl>
+
+    private lateinit var spanFactory: SpanFactory
+
+    @Before
+    fun createSpanFactory() {
+        collectedSpans = Collections.synchronizedList(ArrayList())
+        spanFactory = SpanFactory(spanProcessor = { collectedSpans.add(it as SpanImpl) })
+    }
+
+    @Test
+    fun testForkJoinCoroutines() = runBlocking {
+        val scope = BugsnagPerformanceScope(Dispatchers.Default)
+
+        scope.async {
+            val rootSpan = spanFactory.createCustomSpan("RootSpan")
+            rootSpan.use {
+                (1..10)
+                    .map { jobId ->
+                        async(Dispatchers.Default) {
+                            spanFactory.createCustomSpan("Job$jobId").use {
+                                delay(10L)
+                                withContext(Dispatchers.IO) {
+                                    spanFactory.createCustomSpan("Job$jobId").use {
+                                        delay(10L)
+                                    }
+                                }
+                            }
+
+                            jobId
+                        }
+                    }
+                    .awaitAll()
+            }
+
+            assertEquals(21, collectedSpans.size)
+            assertTrue("RootSpan was not ended", collectedSpans.remove(rootSpan))
+
+            collectedSpans.forEach { span ->
+                assertEquals(
+                    "all spans should belong to the same trace",
+                    rootSpan.traceId,
+                    span.traceId,
+                )
+            }
+
+            val (directChildren, nestedChildren) = collectedSpans.partition { it.parentSpanId == rootSpan.spanId }
+
+            assertEquals(10, directChildren.size)
+            assertEquals(10, nestedChildren.size)
+
+            val seenParentIds = mutableSetOf<Long>()
+
+            // given that all of these were Forked (async) directly under the rootSpan we
+            // expect all of them to have rootSpan as their logical parent
+            nestedChildren.forEach { span ->
+                assertNotNull(
+                    "nested span has unknown parent: ${span.parentSpanId}",
+                    directChildren.find { it.spanId == span.parentSpanId },
+                )
+
+                assertTrue(
+                    "unexpected parentSpanId, this parent has more than one child",
+                    seenParentIds.add(span.parentSpanId),
+                )
+            }
+        }.await() // wait for the launched job to complete
+    }
+}


### PR DESCRIPTION
## Goal
Ensure that spans measured within child coroutines of measured coroutines nest as expected.

## Design
Introduce a `BugsnagCoroutineContext` to handle copying the `SpanContext` stack when child coroutines are forked (using `async` or `launch` from within a coroutine).

This avoids the currently experimental & delicate `CopyableThreadContextElement` API which is still subject to change, but also only works if the initial `coroutineContext` is derived from a `BugsnagPerformanceScope`.

## Testing
A new unit test was introduced to assert the expected nesting of spans, including a second-level nested span within the child coroutines.