### PR TITLE
Apply explicit API rules

### DIFF
--- a/bugsnag-android-performance/build.gradle.kts
+++ b/bugsnag-android-performance/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -45,6 +47,12 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (name.endsWith("TestKotlin")) return@configureEach
+    kotlinOptions.freeCompilerArgs += listOf("-Xexplicit-api=strict")
 }
 
 dependencies {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ActivityControl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ActivityControl.kt
@@ -6,11 +6,11 @@ package com.bugsnag.android.performance
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class DoNotEndAppStart
+public annotation class DoNotEndAppStart
 
 /**
  * Annotation Activities and Fragments are ignored by automatic instrumentation.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class DoNotAutoInstrument
+public annotation class DoNotAutoInstrument

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
@@ -1,14 +1,14 @@
 package com.bugsnag.android.performance
 
-class Attributes : Collection<Pair<String, Any>> {
+public class Attributes : Collection<Pair<String, Any>> {
     private val content = mutableMapOf<String, Any>()
 
     override val size: Int
         get() = content.size
 
-    val keys get() = content.keys.toSet()
+    public val keys: Set<String> get() = content.keys.toSet()
 
-    operator fun set(name: String, value: String?) {
+    public operator fun set(name: String, value: String?) {
         if(value != null) {
             content[name] = value
         } else {
@@ -16,19 +16,19 @@ class Attributes : Collection<Pair<String, Any>> {
         }
     }
 
-    operator fun set(name: String, value: Long) {
+    public operator fun set(name: String, value: Long) {
         content[name] = value
     }
 
-    operator fun set(name: String, value: Int) {
+    public operator fun set(name: String, value: Int) {
         content[name] = value.toLong()
     }
 
-    operator fun set(name: String, value: Double) {
+    public operator fun set(name: String, value: Double) {
         content[name] = value
     }
 
-    operator fun set(name: String, value: Boolean) {
+    public operator fun set(name: String, value: Boolean) {
         content[name] = value
     }
 
@@ -37,7 +37,7 @@ class Attributes : Collection<Pair<String, Any>> {
         return content[name]
     }
 
-    fun remove(name: String) {
+    public fun remove(name: String) {
         content.remove(name)
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/AutoInstrument.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/AutoInstrument.kt
@@ -6,7 +6,7 @@ package com.bugsnag.android.performance
  *
  * @see PerformanceConfiguration.autoInstrumentActivities
  */
-enum class AutoInstrument {
+public enum class AutoInstrument {
     /**
      * No automatic instrumentation should be done.
      */

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -30,8 +30,8 @@ import java.net.URL
  *
  * @see [start]
  */
-object BugsnagPerformance {
-    const val VERSION: String = "1.2.0"
+public object BugsnagPerformance {
+    public const val VERSION: String = "1.2.0"
 
     internal val instrumentedAppState = InstrumentedAppState()
 
@@ -48,12 +48,12 @@ object BugsnagPerformance {
      * @param context an Android `Context`, typically your `Application` instance
      */
     @JvmStatic
-    fun start(context: Context) {
+    public fun start(context: Context) {
         start(PerformanceConfiguration.load(context))
     }
 
     @JvmStatic
-    fun start(context: Context, apiKey: String) {
+    public fun start(context: Context, apiKey: String) {
         start(PerformanceConfiguration.load(context, apiKey))
     }
 
@@ -64,7 +64,7 @@ object BugsnagPerformance {
      * @param configuration the configuration for the SDK
      */
     @JvmStatic
-    fun start(configuration: PerformanceConfiguration) {
+    public fun start(configuration: PerformanceConfiguration) {
         if (!isStarted) {
             synchronized(this) {
                 if (!isStarted) {
@@ -181,7 +181,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): Span =
+    public fun startSpan(name: String, options: SpanOptions = SpanOptions.DEFAULTS): Span =
         spanFactory.createCustomSpan(name, options)
 
     /**
@@ -193,7 +193,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startNetworkRequestSpan(
+    public fun startNetworkRequestSpan(
         url: URL,
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -208,7 +208,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startNetworkRequestSpan(
+    public fun startNetworkRequestSpan(
         uri: Uri,
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -226,7 +226,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startViewLoadSpan(
+    public fun startViewLoadSpan(
         activity: Activity,
         options: SpanOptions = SpanOptions.DEFAULTS,
     ): Span {
@@ -244,7 +244,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun endViewLoadSpan(activity: Activity, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
+    public fun endViewLoadSpan(activity: Activity, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
         instrumentedAppState.spanTracker.endSpan(activity, endTime = endTime)
     }
 
@@ -257,7 +257,7 @@ object BugsnagPerformance {
      */
     @JvmStatic
     @JvmOverloads
-    fun startViewLoadSpan(
+    public fun startViewLoadSpan(
         viewType: ViewType,
         viewName: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -278,7 +278,7 @@ object BugsnagPerformance {
      * This method is safe to call before [start].
      */
     @JvmStatic
-    fun reportApplicationClassLoaded() {
+    public fun reportApplicationClassLoaded() {
         synchronized(this) {
             instrumentedAppState.startupTracker.onFirstClassLoadReported()
         }
@@ -296,6 +296,6 @@ object BugsnagPerformance {
  * @param block the block of code to measure the execution time
  * @see [BugsnagPerformance.startSpan]
  */
-inline fun <R> measureSpan(name: String, block: () -> R): R {
+public inline fun <R> measureSpan(name: String, block: () -> R): R {
     return BugsnagPerformance.startSpan(name).use { block() }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareScheduledThreadPoolExecutor.kt
@@ -12,19 +12,19 @@ import java.util.concurrent.TimeUnit
  * Sets the current [SpanContext] within a task to the [SpanContext] that was active
  * when the task was scheduled.
  */
-class ContextAwareScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor {
-    constructor(corePoolSize: Int) : super(corePoolSize)
-    constructor(corePoolSize: Int, threadFactory: ThreadFactory?) : super(
+public class ContextAwareScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor {
+    public constructor(corePoolSize: Int) : super(corePoolSize)
+    public constructor(corePoolSize: Int, threadFactory: ThreadFactory?) : super(
         corePoolSize,
         threadFactory
     )
 
-    constructor(corePoolSize: Int, handler: RejectedExecutionHandler?) : super(
+    public constructor(corePoolSize: Int, handler: RejectedExecutionHandler?) : super(
         corePoolSize,
         handler
     )
 
-    constructor(
+    public constructor(
         corePoolSize: Int,
         threadFactory: ThreadFactory?,
         handler: RejectedExecutionHandler?

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareThreadPoolExecutor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ContextAwareThreadPoolExecutor.kt
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeUnit
  * Sets the current [SpanContext] within a task to the [SpanContext] that was active
  * when the task was submitted.
  */
-class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
-    constructor(
+public class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
+    public constructor(
         corePoolSize: Int,
         maximumPoolSize: Int,
         keepAliveTime: Long,
@@ -20,7 +20,7 @@ class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
         workQueue: BlockingQueue<Runnable>?
     ) : super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue)
 
-    constructor(
+    public constructor(
         corePoolSize: Int,
         maximumPoolSize: Int,
         keepAliveTime: Long,
@@ -29,7 +29,7 @@ class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
         threadFactory: ThreadFactory?
     ) : super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory)
 
-    constructor(
+    public constructor(
         corePoolSize: Int,
         maximumPoolSize: Int,
         keepAliveTime: Long,
@@ -39,7 +39,7 @@ class ContextAwareThreadPoolExecutor : ThreadPoolExecutor {
     ) : super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler)
 
     @Suppress("LongParameterList")
-    constructor(
+    public constructor(
         corePoolSize: Int,
         maximumPoolSize: Int,
         keepAliveTime: Long,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
@@ -4,8 +4,8 @@ package com.bugsnag.android.performance
  * Declares that a class contains [Attributes] and provides convenience functions to modify the
  * attributes directly without needing to access the [attributes] property.
  */
-interface HasAttributes {
-    val attributes: Attributes
+public interface HasAttributes {
+    public val attributes: Attributes
 
     /**
      * Set or clear a string attribute. Passing `null` is the same as calling [clearAttribute] for
@@ -14,7 +14,7 @@ interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    fun setAttribute(name: String, value: String?) {
+    public fun setAttribute(name: String, value: String?) {
         attributes[name] = value
     }
 
@@ -24,7 +24,7 @@ interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    fun setAttribute(name: String, value: Long) {
+    public fun setAttribute(name: String, value: Long) {
         attributes[name] = value
     }
 
@@ -34,7 +34,7 @@ interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    fun setAttribute(name: String, value: Int) {
+    public fun setAttribute(name: String, value: Int) {
         attributes[name] = value
     }
 
@@ -44,7 +44,7 @@ interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    fun setAttribute(name: String, value: Double) {
+    public fun setAttribute(name: String, value: Double) {
         attributes[name] = value
     }
 
@@ -54,7 +54,7 @@ interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    fun setAttribute(name: String, value: Boolean) {
+    public fun setAttribute(name: String, value: Boolean) {
         attributes[name] = value
     }
 
@@ -62,7 +62,7 @@ interface HasAttributes {
      * Clear / remove the specified attribute if it exists. This is the same
      * as `attributes.remove(name)`.
      */
-    fun clearAttribute(name: String) {
+    public fun clearAttribute(name: String) {
         attributes.remove(name)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Logger.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Logger.kt
@@ -5,59 +5,59 @@ import com.bugsnag.android.performance.internal.DebugLogger
 /**
  * Logs internal messages from within the bugsnag notifier.
  */
-interface Logger {
+public interface Logger {
 
     /**
      * Logs a message at the error level.
      */
-    fun e(msg: String)
+    public fun e(msg: String)
 
     /**
      * Logs a message at the error level.
      */
-    fun e(msg: String, throwable: Throwable)
+    public fun e(msg: String, throwable: Throwable)
 
     /**
      * Logs a message at the warning level.
      */
-    fun w(msg: String)
+    public fun w(msg: String)
 
     /**
      * Logs a message at the warning level.
      */
-    fun w(msg: String, throwable: Throwable)
+    public fun w(msg: String, throwable: Throwable)
 
     /**
      * Logs a message at the info level.
      */
-    fun i(msg: String)
+    public fun i(msg: String)
 
     /**
      * Logs a message at the info level.
      */
-    fun i(msg: String, throwable: Throwable)
+    public fun i(msg: String, throwable: Throwable)
 
     /**
      * Logs a message at the debug level.
      */
-    fun d(msg: String)
+    public fun d(msg: String)
 
     /**
      * Logs a message at the debug level.
      */
-    fun d(msg: String, throwable: Throwable)
+    public fun d(msg: String, throwable: Throwable)
 
-    companion object Global : Logger {
-        var delegate: Logger = DebugLogger
+    public companion object Global : Logger {
+        public var delegate: Logger = DebugLogger
             internal set
 
-        override fun e(msg: String) = delegate.e(msg)
-        override fun e(msg: String, throwable: Throwable) = delegate.e(msg, throwable)
-        override fun w(msg: String) = delegate.w(msg)
-        override fun w(msg: String, throwable: Throwable) = delegate.w(msg, throwable)
-        override fun i(msg: String) = delegate.i(msg)
-        override fun i(msg: String, throwable: Throwable) = delegate.i(msg, throwable)
-        override fun d(msg: String) = delegate.d(msg)
-        override fun d(msg: String, throwable: Throwable) = delegate.d(msg, throwable)
+        override fun e(msg: String): Unit = delegate.e(msg)
+        override fun e(msg: String, throwable: Throwable): Unit = delegate.e(msg, throwable)
+        override fun w(msg: String): Unit = delegate.w(msg)
+        override fun w(msg: String, throwable: Throwable): Unit = delegate.w(msg, throwable)
+        override fun i(msg: String): Unit = delegate.i(msg)
+        override fun i(msg: String, throwable: Throwable): Unit = delegate.i(msg, throwable)
+        override fun d(msg: String): Unit = delegate.d(msg)
+        override fun d(msg: String, throwable: Throwable): Unit = delegate.d(msg, throwable)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestAttributes.kt
@@ -6,7 +6,7 @@ import com.bugsnag.android.performance.internal.SpanImpl
  * A container object for the well-known attributes for network request spans (started
  * with [BugsnagPerformance.startNetworkRequestSpan]).
  */
-object NetworkRequestAttributes {
+public object NetworkRequestAttributes {
     /**
      * Set the `"http.status_code"` attribute on the given [Span].
      *
@@ -14,7 +14,7 @@ object NetworkRequestAttributes {
      * @param statusCode the HTTP response code to record on the `Span`
      */
     @JvmStatic
-    fun setResponseCode(span: Span, statusCode: Int) {
+    public fun setResponseCode(span: Span, statusCode: Int) {
         (span as? SpanImpl)?.setAttribute("http.status_code", statusCode)
     }
 
@@ -25,7 +25,7 @@ object NetworkRequestAttributes {
      * @param contentLength the number of bytes in the request body
      */
     @JvmStatic
-    fun setRequestContentLength(span: Span, contentLength: Long) {
+    public fun setRequestContentLength(span: Span, contentLength: Long) {
         (span as? SpanImpl)?.setAttribute("http.request_content_length", contentLength)
     }
 
@@ -36,7 +36,7 @@ object NetworkRequestAttributes {
      * @param contentLength the number of bytes in the uncompressed request body
      */
     @JvmStatic
-    fun setUncompressedRequestContentLength(span: Span, contentLength: Long) {
+    public fun setUncompressedRequestContentLength(span: Span, contentLength: Long) {
         (span as? SpanImpl)?.setAttribute("http.request_content_length_uncompressed", contentLength)
     }
 
@@ -47,7 +47,7 @@ object NetworkRequestAttributes {
      * @param contentLength the number of bytes in the response body
      */
     @JvmStatic
-    fun setResponseContentLength(span: Span, contentLength: Long) {
+    public fun setResponseContentLength(span: Span, contentLength: Long) {
         (span as? SpanImpl)?.setAttribute("http.response_content_length", contentLength)
     }
 
@@ -58,7 +58,7 @@ object NetworkRequestAttributes {
      * @param contentLength the number of bytes in the uncompressed response body
      */
     @JvmStatic
-    fun setUncompressedResponseContentLength(span: Span, contentLength: Long) {
+    public fun setUncompressedResponseContentLength(span: Span, contentLength: Long) {
         (span as? SpanImpl)?.setAttribute(
             "http.response_content_length_uncompressed",
             contentLength,
@@ -75,7 +75,7 @@ object NetworkRequestAttributes {
      * @param httpFlavor the HTTP flavor
      */
     @JvmStatic
-    fun setHttpFlavor(span: Span, httpFlavor: String) {
+    public fun setHttpFlavor(span: Span, httpFlavor: String) {
         (span as? SpanImpl)?.setAttribute("http.flavor", httpFlavor)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInfo.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInfo.kt
@@ -1,9 +1,9 @@
 package com.bugsnag.android.performance
 
-class NetworkRequestInfo(
+public class NetworkRequestInfo(
     /**
      * The URL that will be reported in this network request's span.
      * If null, no span will be created.
      */
-    var url: String? = null,
+    public var url: String? = null,
 )

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/NetworkRequestInstrumentationCallback.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.performance
 
-fun interface NetworkRequestInstrumentationCallback {
+public fun interface NetworkRequestInstrumentationCallback {
     /**
      * Use this callback to filter network request URLs when generating spans.
      *
@@ -20,5 +20,5 @@ fun interface NetworkRequestInstrumentationCallback {
      * }
      * ```
      */
-    fun onNetworkRequest(info: NetworkRequestInfo)
+    public fun onNetworkRequest(info: NetworkRequestInfo)
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -6,47 +6,47 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
 
-class PerformanceConfiguration private constructor(val context: Context) {
+public class PerformanceConfiguration private constructor(public val context: Context) {
 
-    constructor(context: Context, apiKey: String) : this(context) {
+    public constructor(context: Context, apiKey: String) : this(context) {
         this.apiKey = apiKey
     }
 
-    var apiKey: String = ""
+    public var apiKey: String = ""
 
-    var endpoint: String = "https://otlp.bugsnag.com/v1/traces"
+    public var endpoint: String = "https://otlp.bugsnag.com/v1/traces"
 
-    var autoInstrumentAppStarts = true
+    public var autoInstrumentAppStarts: Boolean = true
 
-    var autoInstrumentActivities = AutoInstrument.FULL
+    public var autoInstrumentActivities: AutoInstrument = AutoInstrument.FULL
 
-    var releaseStage: String? = null
+    public var releaseStage: String? = null
 
-    var enabledReleaseStages: Set<String>? = null
+    public var enabledReleaseStages: Set<String>? = null
 
-    var versionCode: Long? = null
+    public var versionCode: Long? = null
 
-    var appVersion: String? = null
+    public var appVersion: String? = null
 
-    var logger: Logger? = null
+    public var logger: Logger? = null
 
     /**
      * Activity classes that are considered part of the AppStart and therefore will not
      * end the AppStart when the associated ViewLoad is ended.
      */
-    var doNotEndAppStart: Collection<Class<out Activity>> = HashSet()
+    public var doNotEndAppStart: Collection<Class<out Activity>> = HashSet()
 
     /**
      * A list of classes to not automatically instrument. This will only match the classes
      * exactly (sub-classes must be listed separately).
      */
-    var doNotAutoInstrument: Collection<Class<*>> = HashSet()
+    public var doNotAutoInstrument: Collection<Class<*>> = HashSet()
 
     /**
      * Callback to be invoked on every network request that would generate a span.
      * Use this to filter what URLs will generate spans and how.
      */
-    var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
+    public var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
 
     override fun toString(): String =
         "PerformanceConfiguration(" +
@@ -63,7 +63,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
                 "doNotAutoInstrument=$doNotAutoInstrument " +
                 ")"
 
-    companion object Loader {
+    public companion object Loader {
 
         // mandatory
         private const val BUGSNAG_NS = "com.bugsnag.android"
@@ -89,7 +89,7 @@ class PerformanceConfiguration private constructor(val context: Context) {
 
         @JvmStatic
         @JvmOverloads
-        fun load(ctx: Context, apiKey: String? = null): PerformanceConfiguration {
+        public fun load(ctx: Context, apiKey: String? = null): PerformanceConfiguration {
             try {
                 val packageManager = ctx.packageManager
                 val packageName = ctx.packageName

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Span.kt
@@ -14,27 +14,27 @@ import java.io.Closeable
  *
  * @see BugsnagPerformance.startSpan
  */
-interface Span : SpanContext, Closeable {
+public interface Span : SpanContext, Closeable {
     /**
      * End this with a specified timestamp relative to [SystemClock.elapsedRealtimeNanos]. If this
      * span has already been closed this will have no effect.
      */
-    fun end(endTime: Long)
+    public fun end(endTime: Long)
 
     /**
      * End this span now. This is the same as `end(SystemClock.elapsedRealtimeNanos())`.
      */
-    fun end()
+    public fun end()
 
     /**
      * Convenience function to call [end], implementing the [Closeable] interface and allowing
      * `Span` to be used with try-with-resources in Java.
      */
-    override fun close() = end()
+    override fun close(): Unit = end()
 
     /**
      * Returns `true` if this span has been closed / ended. If this returns `true` the
      * span cannot be modified further.
      */
-    fun isEnded(): Boolean
+    public fun isEnded(): Boolean
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanContext.kt
@@ -5,16 +5,16 @@ import java.util.Deque
 import java.util.UUID
 import java.util.concurrent.Callable
 
-interface SpanContext {
-    val spanId: Long
-    val traceId: UUID
+public interface SpanContext {
+    public val spanId: Long
+    public val traceId: UUID
 
     /**
      * Convenience function to wrap a given [Runnable] in the current [SpanContext].
      * This can be used when submitting tasks to Executors or other targets that are not aware of
      * the BugSnag [SpanContext].
      */
-    fun wrap(runnable: Runnable): Runnable {
+    public fun wrap(runnable: Runnable): Runnable {
         return Runnable {
             try {
                 SpanContext.attach(this)
@@ -30,7 +30,7 @@ interface SpanContext {
      * This can be used when submitting tasks to Executors or other targets that are not aware of
      * the BugSnag [SpanContext].
      */
-    fun <T> wrap(callable: Callable<T>): Callable<T> {
+    public fun <T> wrap(callable: Callable<T>): Callable<T> {
         return Callable<T> {
             try {
                 SpanContext.attach(this)
@@ -41,7 +41,7 @@ interface SpanContext {
         }
     }
 
-    companion object Storage {
+    public companion object Storage {
         private val threadLocalStorage = object : ThreadLocal<Deque<SpanContext>>() {
             override fun initialValue(): Deque<SpanContext> = ArrayDeque()
         }
@@ -57,7 +57,7 @@ interface SpanContext {
          * Retrieve the current [SpanContext] for this thread (or [invalid] if not available).
          */
         @JvmStatic
-        val current: SpanContext
+        public val current: SpanContext
             get() {
                 removeClosedContexts()
                 return contextStack.peekFirst() ?: invalid
@@ -84,7 +84,7 @@ interface SpanContext {
         }
 
         @JvmStatic
-        val invalid: SpanContext = object : SpanContext {
+        public val invalid: SpanContext = object : SpanContext {
             override val spanId: Long
                 get() = 0
             override val traceId: UUID

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanKind.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanKind.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.performance
 
-enum class SpanKind(
+public enum class SpanKind(
     @JvmField
     internal val otelName: String,
     @JvmField

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -17,11 +17,11 @@ import com.bugsnag.android.performance.SpanOptions.Companion.DEFAULTS
  * @see DEFAULTS
  * @see BugsnagPerformance.startSpan
  */
-class SpanOptions private constructor(
+public class SpanOptions private constructor(
     private val optionsSet: Int,
     startTime: Long,
     parentContext: SpanContext?,
-    val makeContext: Boolean,
+    public val makeContext: Boolean,
     isFirstClass: Boolean,
 ) {
     private val _startTime: Long = startTime
@@ -35,15 +35,15 @@ class SpanOptions private constructor(
      * be reported with. Defaults to returning [SystemClock.elapsedRealtimeNanos] if no specific
      * start time is specified.
      */
-    val startTime: Long
+    public val startTime: Long
         get() =
             if (isOptionSet(OPT_START_TIME)) _startTime
             else SystemClock.elapsedRealtimeNanos()
 
-    val isFirstClass: Boolean?
+    public val isFirstClass: Boolean?
         get() = _isFirstClass.takeIf { isOptionSet(OPT_IS_FIRST_CLASS) }
 
-    val parentContext: SpanContext?
+    public val parentContext: SpanContext?
         get() =
             if (isOptionSet(OPT_PARENT_CONTEXT)) _parentContext
             else SpanContext.current
@@ -54,7 +54,7 @@ class SpanOptions private constructor(
      *
      * @param startTime the start time to report relative to [SystemClock.elapsedRealtimeNanos]
      */
-    fun startTime(startTime: Long) = SpanOptions(
+    public fun startTime(startTime: Long): SpanOptions = SpanOptions(
         optionsSet or OPT_START_TIME,
         startTime,
         _parentContext,
@@ -62,7 +62,7 @@ class SpanOptions private constructor(
         _isFirstClass,
     )
 
-    fun within(parentContext: SpanContext?) = SpanOptions(
+    public fun within(parentContext: SpanContext?): SpanOptions = SpanOptions(
         optionsSet or OPT_PARENT_CONTEXT,
         _startTime,
         parentContext,
@@ -70,7 +70,7 @@ class SpanOptions private constructor(
         _isFirstClass,
     )
 
-    fun makeCurrentContext(makeContext: Boolean) = SpanOptions(
+    public fun makeCurrentContext(makeContext: Boolean): SpanOptions = SpanOptions(
         optionsSet or OPT_MAKE_CONTEXT,
         _startTime,
         _parentContext,
@@ -78,7 +78,7 @@ class SpanOptions private constructor(
         _isFirstClass,
     )
 
-    fun setFirstClass(isFirstClass: Boolean) = SpanOptions(
+    public fun setFirstClass(isFirstClass: Boolean): SpanOptions = SpanOptions(
         optionsSet or OPT_IS_FIRST_CLASS,
         _startTime,
         _parentContext,
@@ -102,6 +102,7 @@ class SpanOptions private constructor(
             && this.makeContext != other.makeContext
         ) return false
 
+        @Suppress("RedundantIf")
         if ((isOptionSet(OPT_IS_FIRST_CLASS) || other.isOptionSet(OPT_IS_FIRST_CLASS))
             && this.isFirstClass != other.isFirstClass
         ) return false
@@ -149,7 +150,7 @@ class SpanOptions private constructor(
     private fun isOptionSet(expectedFlag: Int): Boolean =
         (optionsSet and expectedFlag) != 0
 
-    companion object {
+    public companion object {
         private const val OPT_NONE = 0
         private const val OPT_START_TIME = 1
         private const val OPT_PARENT_CONTEXT = 2
@@ -161,6 +162,7 @@ class SpanOptions private constructor(
          * create new `SpanOptions`
          */
         @JvmField
-        val DEFAULTS = SpanOptions(OPT_NONE, 0, null, makeContext = true, isFirstClass = false)
+        public val DEFAULTS: SpanOptions =
+            SpanOptions(OPT_NONE, 0, null, makeContext = true, isFirstClass = false)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ViewType.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/ViewType.kt
@@ -5,7 +5,7 @@ package com.bugsnag.android.performance
  *
  * @see BugsnagPerformance.startViewLoadSpan
  */
-enum class ViewType(internal val typeName: String, internal val spanName: String) {
+public enum class ViewType(internal val typeName: String, internal val spanName: String) {
     ACTIVITY("activity", "Activity"),
     FRAGMENT("fragment", "Fragment"),
     COMPOSE("compose", "Compose");

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
@@ -1,5 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-enum class AppStartPhase(internal val phaseName: String) {
+public enum class AppStartPhase(internal val phaseName: String) {
     FRAMEWORK("Framework"),
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartPhase.kt
@@ -1,5 +1,8 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public enum class AppStartPhase(internal val phaseName: String) {
     FRAMEWORK("Framework"),
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AppStartTracker.kt
@@ -3,7 +3,7 @@ package com.bugsnag.android.performance.internal
 import android.os.Handler
 import android.os.Message
 
-class AppStartTracker(
+internal class AppStartTracker(
     private val spanTracker: SpanTracker,
     private val spanFactory: SpanFactory,
 ) : Handler.Callback {
@@ -18,7 +18,7 @@ class AppStartTracker(
 
     private val handler = Loopers.newMainHandler(this)
 
-    fun onFirstClassLoadReported() {
+    public fun onFirstClassLoadReported() {
         if (processStarted) return
         val appStart = startAppStartSpan("Cold")
 
@@ -29,12 +29,12 @@ class AppStartTracker(
         processStarted = true
     }
 
-    fun onApplicationCreate() {
+    public fun onApplicationCreate() {
         handler.sendMessageAtFrontOfQueue(handler.obtainMessage(MSG_APP_CLASS_COMPLETE))
         spanTracker.endSpan(appStartToken, AppStartPhase.FRAMEWORK)
     }
 
-    fun onBugsnagPerformanceStart() {
+    public fun onBugsnagPerformanceStart() {
         if (processStarted) return
 
         onApplicationCreate()
@@ -58,7 +58,7 @@ class AppStartTracker(
         handler.sendEmptyMessageDelayed(MSG_DISCARD_APP_START, APP_START_TIMEOUT_MS)
     }
 
-    fun onActivityCreate(hasSavedInstanceState: Boolean) {
+    public fun onActivityCreate(hasSavedInstanceState: Boolean) {
         if (isInBackground) {
             if (hasSavedInstanceState) {
                 startAppStartSpan("Hot")
@@ -78,7 +78,7 @@ class AppStartTracker(
         handler.removeMessages(MSG_DISCARD_APP_START)
     }
 
-    fun onViewLoadComplete(timestamp: Long) {
+    public fun onViewLoadComplete(timestamp: Long) {
         // end the AppStart since the app is now considered "visible"
         spanTracker.endAllSpans(appStartToken, timestamp)
     }
@@ -93,7 +93,7 @@ class AppStartTracker(
         return true
     }
 
-    fun discardAppStart() {
+    public fun discardAppStart() {
         spanTracker.discardAllSpans(appStartToken)
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AutoInstrumentationCache.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AutoInstrumentationCache.kt
@@ -1,17 +1,19 @@
-package com.bugsnag.android.performance
+package com.bugsnag.android.performance.internal
 
 import android.app.Activity
 import androidx.annotation.RestrictTo
+import com.bugsnag.android.performance.DoNotAutoInstrument
+import com.bugsnag.android.performance.DoNotEndAppStart
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class AutoInstrumentationCache {
+public class AutoInstrumentationCache {
     private val appStartActivitiesCache = HashMap<Class<out Activity>, Boolean>()
     private val autoInstrumentCache = HashMap<Class<*>, Boolean>()
 
     /**
      * Class does not need instrumentation.
      */
-    fun isInstrumentationEnabled(jclass: Class<*>): Boolean {
+    public fun isInstrumentationEnabled(jclass: Class<*>): Boolean {
         return autoInstrumentCache.getOrPut(jclass) {
             !jclass.isAnnotationPresent(DoNotAutoInstrument::class.java)
         }
@@ -20,13 +22,13 @@ class AutoInstrumentationCache {
     /**
      * Activities do not need to be ended.
      */
-    fun isAppStartActivity(jclass: Class<out Activity>): Boolean {
+    public fun isAppStartActivity(jclass: Class<out Activity>): Boolean {
         return appStartActivitiesCache.getOrPut(jclass) {
             jclass.isAnnotationPresent(DoNotEndAppStart::class.java)
         }
     }
 
-    fun configure(
+    public fun configure(
         appStartActivities: Collection<Class<out Activity>>,
         autoInstrument: Collection<Class<*>>,
     ) {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
@@ -21,7 +21,7 @@ import java.util.UUID
  *
  * This file mirrors the `DeviceIdFilePersistence` class in `bugsnag-android`.
  */
-class DeviceIdFilePersistence(
+public class DeviceIdFilePersistence(
     private val file: File,
     private val deviceIdGenerator: () -> UUID,
 ) {
@@ -30,7 +30,7 @@ class DeviceIdFilePersistence(
      * Loads the device ID from its file system location.
      * If no value is present then a UUID will be generated and persisted.
      */
-    fun loadDeviceId(requestCreateIfDoesNotExist: Boolean): String? {
+    public fun loadDeviceId(requestCreateIfDoesNotExist: Boolean): String? {
         return try {
             // optimistically read device ID without a lock - the majority of the time
             // the device ID will already be present so no synchronization is required.
@@ -119,15 +119,13 @@ class DeviceIdFilePersistence(
         return null
     }
 
-    companion object {
+    public companion object {
         private const val MAX_FILE_LOCK_ATTEMPTS = 20
         private const val FILE_LOCK_WAIT_MS = 25L
         private const val KEY_ID = "id"
 
-        fun forContext(context: Context) = DeviceIdFilePersistence(
-            File(context.filesDir, "device-id"),
-            UUID::randomUUID,
-        )
+        public fun forContext(context: Context): DeviceIdFilePersistence =
+            DeviceIdFilePersistence(File(context.filesDir, "device-id"), UUID::randomUUID)
     }
 }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance.internal
 
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 import org.json.JSONObject
@@ -21,6 +22,7 @@ import java.util.UUID
  *
  * This file mirrors the `DeviceIdFilePersistence` class in `bugsnag-android`.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class DeviceIdFilePersistence(
     private val file: File,
     private val deviceIdGenerator: () -> UUID,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -12,7 +12,7 @@ import com.bugsnag.android.performance.internal.instrumentation.LegacyActivityIn
 import com.bugsnag.android.performance.internal.processing.ForwardingSpanProcessor
 import com.bugsnag.android.performance.internal.processing.Tracer
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class InstrumentedAppState {
     internal val defaultAttributeSource = DefaultAttributeSource()
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -2,8 +2,8 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Application
 import android.os.Build
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.AutoInstrument
-import com.bugsnag.android.performance.AutoInstrumentationCache
 import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.internal.instrumentation.AbstractActivityLifecycleInstrumentation
 import com.bugsnag.android.performance.internal.instrumentation.ActivityLifecycleInstrumentation
@@ -12,23 +12,24 @@ import com.bugsnag.android.performance.internal.instrumentation.LegacyActivityIn
 import com.bugsnag.android.performance.internal.processing.ForwardingSpanProcessor
 import com.bugsnag.android.performance.internal.processing.Tracer
 
-class InstrumentedAppState {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+public class InstrumentedAppState {
     internal val defaultAttributeSource = DefaultAttributeSource()
 
-    var spanProcessor: SpanProcessor = ForwardingSpanProcessor()
+    public var spanProcessor: SpanProcessor = ForwardingSpanProcessor()
         private set
 
-    val spanTracker = SpanTracker()
+    public val spanTracker: SpanTracker = SpanTracker()
 
-    val spanFactory = SpanFactory(spanProcessor, defaultAttributeSource)
+    public val spanFactory: SpanFactory = SpanFactory(spanProcessor, defaultAttributeSource)
 
-    val startupTracker = AppStartTracker(spanTracker, spanFactory)
+    internal val startupTracker: AppStartTracker = AppStartTracker(spanTracker, spanFactory)
 
-    val autoInstrumentationCache = AutoInstrumentationCache()
+    public val autoInstrumentationCache: AutoInstrumentationCache = AutoInstrumentationCache()
 
     internal val activityInstrumentation = createActivityInstrumentation()
 
-    lateinit var app: Application
+    public lateinit var app: Application
         private set
 
     internal fun attach(application: Application) {
@@ -101,7 +102,7 @@ class InstrumentedAppState {
         }
     }
 
-    fun onBugsnagPerformanceStart() {
+    public fun onBugsnagPerformanceStart() {
         startupTracker.onBugsnagPerformanceStart()
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InternalDebug.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InternalDebug.kt
@@ -1,18 +1,21 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
+
 /**
  * Warning: Everything in here is to support internal testing, and is subject to change
  * without notice.
  * DO NOT USE!
  */
-object InternalDebug {
-    var spanBatchSizeSendTriggerPoint = 100
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+public object InternalDebug {
+    public var spanBatchSizeSendTriggerPoint: Int = 100
 
     /**
      * The maximum amount of time the worker thread will sleep without a `wake()`
      */
-    var workerSleepMs = 30000L
+    public var workerSleepMs: Long = 30000L
 
-    var dropSpansOlderThanMs = 24L * 60 * 60 * 1000
-    var pValueExpireAfterMs = 24 * 60 * 60 * 1000
+    public var dropSpansOlderThanMs: Long = 24L * 60 * 60 * 1000
+    public var pValueExpireAfterMs: Int = 24 * 60 * 60 * 1000
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
@@ -17,7 +17,7 @@ internal inline fun SpanContext.Storage.findSpan(predicate: (SpanImpl) -> Boolea
     return contextStack.find { it is SpanImpl && predicate(it) } as? SpanImpl
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public object BugsnagPerformanceInternals {
     public var currentSpanContextStack: Deque<SpanContext> by SpanContext.Storage::contextStack
     public val spanFactory: SpanFactory get() = BugsnagPerformance.instrumentedAppState.spanFactory

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Internals.kt
@@ -1,7 +1,9 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.SpanContext
+import java.util.Deque
 
 /**
  * Test that no [SpanImpl] objects within the current [SpanContext] match the given [predicate].
@@ -15,7 +17,8 @@ internal inline fun SpanContext.Storage.findSpan(predicate: (SpanImpl) -> Boolea
     return contextStack.find { it is SpanImpl && predicate(it) } as? SpanImpl
 }
 
-object BugsnagPerformanceInternals {
-    var currentSpanContextStack by SpanContext.Storage::contextStack
-    val spanFactory get() = BugsnagPerformance.instrumentedAppState.spanFactory
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+public object BugsnagPerformanceInternals {
+    public var currentSpanContextStack: Deque<SpanContext> by SpanContext.Storage::contextStack
+    public val spanFactory: SpanFactory get() = BugsnagPerformance.instrumentedAppState.spanFactory
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Loopers.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Loopers.kt
@@ -5,7 +5,7 @@ import android.os.Looper
 
 internal object Loopers {
     @JvmStatic
-    val main = Looper.getMainLooper()
+    val main: Looper = Looper.getMainLooper()
 
     val mainHandler = Handler(main)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Module.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Module.kt
@@ -1,11 +1,15 @@
 package com.bugsnag.android.performance.internal
 
-interface Module {
-    fun load(instrumentedAppState: InstrumentedAppState)
-    fun unload()
+import androidx.annotation.RestrictTo
 
-    class Loader(private val instrumentedAppState: InstrumentedAppState) : (String) -> Module? {
-        fun loadModule(className: String): Module? {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+public interface Module {
+    public fun load(instrumentedAppState: InstrumentedAppState)
+    public fun unload()
+
+    public class Loader(private val instrumentedAppState: InstrumentedAppState) :
+            (String) -> Module? {
+        public fun loadModule(className: String): Module? {
             return try {
                 val clazz = Class.forName(className)
                 val module = clazz.newInstance() as Module

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkType.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NetworkType.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.performance.internal
 
-enum class NetworkType(
+internal enum class NetworkType(
     @JvmField
-    internal val otelName: String
+    internal val otelName: String,
 ) {
     WIFI("wifi"),
     WIRED("wired"),

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NoopLogger.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/NoopLogger.kt
@@ -2,13 +2,13 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Logger
 
-object NoopLogger : Logger {
-    override fun e(msg: String) = Unit
-    override fun e(msg: String, throwable: Throwable) = Unit
-    override fun w(msg: String) = Unit
-    override fun w(msg: String, throwable: Throwable) = Unit
-    override fun i(msg: String) = Unit
-    override fun i(msg: String, throwable: Throwable) = Unit
-    override fun d(msg: String) = Unit
-    override fun d(msg: String, throwable: Throwable) = Unit
+internal object NoopLogger : Logger {
+    override fun e(msg: String): Unit = Unit
+    override fun e(msg: String, throwable: Throwable): Unit = Unit
+    override fun w(msg: String): Unit = Unit
+    override fun w(msg: String, throwable: Throwable): Unit = Unit
+    override fun i(msg: String): Unit = Unit
+    override fun i(msg: String, throwable: Throwable): Unit = Unit
+    override fun d(msg: String): Unit = Unit
+    override fun d(msg: String, throwable: Throwable): Unit = Unit
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.performance.internal
 
-enum class SpanCategory(val category: String?) {
+public enum class SpanCategory(public val category: String?) {
     CUSTOM(null),
     VIEW_LOAD("view_load"),
     VIEW_LOAD_PHASE("view_load_phase"),

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -1,5 +1,8 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public enum class SpanCategory(public val category: String?) {
     CUSTOM(null),
     VIEW_LOAD("view_load"),

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -12,12 +12,12 @@ import java.util.UUID
 
 internal typealias AttributeSource = (target: HasAttributes) -> Unit
 
-class SpanFactory(
-    var spanProcessor: SpanProcessor,
-    val spanAttributeSource: AttributeSource = {},
+public class SpanFactory(
+    public var spanProcessor: SpanProcessor,
+    public val spanAttributeSource: AttributeSource = {},
 ) {
-    var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
-    fun createCustomSpan(
+    public var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
+    public fun createCustomSpan(
         name: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
         spanProcessor: SpanProcessor = this.spanProcessor,
@@ -28,7 +28,7 @@ class SpanFactory(
         return span
     }
 
-    fun createNetworkSpan(
+    public fun createNetworkSpan(
         url: String,
         verb: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -52,7 +52,7 @@ class SpanFactory(
         return null
     }
 
-    fun createViewLoadSpan(
+    public fun createViewLoadSpan(
         activity: Activity,
         options: SpanOptions = SpanOptions.DEFAULTS,
         spanProcessor: SpanProcessor = this.spanProcessor,
@@ -61,7 +61,7 @@ class SpanFactory(
         return createViewLoadSpan(ViewType.ACTIVITY, activityName, options, spanProcessor)
     }
 
-    fun createViewLoadSpan(
+    public fun createViewLoadSpan(
         viewType: ViewType,
         viewName: String,
         options: SpanOptions = SpanOptions.DEFAULTS,
@@ -91,7 +91,7 @@ class SpanFactory(
         return span
     }
 
-    fun createViewLoadPhaseSpan(
+    public fun createViewLoadPhaseSpan(
         viewName: String,
         viewType: ViewType,
         phase: ViewLoadPhase,
@@ -114,7 +114,7 @@ class SpanFactory(
         return span
     }
 
-    fun createViewLoadPhaseSpan(
+    public fun createViewLoadPhaseSpan(
         activity: Activity,
         phase: ViewLoadPhase,
         options: SpanOptions,
@@ -129,7 +129,7 @@ class SpanFactory(
         )
     }
 
-    fun createAppStartSpan(
+    public fun createAppStartSpan(
         startType: String,
         spanProcessor: SpanProcessor = this.spanProcessor,
     ): SpanImpl {
@@ -146,7 +146,7 @@ class SpanFactory(
         return span
     }
 
-    fun createAppStartPhaseSpan(
+    public fun createAppStartPhaseSpan(
         phase: AppStartPhase,
         appStartContext: SpanContext,
         spanProcessor: SpanProcessor = this.spanProcessor,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import android.app.Activity
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.HasAttributes
 import com.bugsnag.android.performance.NetworkRequestInfo
 import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
@@ -12,6 +13,7 @@ import java.util.UUID
 
 internal typealias AttributeSource = (target: HasAttributes) -> Unit
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class SpanFactory(
     public var spanProcessor: SpanProcessor,
     public val spanAttributeSource: AttributeSource = {},

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.performance.internal
 import android.os.SystemClock
 import android.util.JsonWriter
 import androidx.annotation.FloatRange
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.HasAttributes
 import com.bugsnag.android.performance.Span
@@ -14,6 +15,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLongFieldUpdater
 
 @Suppress("LongParameterList")
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class SpanImpl internal constructor(
     name: String,
     internal val category: SpanCategory,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -14,14 +14,14 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLongFieldUpdater
 
 @Suppress("LongParameterList")
-class SpanImpl internal constructor(
+public class SpanImpl internal constructor(
     name: String,
     internal val category: SpanCategory,
     internal val kind: SpanKind,
     internal val startTime: Long,
     override val traceId: UUID,
     override val spanId: Long = nextSpanId(),
-    val parentSpanId: Long,
+    public val parentSpanId: Long,
     private val processor: SpanProcessor,
     private val makeContext: Boolean,
 ) : Span, HasAttributes {
@@ -84,15 +84,15 @@ class SpanImpl internal constructor(
      * Deliberately discard this `SpanImpl`. This will mark the span as ended, but not record
      * a valid end time. It will also (if required) detach the Span from the SpanContext
      */
-    fun discard() {
+    public fun discard() {
         if (END_TIME_UPDATER.compareAndSet(this, NO_END_TIME, DISCARDED)) {
             if (makeContext) SpanContext.detach(this)
         }
     }
 
-    override fun end() = end(SystemClock.elapsedRealtimeNanos())
+    override fun end(): Unit = end(SystemClock.elapsedRealtimeNanos())
 
-    override fun isEnded() = endTime != NO_END_TIME
+    override fun isEnded(): Boolean = endTime != NO_END_TIME
 
     internal fun toJson(json: JsonWriter) {
         json.obj {
@@ -149,6 +149,7 @@ class SpanImpl internal constructor(
 
         if (traceId != other.traceId) return false
         if (spanId != other.spanId) return false
+        @Suppress("RedundantIf")
         if (parentSpanId != other.parentSpanId) return false
 
         return true
@@ -161,14 +162,14 @@ class SpanImpl internal constructor(
         return result
     }
 
-    companion object {
+    public companion object {
         private val END_TIME_UPDATER =
             AtomicLongFieldUpdater.newUpdater(SpanImpl::class.java, "endTime")
 
         private const val INVALID_ID = 0L
 
-        const val NO_END_TIME = -1L
-        const val DISCARDED = -2L
+        internal const val NO_END_TIME: Long = -1L
+        internal const val DISCARDED: Long = -2L
 
         private val spanIdRandom = Random(SecureRandom().nextLong())
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanProcessor.kt
@@ -1,7 +1,9 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.Span
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public fun interface SpanProcessor {
     public fun onEnd(span: Span)
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanProcessor.kt
@@ -2,6 +2,6 @@ package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Span
 
-fun interface SpanProcessor {
-    fun onEnd(span: Span)
+public fun interface SpanProcessor {
+    public fun onEnd(span: Span)
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -17,11 +17,11 @@ import kotlin.concurrent.write
  * the `endTime`. If the `Span` is then [marked as leaked](markSpanLeaked) then its "auto end"
  * time is used to close it.
  */
-class SpanTracker {
+public class SpanTracker {
     private val backingStore: MutableMap<Any, MutableMap<Enum<*>?, SpanBinding>> = WeakHashMap()
     private val lock = ReentrantReadWriteLock()
 
-    operator fun get(token: Any, subToken: Enum<*>? = null): SpanImpl? {
+    public operator fun get(token: Any, subToken: Enum<*>? = null): SpanImpl? {
         return lock.read { backingStore[token]?.get(subToken)?.span }
     }
 
@@ -30,7 +30,7 @@ class SpanTracker {
      * the actual `Span` being tracked. This function may discard [span] if the given [token] is
      * already being tracked, if this is the case the tracked span will be returned.
      */
-    fun associate(token: Any, subToken: Enum<*>? = null, span: SpanImpl): SpanImpl {
+    public fun associate(token: Any, subToken: Enum<*>? = null, span: SpanImpl): SpanImpl {
         lock.write {
             val trackedSpans = backingStore[token] ?: IdentityHashMap()
             val existingSpan = trackedSpans[subToken]
@@ -52,7 +52,7 @@ class SpanTracker {
      * Note: in race scenarios the [createSpan] may be invoked and the resulting `Span` discarded,
      * the currently tracked `Span` will however always be returned.
      */
-    inline fun associate(
+    public inline fun associate(
         token: Any,
         subToken: Enum<*>? = null,
         createSpan: () -> SpanImpl,
@@ -65,7 +65,7 @@ class SpanTracker {
         return associatedSpan
     }
 
-    fun removeAssociation(tag: Any?, subToken: Enum<*>? = null): SpanImpl? {
+    public fun removeAssociation(tag: Any?, subToken: Enum<*>? = null): SpanImpl? {
         return lock.write {
             val associatedSpans = backingStore[tag]
             val span = associatedSpans?.remove(subToken)?.span
@@ -78,7 +78,7 @@ class SpanTracker {
         }
     }
 
-    fun removeAllAssociations(tag: Any?): Collection<SpanImpl> {
+    public fun removeAllAssociations(tag: Any?): Collection<SpanImpl> {
         return lock.write {
             val associatedSpans = backingStore.remove(tag)
             associatedSpans.orEmpty().values.map { it.span }
@@ -90,7 +90,7 @@ class SpanTracker {
      * marked as [leaked](markSpanLeaked) then its `endTime` will be set to the time that this
      * function was last called. Otherwise this value will be discarded.
      */
-    fun markSpanAutomaticEnd(token: Any, subToken: Enum<*>? = null) {
+    public fun markSpanAutomaticEnd(token: Any, subToken: Enum<*>? = null) {
         backingStore[token]?.get(subToken)?.autoEndTime = SystemClock.elapsedRealtimeNanos()
     }
 
@@ -99,7 +99,7 @@ class SpanTracker {
      * Returns `true` if the `Span` was marked as leaked, or `false` if the `Span` was already
      * considered to be closed (or was not tracked).
      */
-    fun markSpanLeaked(token: Any, subToken: Enum<*>? = null): Boolean {
+    public fun markSpanLeaked(token: Any, subToken: Enum<*>? = null): Boolean {
         return lock.write {
             val associatedSpans = backingStore[token]
             val leaked = associatedSpans?.remove(subToken)?.markLeaked() == true
@@ -116,7 +116,7 @@ class SpanTracker {
      * End the tracking of a `Span` marking its `endTime` if it has not already been closed.
      * This *must* be called in order to ensure tokens can be garbage-collected.
      */
-    fun endSpan(
+    public fun endSpan(
         token: Any,
         subToken: Enum<*>? = null,
         endTime: Long = SystemClock.elapsedRealtimeNanos(),
@@ -136,7 +136,7 @@ class SpanTracker {
      * use autoEndTimes where they are available, but will otherwise fallback to using [endTime]
      * for each of the spans that get closed.
      */
-    fun endAllSpans(token: Any, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
+    public fun endAllSpans(token: Any, endTime: Long = SystemClock.elapsedRealtimeNanos()) {
         lock.write {
             val associatedSpans = backingStore[token]
             associatedSpans?.values?.forEach { it.markLeaked(endTime) }
@@ -150,7 +150,7 @@ class SpanTracker {
      * associated spans being discarded, any of their child spans that have already been closed
      * will have no valid parent span and will also be discarded by the server-side.
      */
-    fun discardAllSpans(token: Any) {
+    public fun discardAllSpans(token: Any) {
         lock.write {
             val associatedSpans = backingStore[token]
             associatedSpans?.values?.forEach { it.span.discard() }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import android.os.SystemClock
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.internal.SpanImpl.Companion.NO_END_TIME
 import java.util.IdentityHashMap
@@ -17,6 +18,7 @@ import kotlin.concurrent.write
  * the `endTime`. If the `Span` is then [marked as leaked](markSpanLeaked) then its "auto end"
  * time is used to close it.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class SpanTracker {
     private val backingStore: MutableMap<Any, MutableMap<Enum<*>?, SpanBinding>> = WeakHashMap()
     private val lock = ReentrantReadWriteLock()

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
@@ -1,8 +1,10 @@
 package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.ViewType
 
-enum class ViewLoadPhase(private val phaseName: String) {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+public enum class ViewLoadPhase(private val phaseName: String) {
     CREATE("Create"),
     START("Start"),
     RESUME("Resume");

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ViewLoadPhase.kt
@@ -3,7 +3,7 @@ package com.bugsnag.android.performance.internal
 import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.ViewType
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public enum class ViewLoadPhase(private val phaseName: String) {
     CREATE("Create"),
     START("Start"),

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -1,17 +1,16 @@
 package com.bugsnag.android.performance.internal.instrumentation
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.os.Handler
 import android.os.Message
 import android.os.SystemClock
-import com.bugsnag.android.performance.AutoInstrumentationCache
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.internal.AppStartTracker
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
 import com.bugsnag.android.performance.internal.Loopers
 import com.bugsnag.android.performance.internal.SpanFactory
 import com.bugsnag.android.performance.internal.SpanImpl

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/BatchingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/BatchingSpanProcessor.kt
@@ -9,7 +9,7 @@ import com.bugsnag.android.performance.internal.unlinkTo
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-open class BatchingSpanProcessor : SpanProcessor {
+internal open class BatchingSpanProcessor : SpanProcessor {
 
     private val batch = AtomicReference<SpanChain?>(null)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
@@ -10,7 +10,7 @@ import com.bugsnag.android.performance.internal.SpanProcessor
  * [forwardTo] is called, any batched spans are forwarded to the new processor (along with any
  * in-flight spans that end with the `ForwardingSpanProcessor`).
  */
-class ForwardingSpanProcessor : SpanProcessor {
+internal class ForwardingSpanProcessor : SpanProcessor {
     @Volatile
     private var backingProcessor: SpanProcessor = BatchingSpanProcessor()
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
@@ -8,7 +8,7 @@ import com.bugsnag.android.performance.internal.Sampler
 import com.bugsnag.android.performance.internal.SpanImpl
 import com.bugsnag.android.performance.internal.Worker
 
-class Tracer : BatchingSpanProcessor() {
+internal class Tracer : BatchingSpanProcessor() {
 
     private var lastBatchSendTime = SystemClock.elapsedRealtime()
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/startup/AbstractStartupProvider.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/startup/AbstractStartupProvider.kt
@@ -11,7 +11,7 @@ import android.os.Build.VERSION_CODES
 /**
  * Empty `ContentProvider` used for early loading / startup processing.
  */
-abstract class AbstractStartupProvider : ContentProvider() {
+public abstract class AbstractStartupProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         return true
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/startup/BugsnagPerformanceProvider.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/startup/BugsnagPerformanceProvider.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.internal.instrumentation.ForegroundState
 
-class BugsnagPerformanceProvider : AbstractStartupProvider() {
+public class BugsnagPerformanceProvider : AbstractStartupProvider() {
     private val startupTracker get() = BugsnagPerformance.instrumentedAppState.startupTracker
 
     override fun onCreate(): Boolean {
@@ -18,7 +18,7 @@ class BugsnagPerformanceProvider : AbstractStartupProvider() {
         return true
     }
 
-    companion object {
+    public companion object {
         init {
             // report the earliest class load we are aware of
             BugsnagPerformance.reportApplicationClassLoaded()

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AutoInstrumentationCacheTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AutoInstrumentationCacheTest.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
 import android.app.Activity
-import com.bugsnag.android.performance.AutoInstrumentationCache
 import com.bugsnag.android.performance.DoNotAutoInstrument
 import com.bugsnag.android.performance.DoNotEndAppStart
 import org.junit.Assert.assertFalse

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentationTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.performance.internal.instrumentation
 
 import android.app.Activity
-import com.bugsnag.android.performance.AutoInstrumentationCache
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
 import com.bugsnag.android.performance.internal.Loopers
 import com.bugsnag.android.performance.internal.SpanCategory
 import com.bugsnag.android.performance.internal.SpanFactory

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
@@ -1,9 +1,9 @@
 package com.bugsnag.android.performance.internal.instrumentation
 
 import android.app.Activity
-import com.bugsnag.android.performance.AutoInstrumentationCache
 import com.bugsnag.android.performance.DoNotAutoInstrument
 import com.bugsnag.android.performance.DoNotEndAppStart
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
 import com.bugsnag.android.performance.internal.Loopers
 import com.bugsnag.android.performance.internal.SpanCategory
 import com.bugsnag.android.performance.internal.SpanFactory

--- a/bugsnag-plugin-android-performance-appcompat/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-appcompat/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -46,6 +48,12 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (name.endsWith("TestKotlin")) return@configureEach
+    kotlinOptions.freeCompilerArgs += listOf("-Xexplicit-api=strict")
 }
 
 dependencies {

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/AppCompatModule.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/AppCompatModule.kt
@@ -3,7 +3,7 @@ package com.bugsnag.android.performance
 import com.bugsnag.android.performance.internal.InstrumentedAppState
 import com.bugsnag.android.performance.internal.Module
 
-class AppCompatModule : Module {
+public class AppCompatModule : Module {
     private lateinit var instrumentedAppState: InstrumentedAppState
     private lateinit var fragmentActivityLifecycleCallbacks: FragmentActivityLifecycleCallbacks
     override fun load(instrumentedAppState: InstrumentedAppState) {

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformanceExt.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformanceExt.kt
@@ -34,7 +34,7 @@ internal fun SpanFactory.createViewLoadSpan(
  * @param fragment the fragment load being measured
  * @param options the optional configuration for the span
  */
-fun BugsnagPerformance.startViewLoadSpan(
+public fun BugsnagPerformance.startViewLoadSpan(
     fragment: Fragment,
     options: SpanOptions = SpanOptions.DEFAULTS,
 ): Span {

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
@@ -8,11 +8,12 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
 import com.bugsnag.android.performance.internal.SpanFactory
 import com.bugsnag.android.performance.internal.SpanTracker
 import com.bugsnag.android.performance.internal.ViewLoadPhase
 
-class FragmentActivityLifecycleCallbacks(
+public class FragmentActivityLifecycleCallbacks(
     private val spanTracker: SpanTracker,
     private val spanFactory: SpanFactory,
     private val autoInstrumentationCache: AutoInstrumentationCache,
@@ -85,10 +86,10 @@ class FragmentActivityLifecycleCallbacks(
         spanTracker.endAllSpans(f)
     }
 
-    override fun onActivityStarted(activity: Activity) = Unit
-    override fun onActivityResumed(activity: Activity) = Unit
-    override fun onActivityPaused(activity: Activity) = Unit
-    override fun onActivityStopped(activity: Activity) = Unit
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
-    override fun onActivityDestroyed(activity: Activity) = Unit
+    override fun onActivityStarted(activity: Activity): Unit = Unit
+    override fun onActivityResumed(activity: Activity): Unit = Unit
+    override fun onActivityPaused(activity: Activity): Unit = Unit
+    override fun onActivityStopped(activity: Activity): Unit = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle): Unit = Unit
+    override fun onActivityDestroyed(activity: Activity): Unit = Unit
 }

--- a/bugsnag-plugin-android-performance-appcompat/src/test/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacksTest.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/test/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacksTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
 import com.bugsnag.android.performance.internal.BugsnagPerformanceInternals
 import com.bugsnag.android.performance.internal.SpanFactory
 import com.bugsnag.android.performance.internal.SpanImpl

--- a/bugsnag-plugin-android-performance-coroutines/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-coroutines/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -45,6 +47,12 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (name.endsWith("TestKotlin")) return@configureEach
+    kotlinOptions.freeCompilerArgs += listOf("-Xexplicit-api=strict")
 }
 
 dependencies {

--- a/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
+++ b/bugsnag-plugin-android-performance-coroutines/src/main/kotlin/com/bugsnag/android/performance/coroutines/BugsnagPerformanceCoroutines.kt
@@ -48,7 +48,7 @@ private class ContextAwareCoroutineContextElement(
  * Maintains a Span Context stack for the coroutine, with the [SpanContext] at the root,
  * which persists the suspend/resume boundary.
  */
-fun SpanContext.asCoroutineElement(): CoroutineContext.Element =
+public fun SpanContext.asCoroutineElement(): CoroutineContext.Element =
     ContextAwareCoroutineContextElement(this)
 
 
@@ -56,7 +56,7 @@ fun SpanContext.asCoroutineElement(): CoroutineContext.Element =
  * Returns a context containing the [SpanContext] as a [CoroutineContext.Element] and elements
  * from other context.
  */
-operator fun SpanContext.plus(context: CoroutineContext): CoroutineContext {
+public operator fun SpanContext.plus(context: CoroutineContext): CoroutineContext {
     return context + this.asCoroutineElement()
 }
 
@@ -64,7 +64,7 @@ operator fun SpanContext.plus(context: CoroutineContext): CoroutineContext {
  * Returns a context containing elements from this context and the [SpanContext] as a
  * [CoroutineContext.Element].
  */
-operator fun CoroutineContext.plus(context: SpanContext): CoroutineContext {
+public operator fun CoroutineContext.plus(context: SpanContext): CoroutineContext {
     return this + context.asCoroutineElement()
 }
 
@@ -94,6 +94,7 @@ private class BugsnagCoroutineContext(
 
     override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? {
         return if (key === ContextAwareCoroutineContextElement.Key) {
+            @Suppress("UNCHECKED_CAST")
             baseSpanContext as E
         } else {
             baseContext[key]
@@ -113,7 +114,9 @@ private class BugsnagCoroutineContext(
 /**
  * A Coroutine Scope to automatically create context-aware coroutines
  */
-class BugsnagPerformanceScope(dispatcher: CoroutineDispatcher = Dispatchers.Main) : CoroutineScope {
+public class BugsnagPerformanceScope(
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : CoroutineScope {
     private val baseContext = SupervisorJob() + dispatcher
 
     override val coroutineContext: CoroutineContext

--- a/bugsnag-plugin-android-performance-okhttp/build.gradle.kts
+++ b/bugsnag-plugin-android-performance-okhttp/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -45,6 +47,12 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (name.endsWith("TestKotlin")) return@configureEach
+    kotlinOptions.freeCompilerArgs += listOf("-Xexplicit-api=strict")
 }
 
 dependencies {

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -12,8 +12,8 @@ import okhttp3.Response
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
-class BugsnagPerformanceOkhttp : EventListener() {
-    companion object EventListenerFactory : EventListener.Factory {
+public class BugsnagPerformanceOkhttp : EventListener() {
+    public companion object EventListenerFactory : EventListener.Factory {
         override fun create(call: Call): EventListener {
             return BugsnagPerformanceOkhttp()
         }


### PR DESCRIPTION
## Goal
Apply the Kotlin compilers explicit api rules to the project in order to generally improve code readability and quality.

## Changeset
Nearly all of the files were touched by this change.

Not obviously part of the change was moving the `AutoInstrumentationCache` to the `internal` package, as it was never part of the public API.

## Testing
Relied on existing tests.