### PR TITLE
Fix Warm/Hot Activity / AppStart span ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Coroutines forked from other coroutines within a `BugsnagPerformanceScope` will now have spans that nest naturally
   [#193](https://github.com/bugsnag/bugsnag-android-performance/pull/193)
+* Warm & Hot start spans will no longer be started before the AppStart spans
+  [#196](https://github.com/bugsnag/bugsnag-android-performance/pull/196)
 
 ## 1.2.0 (2023-11-22)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -113,9 +113,6 @@ internal abstract class AbstractActivityLifecycleInstrumentation(
         }
     }
 
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        startupTracker.onActivityCreate(savedInstanceState != null)
-    }
 
     override fun onActivityDestroyed(activity: Activity) {
         onViewLoadLeak(activity)
@@ -125,6 +122,7 @@ internal abstract class AbstractActivityLifecycleInstrumentation(
         onViewLoadLeak(activity)
     }
 
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
     override fun onActivityStarted(activity: Activity) = Unit
     override fun onActivityResumed(activity: Activity) = Unit
     override fun onActivityPaused(activity: Activity) = Unit
@@ -145,12 +143,11 @@ internal class LegacyActivityInstrumentation(
 ) {
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        super.onActivityCreated(activity, savedInstanceState)
+        startupTracker.onActivityCreate(savedInstanceState != null)
         autoStartViewLoadSpan(activity)
     }
 
     override fun onActivityResumed(activity: Activity) {
-        super.onActivityResumed(activity)
         autoEndViewLoadSpan(activity)
     }
 
@@ -169,6 +166,7 @@ internal class ActivityLifecycleInstrumentation(
 ) {
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        startupTracker.onActivityCreate(savedInstanceState != null)
         autoStartViewLoadSpan(activity)
         startViewLoadPhase(activity, ViewLoadPhase.CREATE)
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/HotStartTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/HotStartTest.kt
@@ -1,0 +1,116 @@
+package com.bugsnag.android.performance.internal.instrumentation
+
+import android.app.Activity
+import android.os.Bundle
+import com.bugsnag.android.performance.internal.AppStartTracker
+import com.bugsnag.android.performance.internal.AutoInstrumentationCache
+import com.bugsnag.android.performance.internal.Loopers
+import com.bugsnag.android.performance.internal.SpanCategory
+import com.bugsnag.android.performance.internal.SpanFactory
+import com.bugsnag.android.performance.internal.SpanTracker
+import com.bugsnag.android.performance.test.ActivityLifecycleHelper
+import com.bugsnag.android.performance.test.ActivityLifecycleStep
+import com.bugsnag.android.performance.test.CollectingSpanProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPausedSystemClock
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowPausedSystemClock::class], sdk = [32])
+class HotStartTest {
+
+    private lateinit var spanTracker: SpanTracker
+    private lateinit var spanProcessor: CollectingSpanProcessor
+    private lateinit var spanFactory: SpanFactory
+    private lateinit var appStartTracker: AppStartTracker
+    private lateinit var activityInstrumentation: ActivityLifecycleInstrumentation
+    private lateinit var lifecycleHelper: ActivityLifecycleHelper
+    private lateinit var autoInstrumentationCache: AutoInstrumentationCache
+
+    @Before
+    fun setup() {
+        spanTracker = SpanTracker()
+        spanProcessor = CollectingSpanProcessor()
+        spanFactory = SpanFactory(spanProcessor)
+        autoInstrumentationCache = AutoInstrumentationCache()
+        appStartTracker = AppStartTracker(spanTracker, spanFactory)
+        activityInstrumentation = ActivityLifecycleInstrumentation(
+            spanTracker,
+            spanFactory,
+            appStartTracker,
+            autoInstrumentationCache,
+        )
+        lifecycleHelper = ActivityLifecycleHelper(activityInstrumentation) {
+            ShadowPausedSystemClock.advanceBy(1, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun testWarmStart() {
+        val activity = Activity()
+
+        lifecycleHelper.progressLifecycle(
+            activity,
+            from = ActivityLifecycleStep.DESTROYED,
+            to = ActivityLifecycleStep.RESUMED,
+        )
+
+        Shadows.shadowOf(Loopers.main).runToEndOfTasks()
+
+        val spans = spanProcessor.toList()
+
+        val appStartSpan = spans.find { it.category == SpanCategory.APP_START }!!
+        assertEquals("[AppStart/AndroidWarm]", appStartSpan.name)
+        assertEquals(0L, appStartSpan.parentSpanId)
+
+        val viewLoad = spans.find { it.category == SpanCategory.VIEW_LOAD }!!
+        assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
+        assertEquals(appStartSpan.spanId, viewLoad.parentSpanId)
+
+        val viewLoadPhases = spans.filter { it.category == SpanCategory.VIEW_LOAD_PHASE }
+        assertEquals(3, viewLoadPhases.size)
+        viewLoadPhases.forEach { phase ->
+            assertEquals(viewLoad.spanId, phase.parentSpanId)
+        }
+    }
+
+    @Test
+    fun testHotStart() {
+        val activity = Activity()
+        val savedInstanceState = Bundle()
+
+        activityInstrumentation.onActivityPreCreated(activity, savedInstanceState)
+        activityInstrumentation.onActivityCreated(activity, savedInstanceState)
+        activityInstrumentation.onActivityPostCreated(activity, savedInstanceState)
+
+        lifecycleHelper.progressLifecycle(
+            activity,
+            from = ActivityLifecycleStep.CREATED,
+            to = ActivityLifecycleStep.RESUMED,
+        )
+
+        Shadows.shadowOf(Loopers.main).runToEndOfTasks()
+
+        val spans = spanProcessor.toList()
+
+        val appStartSpan = spans.find { it.category == SpanCategory.APP_START }!!
+        assertEquals("[AppStart/AndroidHot]", appStartSpan.name)
+        assertEquals(0L, appStartSpan.parentSpanId)
+
+        val viewLoad = spans.find { it.category == SpanCategory.VIEW_LOAD }!!
+        assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
+        assertEquals(appStartSpan.spanId, viewLoad.parentSpanId)
+
+        val viewLoadPhases = spans.filter { it.category == SpanCategory.VIEW_LOAD_PHASE }
+        assertEquals(3, viewLoadPhases.size)
+        viewLoadPhases.forEach { phase ->
+            assertEquals(viewLoad.spanId, phase.parentSpanId)
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Ensure that Activity ViewLoad spans are nested under their expected AppStart/Warm / AppStart/Hot spans (when applicable).

## Testing
New unit tests added to ensure the expected span parentage.