### PR TITLE
Set Appium capabilities to be sure of selecting correct start Activity

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,6 +62,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--capabilities={\"appPackage\":\"com.bugsnag.mazeracer\",\"appActivity\":\"com.bugsnag.mazeracer.SplashScreenActivity\"}"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager


### PR DESCRIPTION
## Goal

Reduce test flakes by setting Appium capabilities to identify the correct start Activity.

## Design

The e2e test fixture contains multiple Activity classes, which can confuse Appium when it tries to launch the app,.  This change ensures that Appium uses the correct Activity to detect that the app has started.

## Testing

Before this change the following error was seen at least one in ten times:
```
Cannot start the 'com.bugsnag.mazeracer' application. 
```

After the change the error wasn't seen once in 60 attempts.