### PR TITLE
Persist the command UUID between app restarts when testing

### DIFF
--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -340,7 +340,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun setStoredCommandUUID(commandUUID: String) {
         with(prefs.edit()) {
-            putString(commandUUIDKey, apiKey)
+            putString(commandUUIDKey, commandUUID)
             commit()
         }
     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -158,14 +158,7 @@ class MainActivity : AppCompatActivity() {
         // Get the next maze runner command
         polling = true
         thread(start = true) {
-            if (mazeAddress == null) setMazeRunnerAddress()
-            if (commandUUIDStored()) {
-                log("Using stored command UUID")
-                lastCommandUuid = getStoredCommandUUID()
-                clearStoredCommandUUID()
-            }
-            checkNetwork()
-            startBugsnag()
+            setupCommandRunner()
             @Suppress("LoopWithTooManyJumpStatements")
             while (polling) {
                 Thread.sleep(1000)
@@ -353,6 +346,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun getStoredCommandUUID() = prefs.getString(commandUUIDKey, "")
+
+    private fun setupCommandRunner() {
+        if (mazeAddress == null) setMazeRunnerAddress()
+        if (commandUUIDStored()) {
+            log("Using stored command UUID")
+            lastCommandUuid = getStoredCommandUUID()
+            clearStoredCommandUUID()
+        }
+        checkNetwork()
+        startBugsnag()
+    }
 
     private val String.width
         get() = lineSequence().fold(0) { maxWidth, line -> kotlin.math.max(maxWidth, line.length) }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -154,7 +154,6 @@ class MainActivity : AppCompatActivity() {
 
     // Starts a thread to poll for Maze Runner actions to perform
     private fun startCommandRunner() {
-
         // Get the next maze runner command
         polling = true
         thread(start = true) {
@@ -184,49 +183,53 @@ class MainActivity : AppCompatActivity() {
                         continue
                     }
 
-                    val scenarioName = command.getString("scenario_name")
-                    val scenarioMetadata = command.getString("scenario_metadata")
-                    val endpointUrl = command.getString("endpoint")
-                    val uuid = command.getString("uuid")
-                    log("command.action: $action")
-                    log("command.scenarioName: $scenarioName")
-                    log("command.scenarioMode: $scenarioMetadata")
-                    log("command.endpoint: $endpointUrl")
-                    log("command.uuid: $uuid")
-
-                    // Keep track of the current command
-                    this.lastCommandUuid = uuid
-                    setStoredCommandUUID(uuid)
-
-                    mainHandler.post {
-                        // Display some feedback of the action being run on he UI
-                        val actionField = findViewById<EditText>(R.id.command_action)
-                        val scenarioField = findViewById<EditText>(R.id.command_scenario)
-                        actionField.setText(action)
-                        scenarioField.setText(scenarioName)
-
-                        // Perform the given action on the UI thread
-                        when (action) {
-                            "run_scenario" -> {
-                                polling = false
-                                runScenario(scenarioName, scenarioMetadata, endpointUrl)
-                            }
-
-                            "load_scenario" -> {
-                                scenario = loadScenario(scenarioName, scenarioMetadata, endpointUrl)
-                            }
-
-                            "invoke" -> {
-                                log("invoke: $scenarioName")
-                                scenario!!::class.java.getMethod(scenarioName).invoke(scenario)
-                            }
-
-                            else -> throw IllegalArgumentException("Unknown action: $action")
-                        }
-                    }
+                    executeCommand(command)
                 } catch (e: Exception) {
                     log("Failed to fetch command from Maze Runner", e)
                 }
+            }
+        }
+    }
+
+    private fun executeCommand(command: JSONObject) {
+        val scenarioName = command.getString("scenario_name")
+        val scenarioMetadata = command.getString("scenario_metadata")
+        val endpointUrl = command.getString("endpoint")
+        val uuid = command.getString("uuid")
+        log("command.action: $action")
+        log("command.scenarioName: $scenarioName")
+        log("command.scenarioMode: $scenarioMetadata")
+        log("command.endpoint: $endpointUrl")
+        log("command.uuid: $uuid")
+
+        // Keep track of the current command
+        this.lastCommandUuid = uuid
+        setStoredCommandUUID(uuid)
+
+        mainHandler.post {
+            // Display some feedback of the action being run on he UI
+            val actionField = findViewById<EditText>(R.id.command_action)
+            val scenarioField = findViewById<EditText>(R.id.command_scenario)
+            actionField.setText(action)
+            scenarioField.setText(scenarioName)
+
+            // Perform the given action on the UI thread
+            when (action) {
+                "run_scenario" -> {
+                    polling = false
+                    runScenario(scenarioName, scenarioMetadata, endpointUrl)
+                }
+
+                "load_scenario" -> {
+                    scenario = loadScenario(scenarioName, scenarioMetadata, endpointUrl)
+                }
+
+                "invoke" -> {
+                    log("invoke: $scenarioName")
+                    scenario!!::class.java.getMethod(scenarioName).invoke(scenario)
+                }
+
+                else -> throw IllegalArgumentException("Unknown action: $action")
             }
         }
     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -192,6 +192,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun executeCommand(command: JSONObject) {
+        val action = command.getString("action")
         val scenarioName = command.getString("scenario_name")
         val scenarioMetadata = command.getString("scenario_metadata")
         val endpointUrl = command.getString("endpoint")


### PR DESCRIPTION
## Goal

This fixes a bunch of flakes where the test fixture couldn't pull the next command from maze-runner due to not having the correct UUID when requesting it.