### PR TITLE
Rework the "No P update: fail-retriable, fail-permanent…

### DIFF
--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -363,7 +363,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private val String.width
-        get() = lineSequence().fold(0) { maxWidth, line -> kotlin.math.max(maxWidth, line.length) }
+        get() = lineSequence().maxOf { it.length }
 
     companion object {
         const val REQUEST_CODE_FINISH_ON_RETURN = 9090

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/GenerateSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/GenerateSpansScenario.kt
@@ -1,10 +1,10 @@
 package com.bugsnag.mazeracer.scenarios
 
+import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.Scenario
-
 class GenerateSpansScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String
@@ -22,6 +22,7 @@ class GenerateSpansScenario(
     }
 
     fun sendNextSpan() {
+        Log.i("GenerateSpansScenario", "sendNextSpan($spanId)")
         BugsnagPerformance.startSpan("span $spanId").end()
         spanId++
     }

--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -37,6 +37,10 @@ When('I invoke {string}') do |function|
   execute_command 'invoke', function
 end
 
+When('I invoke {string} for {string}') do |function, metadata|
+  execute_command 'invoke', function, metadata
+end
+
 Then("the {string} span field {string} is stored as the value {string}") do |span_name, field, key|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   named_spans = spans.select { |s| s['name'].eql?(span_name) }


### PR DESCRIPTION
## Goal
Correct the "No P update: fail-retriable, fail-permanent, success" server test so that it passes reliably.

## Changes
Introduced some additional options to aid debugging.

## Testing
Test scenario now passes reliably