### PR TITLE
Removed onViewLoadLeak trigger for Activity.onStop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Remove leak mark when the Activity is on stopped since Auto-instrumented spans should only be considered “leaked” when the Activity is destroyed.
+  [#210](https://github.com/bugsnag/bugsnag-android-performance/pull/210)
+
 ## 1.2.2 (2024-02-22)
 
 ### Bug fixes

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -25,7 +25,6 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CLIENT$3</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
-    <ID>NewLineAtEndOfFile:AutoInstrumentationCache.kt$com.bugsnag.android.performance.AutoInstrumentationCache.kt</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -118,10 +118,7 @@ internal abstract class AbstractActivityLifecycleInstrumentation(
         onViewLoadLeak(activity)
     }
 
-    override fun onActivityStopped(activity: Activity) {
-        onViewLoadLeak(activity)
-    }
-
+    override fun onActivityStopped(activity: Activity)= Unit
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
     override fun onActivityStarted(activity: Activity) = Unit
     override fun onActivityResumed(activity: Activity) = Unit


### PR DESCRIPTION
## Goal

Auto-instrumented spans should only be considered “leaked” when the `Activity` is destroyed, since the `Activity` may stop and restart while the span is still valid (for example when backgrounded briefly).

## Changeset

Removed `onViewLoadLeak` from `Activity.onStop` instrumentation
