### PR TITLE
Correctly reassign the Span samplingProbability

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
@@ -29,7 +29,11 @@ internal class ProbabilitySampler(
     // Side effect: Sets span.samplingProbability to the current probability
     override fun shouldKeepSpan(span: SpanImpl): Boolean {
         val upperBound = sampleProbability
-        span.samplingProbability = upperBound
+        // only change the span samplingProbability if the new probability is lower
+        if (upperBound < span.samplingProbability) {
+            span.samplingProbability = upperBound
+        }
+
         return upperBound > 0.0 && span.samplingValue <= upperBound
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -62,9 +62,8 @@ public class SpanImpl internal constructor(
     @FloatRange(from = 0.0, to = 1.0)
     internal var samplingProbability: Double = 1.0
         internal set(value) {
-            require(field in 0.0..1.0) { "samplingProbability out of range (0..1): $value" }
-            field = value
-            attributes["bugsnag.sampling.p"] = value
+            field = value.coerceIn(0.0, 1.0)
+            attributes["bugsnag.sampling.p"] = field
         }
 
     init {
@@ -151,7 +150,6 @@ public class SpanImpl internal constructor(
 
         if (traceId != other.traceId) return false
         if (spanId != other.spanId) return false
-        @Suppress("RedundantIf")
         if (parentSpanId != other.parentSpanId) return false
 
         return true

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ProbabilitySamplerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ProbabilitySamplerTest.kt
@@ -145,4 +145,34 @@ class ProbabilitySamplerTest {
         val sampled = sampler.sampled(batch)
         assertEquals(3, sampled.size)
     }
+
+    @Test
+    fun testSpanReducedProbability() {
+        val sampler = ProbabilitySampler(0.25)
+        val span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(0),
+        )
+
+        span.samplingProbability = 1.0
+
+        // when the sampler has lower probability, the span samplingProbability should be reduced
+        assertTrue(sampler.shouldKeepSpan(span))
+        assertEquals(0.25, span.samplingProbability, 0.001)
+    }
+
+    @Test
+    fun testSpanIncreaseProbability() {
+        val sampler = ProbabilitySampler(1.0)
+        val span = spanFactory.newSpan(
+            processor = spanProcessor,
+            traceId = uuidWithUpper(0),
+        )
+
+        // when the sampler has higher probability, the span samplingProbability should stay the same
+        span.samplingProbability = 0.4
+
+        assertTrue(sampler.shouldKeepSpan(span))
+        assertEquals(0.4, span.samplingProbability, 0.01)
+    }
 }


### PR DESCRIPTION
## Goal
The `Span.samplingProbability` should only be changed if the new probability is strictly less-than the current span probability.

## Testing
Introduced new unit tests to cover the expected behavior.