### PR TITLE
Ensure that the sampling probably is included correctly

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -59,12 +59,16 @@ public class SpanImpl internal constructor(
 
     internal val samplingValue: Double
 
-    @FloatRange(from = 0.0, to = 1.0)
+    @get:FloatRange(from = 0.0, to = 1.0)
     internal var samplingProbability: Double = 1.0
-        internal set(value) {
+        set(@FloatRange(from = 0.0, to = 1.0) value) {
             field = value.coerceIn(0.0, 1.0)
             attributes["bugsnag.sampling.p"] = field
         }
+
+    init {
+        samplingProbability = 1.0
+    }
 
     init {
         category.category?.let { attributes["bugsnag.span.category"] = it }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanJsonTest.kt
@@ -53,6 +53,10 @@ class SpanJsonTest {
                     "parentSpanId": "000000000000007b",
                     "attributes": [
                         {
+                            "key": "bugsnag.sampling.p",
+                            "value": { "doubleValue": 1.0 }
+                        },
+                        {
                             "key": "fps.average",
                             "value": { "doubleValue": 61.9 }
                         },

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -87,7 +87,13 @@ class SpanPayloadEncodingTest {
                               "spanId": "00000000decafbad",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.startTime)}",
-                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.endTime)}"
+                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.endTime)}",
+                              "attributes": [
+                                {
+                                    "key": "bugsnag.sampling.p",
+                                    "value": { "doubleValue": 1.0 }
+                                }
+                              ]
                             },
                             {
                               "name": "second span",
@@ -95,7 +101,13 @@ class SpanPayloadEncodingTest {
                               "spanId": "00000000baddecaf",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.startTime)}",
-                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.endTime)}"
+                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.endTime)}",
+                              "attributes": [
+                                {
+                                    "key": "bugsnag.sampling.p",
+                                    "value": { "doubleValue": 1.0 }
+                                }
+                              ]
                             }
                           ]
                         }


### PR DESCRIPTION
## Goal
Ensure every span reports it's `samplingProbability` again

## Changeset
Ensure that the `SpanImpl.samplingProbability` setter is called at least once (in the `init` block)

## Testing
Relied on existing tests