### PR TITLE
Build traceparent header from span impl

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -166,6 +166,9 @@ public class SpanImpl internal constructor(
         return result
     }
 
+    public fun isSampled(): Boolean =
+        samplingProbability > 0.0 && samplingValue <= samplingProbability
+
     public companion object {
         private val END_TIME_UPDATER =
             AtomicLongFieldUpdater.newUpdater(SpanImpl::class.java, "endTime")

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -83,4 +83,12 @@ public class BugsnagPerformanceOkhttp : EventListener() {
         // remove the span and discard
         (spans.remove(call) as? SpanImpl)?.discard()
     }
+
+    public fun buildTraceparentHeader(
+        traceId: String,
+        parentSpanId: String,
+        sampled: Boolean,
+    ): String {
+        return "00-$traceId-$parentSpanId-${if (sampled) "01" else "00"}"
+    }
 }


### PR DESCRIPTION
## Goal

Introduce a function to return the content of the traceparent header and a function base on given `SpanImpl` `samplingProbability` and `samplingValue` to determine if the span is sampled.

## Changeset

Added `isSampled()` to `SpanImpl`  and  `buildTraceparentHeader()` to `BugsnagPerformanceOkhttp`
