### PR TITLE
Add OkHttpModule to share cross-module config

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -171,6 +171,7 @@ public object BugsnagPerformance {
     private fun loadModules() {
         val moduleLoader = Module.Loader(instrumentedAppState)
         moduleLoader.loadModule("com.bugsnag.android.performance.AppCompatModule")
+        moduleLoader.loadModule("com.bugsnag.android.performance.okhttp.OkhttpModule")
     }
 
     /**

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -11,6 +11,7 @@ import com.bugsnag.android.performance.internal.instrumentation.ForegroundState
 import com.bugsnag.android.performance.internal.instrumentation.LegacyActivityInstrumentation
 import com.bugsnag.android.performance.internal.processing.ForwardingSpanProcessor
 import com.bugsnag.android.performance.internal.processing.Tracer
+import java.util.regex.Pattern
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class InstrumentedAppState {
@@ -28,6 +29,8 @@ public class InstrumentedAppState {
     public val autoInstrumentationCache: AutoInstrumentationCache = AutoInstrumentationCache()
 
     internal val activityInstrumentation = createActivityInstrumentation()
+
+    public var tracePropagationUrls: Collection<Pattern> = emptySet()
 
     public lateinit var app: Application
         private set
@@ -59,6 +62,8 @@ public class InstrumentedAppState {
         spanProcessor = tracer
         spanFactory.spanProcessor = tracer
         spanFactory.networkRequestCallback = configuration.networkRequestCallback
+
+        tracePropagationUrls = configuration.tracePropagationUrls
 
         if (configuration.autoInstrumentAppStarts) {
             // redirect existing spanProcessor -> new Tracer

--- a/bugsnag-plugin-android-performance-okhttp/consumer-rules.pro
+++ b/bugsnag-plugin-android-performance-okhttp/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keepattributes LineNumberTable,SourceFile
+-keep class com.bugsnag.android.performance.okhttp.OkhttpModule

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/OkhttpModule.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/OkhttpModule.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.performance.okhttp
+
+import com.bugsnag.android.performance.internal.InstrumentedAppState
+import com.bugsnag.android.performance.internal.Module
+import java.util.regex.Pattern
+
+internal class OkhttpModule : Module {
+    override fun load(instrumentedAppState: InstrumentedAppState) {
+        tracePropagationUrls = instrumentedAppState.tracePropagationUrls
+    }
+
+    override fun unload() {
+        tracePropagationUrls = emptyList()
+    }
+
+    internal companion object {
+        var tracePropagationUrls: Collection<Pattern> = emptyList()
+            private set
+    }
+}


### PR DESCRIPTION
## Goal
Make is easier for the `BugsnagPerformanceOkhttp` class to access its configuration by introducing an `OkhttpModule`.

## Testing
Manual testing to see that the new module is loaded as expected.