### PR TITLE
Discard unclosed ViewLoad spans when Activity  is paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Update the `bugsnag-plugin-android-performance-okhttp` module to optionally carry the current `SpanContext` as an OpenTelemetry `traceparent` header in outgoing HTTP requests.
   [#221](https://github.com/bugsnag/bugsnag-android-performance/pull/221)
+* To avoid unrealistically long ViewLoad & AppStart spans, these are discarded if the user backgrounds the app while an Activity is considered loading
+  [#227](https://github.com/bugsnag/bugsnag-android-performance/pull/227)
 
 ### Bug fixes
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -13,7 +13,6 @@ import java.security.SecureRandom
 import java.util.Random
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.atomic.AtomicLongFieldUpdater
 
 @Suppress("LongParameterList")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -103,7 +103,7 @@ internal abstract class AbstractActivityLifecycleInstrumentation(
         }
     }
 
-    override fun onActivityDestroyed(p0: Activity) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
     override fun onActivityStopped(activity: Activity)= Unit
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
     override fun onActivityStarted(activity: Activity) = Unit

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ForegroundState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ForegroundState.kt
@@ -17,7 +17,7 @@ internal object ForegroundState : ActivityLifecycleCallbacks {
      * background / foreground changes when there is only 1 Activity being restarted for configuration
      * changes.
      */
-    private const val BACKGROUND_TIMEOUT_MS = 700L
+    const val BACKGROUND_TIMEOUT_MS = 700L
 
     /**
      * The number of Activities that have been created but not destroyed. This is used to determine

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
@@ -129,31 +129,4 @@ class LegacyActivityInstrumentationTest {
         val spans = spanProcessor.toList()
         assertEquals(1, spans.size)
     }
-
-    @Test
-    fun leakedViewLoad() {
-        val activity = Activity()
-
-        // we tell the Instrumentation not to auto-close the span - but we also don't close it manually
-        activityInstrumentation.closeLoadSpans = false
-
-        val lifecycleHelper = ActivityLifecycleHelper(activityInstrumentation) {
-            ShadowPausedSystemClock.advanceBy(1, TimeUnit.MILLISECONDS)
-        }
-
-        lifecycleHelper.progressLifecycle(activity, from = DESTROYED, to = RESUMED)
-        // tear the activity back down again
-        lifecycleHelper.progressLifecycle(activity, from = RESUMED, to = DESTROYED)
-
-        Shadows.shadowOf(Loopers.main).runToEndOfTasks()
-
-        val spans = spanProcessor.toList()
-        assertEquals(1, spans.size)
-
-        val viewLoad = spans[0]
-        assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
-        assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
-        assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(102_000_000L, viewLoad.endTime.get())
-    }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/DiscardViewLoadOnStopScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/DiscardViewLoadOnStopScenario.kt
@@ -1,21 +1,26 @@
 package com.bugsnag.mazeracer.scenarios
 
+import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.mazeracer.ActivityViewLoadActivity
 import com.bugsnag.mazeracer.Scenario
 
-class ViewLoadLeakScenario(
+class DiscardViewLoadOnStopScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
+    init {
+        config.autoInstrumentAppStarts = false
+        config.autoInstrumentActivities = AutoInstrument.START_ONLY
+    }
+
     override fun startScenario() {
         BugsnagPerformance.start(config)
         startActivityAndFinish(
             ActivityViewLoadActivity.intent(
                 context,
                 config.autoInstrumentActivities,
-                endViewLoadSpan = false
             ),
         )
     }

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -178,8 +178,8 @@ Feature: Automatic creation of spans
       # this is required here to avoid interfering with other scenarios
     * I force stop the Android app
 
-  Scenario: ViewLoad spans can be safely leaked
-    Given I run "ViewLoadLeakScenario"
+  Scenario: ViewLoad spans only appear with app start
+    Given I run "DiscardViewLoadOnStopScenario"
     And I wait to receive a trace
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |


### PR DESCRIPTION
## Goal

When app is in the background, viewLoad does not inflate the aggregate metrics

## Changeset

Added method in onPaused to discard all the span 

## Testing

Unit tests and manual testing in example app