### PR TITLE
Update Span end time with AtomicLong 

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -6,6 +6,7 @@ import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.internal.SpanImpl.Companion.NO_END_TIME
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
@@ -393,7 +394,7 @@ public class SpanTracker {
 
         fun markLeaked(fallbackEndTime: Long = SystemClock.elapsedRealtimeNanos()): Boolean {
             // this span has not leaked, ignore and return
-            if (span.endTime != NO_END_TIME) {
+            if (span.endTime.get() != NO_END_TIME) {
                 return false
             }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
@@ -50,7 +50,7 @@ internal data class TracePayload(
         ): TracePayload {
             val payloadBytes = encodeSpanPayload(spans, resourceAttributes)
             val timestamp =
-                if (spans.isNotEmpty()) spans.maxOf { it.endTime }
+                if (spans.isNotEmpty()) spans.maxOf { it.endTime.get() }
                 else SystemClock.elapsedRealtimeNanos()
 
             val headers = mapOf("Bugsnag-Span-Sampling" to calculateSpanSamplingHeader(spans))

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -66,7 +66,7 @@ internal abstract class AbstractActivityLifecycleInstrumentation(
                 spanFactory.createViewLoadSpan(activity, spanOptions) { span ->
                     // we end the AppStart span at the same timestamp as the ViewLoad span ended
                     startupTracker.onViewLoadComplete(
-                        (span as? SpanImpl)?.endTime ?: SystemClock.elapsedRealtimeNanos(),
+                        (span as? SpanImpl)?.endTime?.get() ?: SystemClock.elapsedRealtimeNanos(),
                     )
                     spanFactory.spanProcessor.onEnd(span)
                 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AppStartTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/AppStartTest.kt
@@ -51,14 +51,14 @@ class AppStartTest {
         assertEquals("[AppStartPhase/Framework]", frameworkStart.name)
         // start and end time are in nanoseconds, not milliseconds
         assertEquals(100_000_000L, frameworkStart.startTime)
-        assertEquals(200_000_000L, frameworkStart.endTime)
+        assertEquals(200_000_000L, frameworkStart.endTime.get())
         assertEquals(SpanKind.INTERNAL, frameworkStart.kind)
         assertTrue(frameworkStart.isEnded())
 
         assertEquals("[AppStart/AndroidCold]", appStart.name)
         // start and end time are in nanoseconds, not milliseconds
         assertEquals(100_000_000L, appStart.startTime)
-        assertEquals(400_000_000L, appStart.endTime)
+        assertEquals(400_000_000L, appStart.endTime.get())
         assertEquals(SpanKind.INTERNAL, appStart.kind)
         assertTrue(appStart.isEnded())
     }
@@ -84,7 +84,7 @@ class AppStartTest {
         assertEquals("[AppStart/AndroidWarm]", appStart.name)
         // start and end time are in nanoseconds, not milliseconds
         assertEquals(500_000_000L, appStart.startTime)
-        assertEquals(600_000_000L, appStart.endTime)
+        assertEquals(600_000_000L, appStart.endTime.get())
         assertEquals(SpanKind.INTERNAL, appStart.kind)
         assertTrue(appStart.isEnded())
     }
@@ -112,7 +112,7 @@ class AppStartTest {
         assertEquals("[AppStartPhase/Framework]", frameworkStart.name)
         // start and end time are in nanoseconds, not milliseconds
         assertEquals(100_000_000L, frameworkStart.startTime)
-        assertEquals(200_000_000L, frameworkStart.endTime)
+        assertEquals(200_000_000L, frameworkStart.endTime.get())
         assertEquals(SpanKind.INTERNAL, frameworkStart.kind)
         assertTrue(frameworkStart.isEnded())
     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -87,7 +87,7 @@ class SpanPayloadEncodingTest {
                               "spanId": "00000000decafbad",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.startTime)}",
-                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.endTime)}",
+                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span1.endTime.get())}",
                               "attributes": [
                                 {
                                     "key": "bugsnag.sampling.p",
@@ -101,7 +101,7 @@ class SpanPayloadEncodingTest {
                               "spanId": "00000000baddecaf",
                               "traceId": "4ee2666146504c7fa35f00f007cd24e7",
                               "startTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.startTime)}",
-                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.endTime)}",
+                              "endTimeUnixNano": "${BugsnagClock.elapsedNanosToUnixTime(span2.endTime.get())}",
                               "attributes": [
                                 {
                                     "key": "bugsnag.sampling.p",

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -61,7 +61,7 @@ class SpanTest {
     fun spanAsClosable() {
         val span = createTestSpan().apply { use { sleep(1L) } }
         assertNotEquals(SpanImpl.NO_END_TIME, span.endTime)
-        assertTrue(span.startTime < span.endTime)
+        assertTrue(span.startTime < span.endTime.get())
     }
 
     private fun createTestSpan() = SpanImpl(

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTrackerTest.kt
@@ -38,16 +38,16 @@ class SpanTrackerTest {
         tracker.markSpanAutomaticEnd("TestActivity", ViewLoadPhase.CREATE)
         tracker.markSpanLeaked("TestActivity", ViewLoadPhase.CREATE)
 
-        assertEquals(autoEndTime, onCreateSpan.endTime)
+        assertEquals(autoEndTime, onCreateSpan.endTime.get())
         assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
 
         assertNotNull(tracker["TestActivity"])
-        assertNotEquals(autoEndTime, loadSpan.endTime)
+        assertNotEquals(autoEndTime, loadSpan.endTime.get())
 
         tracker.markSpanAutomaticEnd("TestActivity")
         tracker.markSpanLeaked("TestActivity")
 
-        assertEquals(autoEndTime, loadSpan.endTime)
+        assertEquals(autoEndTime, loadSpan.endTime.get())
         assertNull(tracker["TestActivity"])
     }
 
@@ -72,7 +72,7 @@ class SpanTrackerTest {
         onCreateSpan.end(realEndTime)
         tracker.markSpanLeaked("TestActivity", ViewLoadPhase.CREATE)
 
-        assertEquals(realEndTime, onCreateSpan.endTime)
+        assertEquals(realEndTime, onCreateSpan.endTime.get())
         assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
 
         // Activity.onResume
@@ -84,7 +84,7 @@ class SpanTrackerTest {
         // Activity.onDestroy
         tracker.markSpanLeaked("TestActivity")
 
-        assertEquals(realEndTime, loadSpan.endTime)
+        assertEquals(realEndTime, loadSpan.endTime.get())
         assertNull(tracker["TestActivity"])
     }
 
@@ -107,14 +107,14 @@ class SpanTrackerTest {
         // end the onCreate span
         tracker.endSpan("TestActivity", ViewLoadPhase.CREATE, endTime = endTime)
 
-        assertEquals(endTime, onCreateSpan.endTime)
+        assertEquals(endTime, onCreateSpan.endTime.get())
         assertNull(tracker["TestActivity", ViewLoadPhase.CREATE])
         assertSame(loadSpan, tracker["TestActivity"])
 
         // end the view load span
         tracker.endSpan("TestActivity", endTime = endTime)
 
-        assertEquals(endTime, loadSpan.endTime)
+        assertEquals(endTime, loadSpan.endTime.get())
         assertNull(tracker["TestActivity"])
     }
 
@@ -153,13 +153,13 @@ class SpanTrackerTest {
 
         val rootSpan = trackedSpans.remove(endedToken to null)!!
         assertTrue(rootSpan.isEnded())
-        assertEquals(1234L, rootSpan.endTime)
+        assertEquals(1234L, rootSpan.endTime.get())
         assertNull(tracker[endedToken])
 
         ViewLoadPhase.values().forEach { phase ->
             val span = trackedSpans.remove(endedToken to phase)!!
             assertTrue(span.isEnded())
-            assertEquals(1234L, span.endTime)
+            assertEquals(1234L, span.endTime.get())
             assertNull(tracker[endedToken, phase])
         }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentationTest.kt
@@ -88,12 +88,12 @@ class ActivityLifecycleInstrumentationTest {
         assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
         assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
         assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(101_000_000L, viewLoad.endTime)
+        assertEquals(101_000_000L, viewLoad.endTime.get())
 
         assertEquals("[ViewLoadPhase/ActivityCreate]Activity", create.name)
         assertEquals(SpanCategory.VIEW_LOAD_PHASE, create.category)
         assertEquals(100_000_000L, create.startTime)
-        assertEquals(100_000_000L, create.endTime)
+        assertEquals(100_000_000L, create.endTime.get())
     }
 
     @Test
@@ -135,21 +135,21 @@ class ActivityLifecycleInstrumentationTest {
         assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
         assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
         assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(102_000_000L, viewLoad.endTime)
+        assertEquals(102_000_000L, viewLoad.endTime.get())
 
         assertEquals("[ViewLoadPhase/ActivityCreate]Activity", create.name)
         assertEquals(SpanCategory.VIEW_LOAD_PHASE, create.category)
         assertEquals(100_000_000L, create.startTime)
-        assertEquals(100_000_000L, create.endTime)
+        assertEquals(100_000_000L, create.endTime.get())
 
         assertEquals("[ViewLoadPhase/ActivityStart]Activity", start.name)
         assertEquals(SpanCategory.VIEW_LOAD_PHASE, start.category)
         assertEquals(101_000_000L, start.startTime)
-        assertEquals(101_000_000L, start.endTime)
+        assertEquals(101_000_000L, start.endTime.get())
 
         assertEquals("[ViewLoadPhase/ActivityResume]Activity", resume.name)
         assertEquals(SpanCategory.VIEW_LOAD_PHASE, resume.category)
         assertEquals(102_000_000L, resume.startTime)
-        assertEquals(102_000_000L, resume.endTime)
+        assertEquals(102_000_000L, resume.endTime.get())
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/instrumentation/LegacyActivityInstrumentationTest.kt
@@ -69,7 +69,7 @@ class LegacyActivityInstrumentationTest {
         assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
         assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
         assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(102_000_000L, viewLoad.endTime)
+        assertEquals(102_000_000L, viewLoad.endTime.get())
     }
 
     @Test
@@ -108,7 +108,7 @@ class LegacyActivityInstrumentationTest {
         assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
         assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
         assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(101_000_000L, viewLoad.endTime)
+        assertEquals(101_000_000L, viewLoad.endTime.get())
     }
 
     @Test
@@ -154,6 +154,6 @@ class LegacyActivityInstrumentationTest {
         assertEquals("[ViewLoad/Activity]Activity", viewLoad.name)
         assertEquals(SpanCategory.VIEW_LOAD, viewLoad.category)
         assertEquals(100_000_000L, viewLoad.startTime)
-        assertEquals(102_000_000L, viewLoad.endTime)
+        assertEquals(102_000_000L, viewLoad.endTime.get())
     }
 }


### PR DESCRIPTION
## Goal

Optimised  updating end time for span by using `AtomicLong`

## Changeset

Replace `AtomicLongFieldUpdater` with `AtomicLong` to update end time in `spanImpl`

## Testing

Existing tests