### PR TITLE
Easier creation of SpanOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+* Added utility functions for creating `SpanOptions` while avoiding the need to reference `DEFAULTS`
+  [#230](https://github.com/bugsnag/bugsnag-android-performance/pull/230)
+
 ## 1.3.0 (2024-05-20)
 
 ### Enhancements

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -11,7 +11,7 @@ import com.bugsnag.android.performance.SpanOptions.Companion.DEFAULTS
  *
  * New `SpanOptions` are typically based on the [DEFAULTS]:
  * ```kotlin
- * BugsnagPerformance.startSpan("LoadSuggestions", SpanOptions.DEFAULTS.startTime(actualStartTime))
+ * BugsnagPerformance.startSpan("LoadSuggestions", SpanOptions.startTime(actualStartTime))
  * ```
  *
  * @see DEFAULTS
@@ -157,12 +157,30 @@ public class SpanOptions private constructor(
         private const val OPT_MAKE_CONTEXT = 4
         private const val OPT_IS_FIRST_CLASS = 8
 
-        /**
-         * The default set of `SpanOptions` with no overrides set. Use this as a starting-point to
-         * create new `SpanOptions`
-         */
-        @JvmField
-        public val DEFAULTS: SpanOptions =
-            SpanOptions(OPT_NONE, 0, null, makeContext = true, isFirstClass = false)
+        public var DEFAULTS: SpanOptions = SpanOptions(
+            OPT_NONE,
+            0,
+            null,
+            makeContext = true,
+            isFirstClass = false,
+        )
+            internal set
+
+        @JvmName("fromStartTime")
+        @JvmStatic
+        public fun startTime(startTime: Long): SpanOptions = DEFAULTS.startTime(startTime)
+
+        @JvmName("fromParentContext")
+        @JvmStatic
+        public fun within(parentContext: SpanContext?): SpanOptions = DEFAULTS.within(parentContext)
+
+        @JvmName("fromMakeCurrentContext")
+        @JvmStatic
+        public fun makeCurrentContext(makeContext: Boolean): SpanOptions = DEFAULTS.makeCurrentContext(makeContext)
+
+        @JvmName("fromFirstClass")
+        @JvmStatic
+        public fun setFirstClass(isFirstClass: Boolean): SpanOptions = DEFAULTS.setFirstClass(isFirstClass)
+
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -157,30 +157,31 @@ public class SpanOptions private constructor(
         private const val OPT_MAKE_CONTEXT = 4
         private const val OPT_IS_FIRST_CLASS = 8
 
-        public var DEFAULTS: SpanOptions = SpanOptions(
-            OPT_NONE,
-            0,
-            null,
-            makeContext = true,
-            isFirstClass = false,
-        )
-            internal set
+        /**
+         * The default set of `SpanOptions` with no overrides set. Use this as a starting-point to
+         * create new `SpanOptions`
+         */
+        @JvmField
+        public val DEFAULTS: SpanOptions =
+            SpanOptions(OPT_NONE, 0, null, makeContext = true, isFirstClass = false)
 
-        @JvmName("fromStartTime")
+        @JvmName("createWithStartTime")
         @JvmStatic
         public fun startTime(startTime: Long): SpanOptions = DEFAULTS.startTime(startTime)
 
-        @JvmName("fromParentContext")
+        @JvmName("createWithin")
         @JvmStatic
         public fun within(parentContext: SpanContext?): SpanOptions = DEFAULTS.within(parentContext)
 
-        @JvmName("fromMakeCurrentContext")
+        @JvmName("createAsCurrentContext")
         @JvmStatic
-        public fun makeCurrentContext(makeContext: Boolean): SpanOptions = DEFAULTS.makeCurrentContext(makeContext)
+        public fun makeCurrentContext(makeContext: Boolean): SpanOptions =
+            DEFAULTS.makeCurrentContext(makeContext)
 
-        @JvmName("fromFirstClass")
+        @JvmName("createFirstClass")
         @JvmStatic
-        public fun setFirstClass(isFirstClass: Boolean): SpanOptions = DEFAULTS.setFirstClass(isFirstClass)
+        public fun setFirstClass(isFirstClass: Boolean): SpanOptions =
+            DEFAULTS.setFirstClass(isFirstClass)
 
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -139,7 +139,7 @@ public class SpanFactory(
             "[AppStart/Android$startType]",
             SpanKind.INTERNAL,
             SpanCategory.APP_START,
-            SpanOptions.DEFAULTS.within(null),
+            SpanOptions.within(null),
             spanProcessor,
         )
 
@@ -157,7 +157,7 @@ public class SpanFactory(
             "[AppStartPhase/${phase.phaseName}]",
             SpanKind.INTERNAL,
             SpanCategory.APP_START_PHASE,
-            SpanOptions.DEFAULTS.within(appStartContext),
+            SpanOptions.within(appStartContext),
             spanProcessor,
         )
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -200,7 +200,7 @@ internal class ActivityLifecycleInstrumentation(
                 spanFactory.createViewLoadPhaseSpan(
                     activity,
                     phase,
-                    SpanOptions.DEFAULTS.within(viewLoadSpan),
+                    SpanOptions.within(viewLoadSpan),
                 )
             }
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -27,52 +27,52 @@ class SpanOptionsTest {
     fun testEquals() {
         assertEquals(
             // doesn't actually change the output
-            SpanOptions.DEFAULTS.makeCurrentContext(SpanOptions.DEFAULTS.makeContext),
+            SpanOptions.makeCurrentContext(SpanOptions.DEFAULTS.makeContext),
             SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.DEFAULTS.makeCurrentContext(true),
-            SpanOptions.DEFAULTS,
-        )
-
-        assertNotEquals(
-            SpanOptions.DEFAULTS.makeCurrentContext(false),
-            SpanOptions.DEFAULTS,
-        )
-
-        assertEquals(
-            SpanOptions.DEFAULTS.startTime(12345L),
-            SpanOptions.DEFAULTS.startTime(12345L),
-        )
-
-        assertNotEquals(
-            SpanOptions.DEFAULTS.startTime(12345L),
+            SpanOptions.makeCurrentContext(true),
             SpanOptions.DEFAULTS,
         )
 
         assertNotEquals(
-            SpanOptions.DEFAULTS.startTime(12345L),
-            SpanOptions.DEFAULTS.startTime(54321L),
-        )
-
-        assertEquals(
-            SpanOptions.DEFAULTS.within(SpanContext.invalid),
-            SpanOptions.DEFAULTS.within(SpanContext.invalid),
-        )
-
-        assertEquals(
-            SpanOptions.DEFAULTS.setFirstClass(true),
-            SpanOptions.DEFAULTS.setFirstClass(true),
-        )
-
-        assertEquals(
-            SpanOptions.DEFAULTS.within(SpanContext.current),
+            SpanOptions.makeCurrentContext(false),
             SpanOptions.DEFAULTS,
         )
 
         assertEquals(
-            SpanOptions.DEFAULTS.within(SpanOptions.DEFAULTS.parentContext),
+            SpanOptions.startTime(12345L),
+            SpanOptions.startTime(12345L),
+        )
+
+        assertNotEquals(
+            SpanOptions.startTime(12345L),
+            SpanOptions.DEFAULTS,
+        )
+
+        assertNotEquals(
+            SpanOptions.startTime(12345L),
+            SpanOptions.startTime(54321L),
+        )
+
+        assertEquals(
+            SpanOptions.within(SpanContext.invalid),
+            SpanOptions.within(SpanContext.invalid),
+        )
+
+        assertEquals(
+            SpanOptions.setFirstClass(true),
+            SpanOptions.setFirstClass(true),
+        )
+
+        assertEquals(
+            SpanOptions.within(SpanContext.current),
+            SpanOptions.DEFAULTS,
+        )
+
+        assertEquals(
+            SpanOptions.within(SpanOptions.DEFAULTS.parentContext),
             SpanOptions.DEFAULTS,
         )
     }
@@ -87,9 +87,9 @@ class SpanOptionsTest {
     @Test
     fun overrideStartTime() {
         val time = 876123L
-        assertEquals(time, SpanOptions.DEFAULTS.startTime(time).startTime)
+        assertEquals(time, SpanOptions.startTime(time).startTime)
         // test multi overrides of the same value
-        assertEquals(time, SpanOptions.DEFAULTS.startTime(0L).startTime(time).startTime)
+        assertEquals(time, SpanOptions.startTime(0L).startTime(time).startTime)
     }
 
     @Test
@@ -97,7 +97,7 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertEquals(false, SpanOptions.DEFAULTS.setFirstClass(false).isFirstClass)
+        assertEquals(false, SpanOptions.setFirstClass(false).isFirstClass)
         // test multi overrides of the same value
         assertEquals(
             true,

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -101,7 +101,7 @@ class SpanOptionsTest {
         // test multi overrides of the same value
         assertEquals(
             true,
-            SpanOptions.DEFAULTS.setFirstClass(false).setFirstClass(true).isFirstClass,
+            SpanOptions.setFirstClass(false).setFirstClass(true).isFirstClass,
         )
 
         // test nested span creation
@@ -110,7 +110,7 @@ class SpanOptionsTest {
             spanFactory.createCustomSpan("child").use { childSpan ->
                 // All Custom spans are first_class
                 assertTrue(childSpan.attributes.contains("bugsnag.span.first_class" to true))
-                spanFactory.createCustomSpan("override", SpanOptions.DEFAULTS.setFirstClass(true))
+                spanFactory.createCustomSpan("override", SpanOptions.setFirstClass(true))
                     .use { overrideSpan ->
                         assertTrue(overrideSpan.attributes.contains("bugsnag.span.first_class" to true))
                     }
@@ -123,16 +123,16 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertNull(SpanOptions.DEFAULTS.within(null).parentContext)
+        assertNull(SpanOptions.within(null).parentContext)
         // test multi overrides of the same value
-        assertNull(SpanOptions.DEFAULTS.within(SpanContext.current).within(null).parentContext)
+        assertNull(SpanOptions.within(SpanContext.current).within(null).parentContext)
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { rootSpan ->
             assertEquals(0L, rootSpan.parentSpanId)
             spanFactory.createCustomSpan("child").use { childSpan ->
                 assertEquals(rootSpan.spanId, childSpan.parentSpanId)
-                spanFactory.createCustomSpan("override", SpanOptions.DEFAULTS.within(null))
+                spanFactory.createCustomSpan("override", SpanOptions.within(null))
                     .use { overrideSpan ->
                         assertEquals(0L, overrideSpan.parentSpanId)
                     }
@@ -145,16 +145,16 @@ class SpanOptionsTest {
         val expectedTime = 12345L
         clock.`when`<Long> { SystemClock.elapsedRealtimeNanos() }.doReturn(expectedTime)
 
-        assertFalse(SpanOptions.DEFAULTS.makeCurrentContext(false).makeContext)
+        assertFalse(SpanOptions.makeCurrentContext(false).makeContext)
         // test multi overrides of the same value
         assertTrue(
-            SpanOptions.DEFAULTS.makeCurrentContext(false).makeCurrentContext(true).makeContext,
+            SpanOptions.makeCurrentContext(false).makeCurrentContext(true).makeContext,
         )
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { defaultSpan ->
             assertSame(SpanContext.current, defaultSpan)
-            spanFactory.createCustomSpan("child", SpanOptions.DEFAULTS.makeCurrentContext(false))
+            spanFactory.createCustomSpan("child", SpanOptions.makeCurrentContext(false))
                 .use { overrideSpan ->
                     assertNotSame(SpanContext.current, overrideSpan)
                 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/TracerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/TracerTest.kt
@@ -30,11 +30,11 @@ class TracerTest {
     fun testBatchSize() = InternalDebug.withDebugValues {
         InternalDebug.spanBatchSizeSendTriggerPoint = 2
 
-        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.DEFAULTS.startTime(1L)).end(10L)
+        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.startTime(1L)).end(10L)
 
         // assert it won't be delivered immediately (the batch size is 2)
         assertNull(tracer.collectNextBatch())
-        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.DEFAULTS.startTime(1L)).end(10L)
+        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.startTime(1L)).end(10L)
         // give the delivery thread time to wake up and do it's work
         assertEquals(2, tracer.collectNextBatch()!!.size)
 
@@ -42,8 +42,8 @@ class TracerTest {
         assertNull(tracer.collectNextBatch())
 
         // we deliver another two to ensure that the loop behaves as expected
-        spanFactory.createCustomSpan("BatchSize2.1", SpanOptions.DEFAULTS.startTime(2L)).end(20L)
-        spanFactory.createCustomSpan("BatchSize2.2", SpanOptions.DEFAULTS.startTime(3L)).end(30L)
+        spanFactory.createCustomSpan("BatchSize2.1", SpanOptions.startTime(2L)).end(20L)
+        spanFactory.createCustomSpan("BatchSize2.2", SpanOptions.startTime(3L)).end(30L)
 
         assertEquals(2, tracer.collectNextBatch()!!.size)
     }
@@ -55,8 +55,8 @@ class TracerTest {
         val worker = mock<Worker>()
         tracer.worker = worker
 
-        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.DEFAULTS.startTime(2L)).end(20L)
-        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.DEFAULTS.startTime(3L)).end(30L)
+        spanFactory.createCustomSpan("BatchSize1.1", SpanOptions.startTime(2L)).end(20L)
+        spanFactory.createCustomSpan("BatchSize1.2", SpanOptions.startTime(3L)).end(30L)
 
         // ensure that 2 spans woke the worker up exactly once
         verify(worker, times(1)).wake()

--- a/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
+++ b/bugsnag-plugin-android-performance-appcompat/src/main/kotlin/com/bugsnag/android/performance/FragmentActivityLifecycleCallbacks.kt
@@ -34,7 +34,7 @@ public class FragmentActivityLifecycleCallbacks(
      * measure ViewLoad from PreCreate -> Resume, and use a ViewLoadPhase/FragmentCreate
      * as the context for [Fragment.onCreate] which does not interleave with other fragments.
      */
-    private val viewLoadOpts = SpanOptions.DEFAULTS.makeCurrentContext(false)
+    private val viewLoadOpts = SpanOptions.makeCurrentContext(false)
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity !is FragmentActivity) return

--- a/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
+++ b/bugsnag-plugin-android-performance-okhttp/src/main/kotlin/com/bugsnag/android/performance/okhttp/BugsnagPerformanceOkhttp.kt
@@ -26,7 +26,7 @@ public class BugsnagPerformanceOkhttp : EventListener(), Interceptor {
         }
     }
 
-    private val networkSpanOptions = SpanOptions.DEFAULTS.makeCurrentContext(false)
+    private val networkSpanOptions = SpanOptions.makeCurrentContext(false)
 
     private val spans = ConcurrentHashMap<Call, Span>()
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
@@ -14,7 +14,7 @@ class MazeRacerAlarmReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         Log.i("MazeRacer", "MazeRacerAlarmReceiver.onReceive()")
-        BugsnagPerformance.startSpan("AlarmReceiver", SpanOptions.DEFAULTS.setFirstClass(true)).use {
+        BugsnagPerformance.startSpan("AlarmReceiver", SpanOptions.setFirstClass(true)).use {
             Thread.sleep(250L)
         }
     }


### PR DESCRIPTION
## Goal

Introduce easier factory functions to create `SpanOptions` to improve the usage syntax.

## Changeset

Introduce factory functions (which line-up with existing instance function names) for `SpanOptions`:

| Kotlin                          | Java                                     |
| --------------------- | -------------------------- |
| `SpanOptions.within`| `SpanOptions.createWithin` |
| `SpanOptions.startTime` | `SpanOptions.createWithStartTime` |
| `SpanOptions.makeCurrentContext` | `SpanOptions.createAsCurrentContext` |
| `SpanOptions.setFirstClass` | `SpanOptions.createFirstClass` |

The new syntax is optional, and simply a convenience over the existing `SpanOptions.DEFAULTS.****` calls.

## Testing

Existing tests