### PR TITLE
Add the current span/trace to Events in bugsnag-android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added utility functions for creating `SpanOptions` while avoiding the need to reference `DEFAULTS`
   [#230](https://github.com/bugsnag/bugsnag-android-performance/pull/230)
+* Set the trace/span id for the current `SpanContext` when an error is reported via `bugsnag-android`
+  [#233](https://github.com/bugsnag/bugsnag-android-performance/pull/233)
 
 ## 1.3.0 (2024-05-20)
 

--- a/bugsnag-android-performance/build.gradle.kts
+++ b/bugsnag-android-performance/build.gradle.kts
@@ -58,12 +58,15 @@ project.tasks.withType(KotlinCompile::class.java).configureEach {
 dependencies {
     api(libs.kotlin.stdlib)
 
+    compileOnly(libs.bugsnag.android)
+
     implementation(libs.androidx.annotation)
 
     testImplementation(libs.bundles.test.jvm)
 
     testImplementation(libs.kotlin.reflect)
     testImplementation(libs.jsonSchemaFriend)
+    testImplementation(libs.bugsnag.android)
 }
 
 license {

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -35,6 +35,7 @@
     <ID>SwallowedException:HttpDelivery.kt$HttpDelivery$e: IOException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
+    <ID>SwallowedException:NotifierIntegration.kt$NotifierIntegration$noClass: NoClassDefFoundError</ID>
     <ID>TooGenericExceptionCaught:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -22,6 +22,7 @@ import com.bugsnag.android.performance.internal.SendBatchTask
 import com.bugsnag.android.performance.internal.Task
 import com.bugsnag.android.performance.internal.Worker
 import com.bugsnag.android.performance.internal.createResourceAttributes
+import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import com.bugsnag.android.performance.internal.isInForeground
 import java.net.URL
 
@@ -166,6 +167,8 @@ public object BugsnagPerformance {
         bsgWorker.start()
 
         worker = bsgWorker
+
+        NotifierIntegration.link()
     }
 
     private fun loadModules() {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -9,6 +9,7 @@ import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.ViewType
+import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import java.util.UUID
 
 internal typealias AttributeSource = (target: HasAttributes) -> Unit
@@ -187,6 +188,8 @@ public class SpanFactory(
         )
 
         spanAttributeSource(span)
+
+        NotifierIntegration.onSpanStarted(span)
 
         return span
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -9,6 +9,7 @@ import com.bugsnag.android.performance.HasAttributes
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanContext
 import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import java.security.SecureRandom
 import java.util.Random
 import java.util.UUID
@@ -79,6 +80,7 @@ public class SpanImpl internal constructor(
     override fun end(endTime: Long) {
         if (this.endTime.compareAndSet(NO_END_TIME, endTime)) {
             processor.onEnd(this)
+            NotifierIntegration.onSpanEnded(this)
             if (makeContext) SpanContext.detach(this)
         }
     }
@@ -89,6 +91,7 @@ public class SpanImpl internal constructor(
      */
     public fun discard() {
         if (endTime.compareAndSet(NO_END_TIME, DISCARDED)) {
+            NotifierIntegration.onSpanEnded(this)
             if (makeContext) SpanContext.detach(this)
         }
     }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/integration/NotifierIntegration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/integration/NotifierIntegration.kt
@@ -1,0 +1,61 @@
+package com.bugsnag.android.performance.internal.integration
+
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.performance.SpanContext
+import com.bugsnag.android.performance.internal.SpanImpl
+
+/**
+ * Integration into the `bugsnag-android` error handling SDK. When `bugsnag-android` is available
+ * this object will automatically set the `Event.traceCorrelation` value to the active [SpanContext]
+ * when an error is being reported, allowing the errors to be linked to the active trace.
+ */
+internal object NotifierIntegration {
+    internal var linked = false
+        private set
+
+    private var topLevelSpan: SpanImpl? = null
+
+    fun link() {
+        // we suppress the errors to avoid breaking when the SDKs are not compatible
+        @Suppress("SwallowedException")
+        try {
+            if (Bugsnag.isStarted()) {
+                Bugsnag.addOnError { event ->
+                    // we suppress the errors to avoid breaking when the SDKs are not compatible
+                    @Suppress("SwallowedException")
+                    try {
+                        spanContextForError()?.let { context ->
+                            event.setTraceCorrelation(context.traceId, context.spanId)
+                        }
+                    } catch (noMethod: NoSuchMethodError) {
+                        // do nothing, the error SDK and performance-SDK are not compatible
+                    }
+                    true
+                }
+
+                linked = true
+            }
+        } catch (noClass: NoClassDefFoundError) {
+            // do nothing, the error SDK is not in use
+        }
+    }
+
+    fun onSpanStarted(span: SpanImpl) {
+        if (!linked) return
+        if (span.attributes["bugsnag.span.first_class"] == true) {
+            topLevelSpan = span
+        }
+    }
+
+    fun onSpanEnded(span: SpanImpl) {
+        if (!linked) return
+
+        if (topLevelSpan === span) {
+            topLevelSpan = null
+        }
+    }
+
+    private fun spanContextForError(): SpanContext? {
+        return SpanContext.current.takeUnless { it == SpanContext.invalid } ?: topLevelSpan
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/integration/NotifierIntegrationTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/integration/NotifierIntegrationTest.kt
@@ -1,0 +1,92 @@
+package com.bugsnag.android.performance.internal.integration
+
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Event
+import com.bugsnag.android.OnErrorCallback
+import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.internal.SpanCategory
+import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.test.NoopSpanProcessor
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import java.util.Random
+import java.util.UUID
+
+class NotifierIntegrationTest {
+    @Test
+    fun withStartedBugsnag() {
+        val onErrorCaptor = argumentCaptor<OnErrorCallback>()
+        val mockBugsnag = mockStatic(Bugsnag::class.java)
+        try {
+            mockBugsnag.`when`<Boolean> { Bugsnag.isStarted() } doReturn true
+            mockBugsnag.`when`<Void> { Bugsnag.addOnError(onErrorCaptor.capture()) }
+                .thenAnswer { null }
+            NotifierIntegration.link()
+
+            assertTrue(NotifierIntegration.linked)
+
+            val traceId = UUID.randomUUID()
+            val spanId = Random().nextLong()
+
+            val mockEvent =
+                createMockEventWithinSpan(createTestSpan(traceId, spanId), onErrorCaptor.firstValue)
+
+            verify(mockEvent).setTraceCorrelation(traceId, spanId)
+        } finally {
+            mockBugsnag.close()
+        }
+    }
+
+    @Test
+    fun withUnlinkedBugsnag() {
+        val mockBugsnag = mockStatic(Bugsnag::class.java)
+        try {
+            // we can't truly mock a classloader failure, but we can come pretty close
+            mockBugsnag.`when`<Boolean> { Bugsnag.isStarted() } doThrow NoClassDefFoundError("Bugsnag")
+            mockBugsnag.verify({ Bugsnag.addOnError(any()) }, never())
+            NotifierIntegration.link()
+
+            assertFalse(NotifierIntegration.linked)
+        } finally {
+            mockBugsnag.close()
+        }
+    }
+
+    private fun createMockEventWithinSpan(
+        span: SpanImpl,
+        onErrorCallback: OnErrorCallback,
+    ): Event {
+        val mockEvent = mock<Event>()
+
+        NotifierIntegration.onSpanStarted(span)
+        assertTrue(onErrorCallback.onError(mockEvent))
+        span.end(54321L)
+
+        return mockEvent
+    }
+
+    private fun createTestSpan(
+        traceId: UUID,
+        spanId: Long,
+        makeContext: Boolean = true,
+    ) = SpanImpl(
+        "Test Span",
+        SpanCategory.CUSTOM,
+        SpanKind.INTERNAL,
+        1234L,
+        traceId,
+        spanId,
+        0L,
+        NoopSpanProcessor,
+        makeContext,
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ androidx-benchmark = "androidx.benchmark:benchmark-junit4:1.1.1"
 androidx-test-runner = "androidx.test:runner:1.5.2"
 androidx-test-junit = "androidx.test.ext:junit:1.1.3"
 
+bugsnag-android = "com.bugsnag:bugsnag-android-core:6.6.0"
+
 jsonSchemaFriend = "net.jimblackler.jsonschemafriend:core:0.11.4"
 
 junit = "junit:junit:4.13.2"


### PR DESCRIPTION
## Goal
Link `Event`s reported by [bugsnag-android](https://github.com/bugsnag/bugsnag-android/) with the currently active `SpanContext`.

## Design
The new `NotifierIntegration` object is `link`ed on startup, and will attempt to check if `Bugsnag` exists and is started. If either the class cannot be loaded (signified by a `NoClassDefError`) or are `Bugsnag` is not started the `NotifierIntegration` marks itself as unlinked, and takes no further actions.

Otherwise (via an [OnErrorCallback](http://bugsnag.github.io/bugsnag-android/bugsnag-android-core/com.bugsnag.android/-on-error-callback/index.html)) the current `SpanContext` is attached to the `Event` via the new `setTraceCorrelation` function.

## Testing
Manually tested with an app, and in a new unit test.