### PR TITLE
Replace server_response.feature with 2 scenarios

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -35,7 +35,6 @@
     <ID>SwallowedException:HttpDelivery.kt$HttpDelivery$e: IOException</ID>
     <ID>SwallowedException:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>SwallowedException:Module.kt$Module.Loader$ex: Exception</ID>
-    <ID>SwallowedException:NotifierIntegration.kt$NotifierIntegration$noClass: NoClassDefFoundError</ID>
     <ID>TooGenericExceptionCaught:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContextExtensions.kt$exc: RuntimeException</ID>

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -94,3 +94,4 @@ Feature: Nested spans
     * the "[ViewLoad/Fragment]SecondFragment" span field "parentSpanId" equals the stored value "custom_root_span_id"
     * the "DoStuff" span field "parentSpanId" equals the stored value "custom_root_span_id"
     * the "LoadData" span field "parentSpanId" equals the stored value "custom_root_span_id"
+

--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -5,48 +5,7 @@ Feature: Server responses
     And I run "ThreeSpansScenario"
     And I should receive no traces
 
-  Scenario: No P update: success, fail-permanent, fail-retriable
-    Given I set the HTTP status code for the next requests to 200,200
-    And I load scenario "GenerateSpansScenario"
-    And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    Then a span name equals "span 1"
-    Then I discard the oldest trace
-    # 400 - Payload rejected
-    Given I set the HTTP status code for the next request to 400
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    Then a span name equals "span 2"
-    Then I discard the oldest trace
-    # 500 - Payload rejected (retry)
-    Given I set the HTTP status code for the next requests to 500,200
-    Then I invoke "sendNextSpan"
-    And I wait to receive 2 traces
-    # we expect a failure, and a retry
-    Then a span name equals "span 3"
-    Then I discard the oldest trace
-    Then a span name equals "span 3"
-
-  Scenario: No P update: success, fail-retriable, fail-permanent
-    Given I set the HTTP status code for the next requests to 200,200
-    And I load scenario "GenerateSpansScenario"
-    And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    # 200 - Payload accepted
-    Then a span name equals "span 1"
-    And I discard the oldest trace
-    Given I set the HTTP status code for the next requests to 500,400
-    Then I invoke "sendNextSpan"
-    And I wait to receive 2 traces
-    # 500 - Server error (retry) but still recorded by MazeRunner
-    Then a span name equals "span 2"
-    And I discard the oldest trace
-    # Retry of the previous request
-    Then a span name equals "span 2"
-
-  Scenario: No P update: fail-retriable, success, fail-permanent
+  Scenario: No P update: fail-retriable, fail-permanent
     Given I set the HTTP status code for the next request to 200
     And I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
@@ -58,20 +17,14 @@ Feature: Server responses
     And I discard the oldest trace
     Then a span name equals "span 1"
     And I discard the oldest trace
-    # 200 - Payload accepted
-    Given I set the HTTP status code for the next request to 200
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    Then a span name equals "span 2"
-    And I discard the oldest trace
     # 400 - Payload rejected
     Given I set the HTTP status code for the next request to 400
     Then I invoke "sendNextSpan"
     And I wait to receive 1 trace
-    Then a span name equals "span 3"
+    Then a span name equals "span 2"
 
-  Scenario: No P update: fail-permanent, fail-retriable, success
-    Given I set the HTTP status code for the next requests to 200,400
+  Scenario: No P update: fail-permanent
+    Given I set the HTTP status code for the next requests to 400
     And I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
     Then I invoke "sendNextSpan"
@@ -79,36 +32,3 @@ Feature: Server responses
     # 400 - Payload rejected, no retry
     Then a span name equals "span 1"
     And I discard the oldest trace
-    # 500 - Server error (retry) but still recorded by MazeRunner
-    Given I set the HTTP status code for the next requests to 500,200
-    Then I invoke "sendNextSpan"
-    And I wait to receive 2 traces
-    Then a span name equals "span 2"
-    And I discard the oldest trace
-    # Retry of the previous request
-    Then a span name equals "span 2"
-
-  Scenario: No P update: fail-permanent, success, fail-retriable
-    Given I set the HTTP status code for the next requests to 200,400
-    And I load scenario "GenerateSpansScenario"
-    And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    # 400 - Payload rejected, no retry
-    Then a span name equals "span 1"
-    And I discard the oldest trace
-    # 200 - Payload accepted
-    Given I set the HTTP status code for the next request to 200
-    Then I invoke "sendNextSpan"
-    And I wait to receive 1 trace
-    Then a span name equals "span 2"
-    And I discard the oldest trace
-    # 500 - Payload rejected (retry)
-    Given I set the HTTP status code for the next requests to 500,200
-    Then I invoke "sendNextSpan"
-    And I wait to receive 2 traces
-    Then a span name equals "span 3"
-    And I discard the oldest trace
-    # Retry of the previous request
-    Then a span name equals "span 3"
-


### PR DESCRIPTION
## Goal

To reduce the complexity in server_response and make it into simple two scenarios

## Changeset

Replace scenario with one fail-permanent and one with fail-retriable and then fail-permanent

## Testing

Update the existing current end to end tests