### PR TITLE
Add end2end test for error correlation

### DIFF
--- a/features/correlation.feature
+++ b/features/correlation.feature
@@ -1,0 +1,18 @@
+Feature: Manual creation of spans
+
+Scenario: Errors notified within a span include the correlation data
+  Given I run "CorrelatedErrorScenario"
+  And I wait to receive a sampling request
+  And I wait to receive a trace
+  And I wait to receive an error
+
+  * a span name equals "CorrelatedError Span"
+  * a span field "kind" equals 1
+  * a span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+  * a span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+  * a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+  * a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+
+  # Check the error correlation with the span
+  * the event "correlation.traceId" is not null
+  * the event "correlation.spanId" is not null

--- a/features/fixtures/mazeracer/app/build.gradle
+++ b/features/fixtures/mazeracer/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     implementation 'com.squareup.okhttp3:okhttp:5.0.0-alpha.11'
 
-    implementation "com.bugsnag:bugsnag-android:5.+"
+    implementation "com.bugsnag:bugsnag-android:6.+"
 
     implementation 'com.bugsnag:bugsnag-android-performance:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-okhttp:9.9.9'

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.mazeracer
 
 import android.util.Log
+import com.bugsnag.android.Logger
 
 fun log(msg: String) {
     Log.d("BugsnagMazeRacer", msg)
@@ -8,4 +9,40 @@ fun log(msg: String) {
 
 fun log(msg: String, e: Exception) {
     Log.e("BugsnagMazeRacer", msg, e)
+}
+
+object BugsnagLogger : Logger {
+    private const val TAG = "Bugsnag"
+
+    override fun d(msg: String) {
+        Log.d(TAG, msg)
+    }
+
+    override fun d(msg: String, throwable: Throwable) {
+        Log.d(TAG, msg, throwable)
+    }
+
+    override fun i(msg: String) {
+        Log.i(TAG, msg)
+    }
+
+    override fun i(msg: String, throwable: Throwable) {
+        Log.i(TAG, msg, throwable)
+    }
+
+    override fun w(msg: String) {
+        Log.w(TAG, msg)
+    }
+
+    override fun w(msg: String, throwable: Throwable) {
+        Log.w(TAG, msg, throwable)
+    }
+
+    override fun e(msg: String) {
+        Log.e(TAG, msg)
+    }
+
+    override fun e(msg: String, throwable: Throwable) {
+        Log.e(TAG, msg, throwable)
+    }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -148,6 +148,8 @@ class MainActivity : AppCompatActivity() {
                 notify = "http://$mazeAddress/notify",
                 sessions = "http://$mazeAddress/session",
             )
+
+            logger = BugsnagLogger
         }
         Bugsnag.start(this, config)
     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/CorrelatedErrorScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/CorrelatedErrorScenario.kt
@@ -1,17 +1,15 @@
 package com.bugsnag.mazeracer.scenarios
 
-import android.util.Log
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.Scenario
 
-class GenerateSpansScenario(
+class CorrelatedErrorScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
-    var spanId = 1
 
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
@@ -19,12 +17,8 @@ class GenerateSpansScenario(
     }
 
     override fun startScenario() {
-        // not used by this scenario, which is driven by "invoke" commands
-    }
-
-    fun sendNextSpan() {
-        Log.i("GenerateSpansScenario", "sendNextSpan($spanId)")
-        BugsnagPerformance.startSpan("span $spanId").end()
-        spanId++
+        BugsnagPerformance.startSpan("CorrelatedError Span").use {
+            Bugsnag.notify(RuntimeException("this is an error"))
+        }
     }
 }


### PR DESCRIPTION
## Goal
Introduce an end2end test sending an event within a correlated `Span`

## Testing
New MazeRunner scenario and feature.