### PR TITLE
Reduce flakeyness in the server response code/probability tests

### DIFF
--- a/features/server_response.feature
+++ b/features/server_response.feature
@@ -7,12 +7,11 @@ Feature: Server responses
     Then I should receive no traces
 
   Scenario: No P update: fail-retriable, fail-permanent
-    Given I set the HTTP status code for the next request to 200
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
     # 500 - Server error (retry) but still recorded by MazeRunner
-    Given I set the HTTP status code for the next request to 500
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next request to 500
+    And I invoke "sendNextSpan"
     # 2 traces: 1 failed, 1 retry
     And I wait to receive 2 traces
     Then a span name equals "span 1"
@@ -20,16 +19,16 @@ Feature: Server responses
     Then a span name equals "span 1"
     And I discard the oldest trace
     # 400 - Payload rejected
-    Given I set the HTTP status code for the next request to 400
+    Then I set the HTTP status code for the next request to 400
     And I invoke "sendNextSpan"
     And I wait to receive 2 traces
     Then a span name equals "span 1"
     And a span name equals "span 2"
 
   Scenario: No P update: fail-permanent
-    Given I set the HTTP status code for the next requests to 400
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
+    Then I set the HTTP status code for the next requests to 400
     Then I invoke "sendNextSpan"
     And I wait to receive 1 trace
     # 400 - Payload rejected, no retry

--- a/features/server_response_pvalue.feature
+++ b/features/server_response_pvalue.feature
@@ -2,38 +2,29 @@ Feature: Server responses P value
     # P=0 on first response
 
   Scenario: Update P to 0 on first response: success, fail-permanent, fail-retriable
-#    Given I set the HTTP status code for the next requests to 200,200,400,500
-    Given I set the HTTP status code for the next requests to 200,200
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next requests to 200
+    And I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 1"
     Then I discard the oldest trace
-    Given I set the HTTP status code for the next request to 400
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next request to 400
+    And I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 2"
     And I discard the oldest trace
-    Given I set the HTTP status code for the next request to 500
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next request to 500
+    And I invoke "sendNextSpan"
     And I wait to receive 2 traces
 
     * a span named "span 3" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
 
-    * a span named "span 3" contains the attributes:
-      | attribute                | type      | value |
-      | bugsnag.span.first_class | boolValue | true  |
-
-    Given I set the HTTP status code for the next request to 200
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next request to 200
+    And I invoke "sendNextSpan"
     And I wait to receive 3 traces
-
-    * a span named "span 3" contains the attributes:
-      | attribute                | type      | value |
-      | bugsnag.span.first_class | boolValue | true  |
 
     * a span named "span 3" contains the attributes:
       | attribute                | type      | value |
@@ -44,10 +35,9 @@ Feature: Server responses P value
       | bugsnag.span.first_class | boolValue | true  |
 
   Scenario: Update P to 0 on first response: success, fail-retriable, fail-permanent
-#    Given I set the HTTP status code for the next requests to 200,200,500,400
-    Given I set the HTTP status code for the next requests to 200,200
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
+    Then I set the HTTP status code for the next requests to 200
     Then I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 1"
@@ -55,10 +45,6 @@ Feature: Server responses P value
     Given I set the HTTP status code for the next request to 500
     Then I invoke "sendNextSpan"
     And I wait to receive 2 traces
-
-    * a span named "span 2" contains the attributes:
-      | attribute                | type      | value |
-      | bugsnag.span.first_class | boolValue | true  |
 
     * a span named "span 2" contains the attributes:
       | attribute                | type      | value |
@@ -72,10 +58,9 @@ Feature: Server responses P value
     Then a span name equals "span 3"
 
   Scenario: Update P to 0 on first response: fail-retriable, success, fail-permanent
-#    Given I set the HTTP status code for the next requests to 200,500,200,400
-    Given I set the HTTP status code for the next requests to 200,500
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
+    Then I set the HTTP status code for the next requests to 500
     Then I invoke "sendNextSpan"
     And I wait to receive at least 1 trace
     Then a span name equals "span 1"
@@ -105,21 +90,16 @@ Feature: Server responses P value
     Then a span name equals "span 4"
 
   Scenario: Update P to 0 on first response: fail-permanent, fail-retriable, success
-#    Given I set the HTTP status code for the next requests to 200,400,500,200
-    Given I set the HTTP status code for the next requests to 200,400
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next requests to 400
+    And I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 1"
     Then I discard the oldest trace
     Given I set the HTTP status code for the next request to 500
     Then I invoke "sendNextSpan"
     And I wait to receive 2 traces
-
-    * a span named "span 2" contains the attributes:
-      | attribute                | type      | value |
-      | bugsnag.span.first_class | boolValue | true  |
 
     * a span named "span 2" contains the attributes:
       | attribute                | type      | value |
@@ -133,10 +113,9 @@ Feature: Server responses P value
     Then a span name equals "span 3"
 
   Scenario: Update P to 0 on first response: fail-permanent, success, fail-retriable
-#    Given I set the HTTP status code for the next requests to 200,400,200,500
-    Given I set the HTTP status code for the next requests to 200,400
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
+    Then I set the HTTP status code for the next requests to 400
     Then I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 1"
@@ -154,10 +133,6 @@ Feature: Server responses P value
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
 
-    * a span named "span 3" contains the attributes:
-      | attribute                | type      | value |
-      | bugsnag.span.first_class | boolValue | true  |
-
     Then I discard the oldest trace
     Then I discard the oldest trace
     Given I set the HTTP status code for the next request to 200
@@ -168,10 +143,10 @@ Feature: Server responses P value
   # P=0 on second response
 
   Scenario: Update P to 0 on second response: success, fail-permanent, fail-retriable
-    Given I set the HTTP status code for the next requests to 200,200
+    Given I load scenario "GenerateSpansScenario"
+    And I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next requests to 200
     And I set the sampling probability for the next traces to "1,null"
-    And I load scenario "GenerateSpansScenario"
-    Then I invoke "sendNextSpan"
     And I wait to receive 1 trace
     Then a span name equals "span 1"
     And I discard the oldest trace
@@ -188,10 +163,10 @@ Feature: Server responses P value
     And I should receive no traces
 
   Scenario: Update P to 0 on second response: fail-retriable, fail-permanent, success
-    Given I set the HTTP status code for the next requests to 200,500
-    And I load scenario "GenerateSpansScenario"
+    Given I load scenario "GenerateSpansScenario"
     And I wait to receive a sampling request
-    Then I invoke "sendNextSpan"
+    Then I set the HTTP status code for the next requests to 500
+    And I invoke "sendNextSpan"
     And I wait to receive at least 1 trace
     Then a span name equals "span 1"
     Then I discard the oldest trace


### PR DESCRIPTION
## Goal
Reduce flakeyness in the server response code/probability tests - again

## Design
Reordered the HTTP response steps so that the selected status codes always only apply to the expected traces.
