### PR TITLE
Reduce the scope of the Attributes / HasAttributes

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/Attributes.kt
@@ -1,15 +1,19 @@
 package com.bugsnag.android.performance
 
-public class Attributes : Collection<Pair<String, Any>> {
+public class Attributes {
     private val content = mutableMapOf<String, Any>()
 
-    override val size: Int
+    @get:JvmSynthetic
+    internal val entries: Collection<Map.Entry<String, Any>>
+        inline get() = content.entries
+
+    public val size: Int
         get() = content.size
 
     public val keys: Set<String> get() = content.keys.toSet()
 
     public operator fun set(name: String, value: String?) {
-        if(value != null) {
+        if (value != null) {
             content[name] = value
         } else {
             content.remove(name)
@@ -40,18 +44,4 @@ public class Attributes : Collection<Pair<String, Any>> {
     public fun remove(name: String) {
         content.remove(name)
     }
-
-    override fun iterator(): Iterator<Pair<String, Any>> =
-        content.asSequence().map { it.toPair() }.iterator()
-
-    override fun contains(element: Pair<String, Any>): Boolean {
-        val (key, value) = element
-        return content[key] == value
-    }
-
-    override fun containsAll(elements: Collection<Pair<String, Any>>): Boolean {
-        return elements.all { (key, value) -> content[key] == value }
-    }
-
-    override fun isEmpty(): Boolean = content.isEmpty()
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/HasAttributes.kt
@@ -5,18 +5,14 @@ package com.bugsnag.android.performance
  * attributes directly without needing to access the [attributes] property.
  */
 public interface HasAttributes {
-    public val attributes: Attributes
 
     /**
-     * Set or clear a string attribute. Passing `null` is the same as calling [clearAttribute] for
-     * the given `name`.
+     * Set or clear a string attribute. Passing `null` will remove the attribute.
      *
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    public fun setAttribute(name: String, value: String?) {
-        attributes[name] = value
-    }
+    public fun setAttribute(name: String, value: String?)
 
     /**
      * Set a long integer attribute.
@@ -24,9 +20,7 @@ public interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    public fun setAttribute(name: String, value: Long) {
-        attributes[name] = value
-    }
+    public fun setAttribute(name: String, value: Long)
 
     /**
      * Set an integer attribute.
@@ -34,9 +28,7 @@ public interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    public fun setAttribute(name: String, value: Int) {
-        attributes[name] = value
-    }
+    public fun setAttribute(name: String, value: Int)
 
     /**
      * Set a floating point / double attribute.
@@ -44,9 +36,7 @@ public interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    public fun setAttribute(name: String, value: Double) {
-        attributes[name] = value
-    }
+    public fun setAttribute(name: String, value: Double)
 
     /**
      * Set a boolean attribute.
@@ -54,15 +44,5 @@ public interface HasAttributes {
      * @param name the attribute name
      * @param value the value to set the attribute to
      */
-    public fun setAttribute(name: String, value: Boolean) {
-        attributes[name] = value
-    }
-
-    /**
-     * Clear / remove the specified attribute if it exists. This is the same
-     * as `attributes.remove(name)`.
-     */
-    public fun clearAttribute(name: String) {
-        attributes.remove(name)
-    }
+    public fun setAttribute(name: String, value: Boolean)
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Attributes.kt
@@ -1,5 +1,8 @@
-package com.bugsnag.android.performance
+package com.bugsnag.android.performance.internal
 
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class Attributes {
     private val content = mutableMapOf<String, Any>()
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
@@ -8,7 +8,7 @@ import kotlin.collections.forEach
 
 internal fun JsonWriter.value(attributes: Attributes): JsonWriter {
     return array {
-        attributes.forEach { (key, value) ->
+        attributes.entries.forEach { (key, value) ->
             obj {
                 name("key").value(key)
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/AttributesJson.kt
@@ -3,7 +3,6 @@
 package com.bugsnag.android.performance.internal
 
 import android.util.JsonWriter
-import com.bugsnag.android.performance.Attributes
 import kotlin.collections.forEach
 
 internal fun JsonWriter.value(attributes: Attributes): JsonWriter {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Delivery.kt
@@ -1,7 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
-
 internal sealed class DeliveryResult {
     object Success : DeliveryResult() {
         override fun toString(): String = "Success"

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/DeviceIdFilePersistence.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.performance.internal
 
 import android.content.Context
 import androidx.annotation.RestrictTo
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 import org.json.JSONObject
 import java.io.File

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 import java.io.IOException
 import java.net.HttpURLConnection

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
 import android.os.Build
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.BugsnagPerformance
 
 internal fun createResourceAttributes(configuration: ImmutableConfig): Attributes {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/RetryDelivery.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 
 internal class RetryDelivery(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.performance.internal
 
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.internal.processing.Tracer
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -4,7 +4,6 @@ import android.os.SystemClock
 import android.util.JsonWriter
 import androidx.annotation.FloatRange
 import androidx.annotation.RestrictTo
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.HasAttributes
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanContext

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -15,7 +15,7 @@ import java.util.Random
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class SpanImpl internal constructor(
     name: String,
@@ -29,7 +29,7 @@ public class SpanImpl internal constructor(
     private val makeContext: Boolean,
 ) : Span, HasAttributes {
 
-    override val attributes: Attributes = Attributes()
+    public val attributes: Attributes = Attributes()
 
     /**
      * Internally SpanImpl objects can be chained together as a fast linked-list structure
@@ -115,7 +115,7 @@ public class SpanImpl internal constructor(
                 name("parentSpanId").value(parentSpanId.toHexString())
             }
 
-            if (attributes.isNotEmpty()) {
+            if (attributes.size > 0) {
                 name("attributes").value(attributes)
             }
         }
@@ -144,6 +144,36 @@ public class SpanImpl internal constructor(
             else append(", endTime=").append(endTime)
 
             append(')')
+        }
+    }
+
+    override fun setAttribute(name: String, value: String?) {
+        if (!isEnded()) {
+            attributes[name] = value
+        }
+    }
+
+    override fun setAttribute(name: String, value: Long) {
+        if (!isEnded()) {
+            attributes[name] = value
+        }
+    }
+
+    override fun setAttribute(name: String, value: Int) {
+        if (!isEnded()) {
+            attributes[name] = value
+        }
+    }
+
+    override fun setAttribute(name: String, value: Double) {
+        if (!isEnded()) {
+            attributes[name] = value
+        }
+    }
+
+    override fun setAttribute(name: String, value: Boolean) {
+        if (!isEnded()) {
+            attributes[name] = value
         }
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.performance.internal
 import android.os.SystemClock
 import android.util.JsonWriter
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.Attributes
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
 import java.util.TreeMap

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/TracePayload.kt
@@ -125,10 +125,10 @@ internal data class TracePayload(
             resourceAttributes: Attributes,
             spans: Collection<SpanImpl>,
         ) {
-            if (resourceAttributes.isEmpty() && spans.isEmpty()) return
+            if (resourceAttributes.size == 0 && spans.isEmpty()) return
 
             obj {
-                if (resourceAttributes.isNotEmpty()) {
+                if (resourceAttributes.size > 0) {
                     name("resource").obj {
                         name("attributes").value(resourceAttributes)
                     }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/NetworkRequestAttributesTest.kt
@@ -19,12 +19,11 @@ class NetworkRequestAttributesTest {
     fun setResponseCode() {
         val expectedCodes = intArrayOf(100, 200, 400, 404, 500)
         for (code in expectedCodes) {
-            val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+            val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
             NetworkRequestAttributes.setResponseCode(span, code)
 
             // Integer attributes are stored as Long, not Int
-            val statusCodeAttr =
-                span.attributes.find { it.first == "http.status_code" }!!.second as Long
+            val statusCodeAttr = span.attributes["http.status_code"] as Long
 
             assertEquals(code, statusCodeAttr.toInt())
         }
@@ -33,11 +32,10 @@ class NetworkRequestAttributesTest {
     @Test
     fun setRequestContentLength() {
         val requestBodySize = 1024L
-        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
         NetworkRequestAttributes.setRequestContentLength(span, requestBodySize)
 
-        val requestLength = span.attributes
-            .find { it.first == "http.request_content_length" }!!.second as Long
+        val requestLength = span.attributes["http.request_content_length"] as Long
 
         assertEquals(requestBodySize, requestLength)
     }
@@ -45,42 +43,39 @@ class NetworkRequestAttributesTest {
     @Test
     fun setUncompressedRequestContentLength() {
         val requestBodySize = 1024L
-        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
         NetworkRequestAttributes.setUncompressedRequestContentLength(span, requestBodySize)
 
-        val requestLength = span.attributes
-            .find { it.first == "http.request_content_length_uncompressed" }!!.second as Long
+        val requestLength = span.attributes["http.request_content_length_uncompressed"] as Long
 
         assertEquals(requestBodySize, requestLength)
     }
 
     @Test
     fun setResponseContentLength() {
-        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
         NetworkRequestAttributes.setResponseContentLength(span, Long.MAX_VALUE)
 
-        val responseLength = span.attributes
-            .find { it.first == "http.response_content_length" }!!.second as Long
+        val responseLength = span.attributes["http.response_content_length"] as Long
 
         assertEquals(Long.MAX_VALUE, responseLength)
     }
 
     @Test
     fun setUncompressedResponseContentLength() {
-        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
         NetworkRequestAttributes.setUncompressedResponseContentLength(span, Long.MAX_VALUE)
 
-        val responseLength = span.attributes
-            .find { it.first == "http.response_content_length_uncompressed" }!!.second as Long
+        val responseLength = span.attributes["http.response_content_length_uncompressed"] as Long
 
         assertEquals(Long.MAX_VALUE, responseLength)
     }
 
     @Test
     fun setHttpFlavor() {
-        val span = spanFactory.newSpan(processor = NoopSpanProcessor)
+        val span = spanFactory.newSpan(processor = NoopSpanProcessor, endTime = null)
         NetworkRequestAttributes.setHttpFlavor(span, "1.1")
-        val flavor = span.attributes.find { it.first == "http.flavor" }!!.second as String
+        val flavor = span.attributes["http.flavor"] as String
         assertEquals("1.1", flavor)
     }
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanContextTest.kt
@@ -146,7 +146,7 @@ internal class SpanContextTest {
         spanFactory.createViewLoadSpan(ViewType.ACTIVITY, "MainActivity").use { activitySpan ->
             assertEquals(
                 true,
-                activitySpan.attributes.find { (key) -> key == "bugsnag.span.first_class" }!!.second,
+                activitySpan.attributes["bugsnag.span.first_class"],
             )
 
             // create a nested span between "MainActivity" and "IndexFragment"
@@ -155,7 +155,7 @@ internal class SpanContextTest {
                     .use { fragmentSpan ->
                         assertEquals(
                             false,
-                            fragmentSpan.attributes.find { (key) -> key == "bugsnag.span.first_class" }!!.second,
+                            fragmentSpan.attributes["bugsnag.span.first_class"],
                         )
                     }
             }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/SpanOptionsTest.kt
@@ -21,6 +21,7 @@ class SpanOptionsTest {
     @Before
     fun newSpanFactory() {
         spanFactory = SpanFactory(NoopSpanProcessor)
+        SpanContext.contextStack.clear()
     }
 
     @Test
@@ -106,13 +107,13 @@ class SpanOptionsTest {
 
         // test nested span creation
         spanFactory.createCustomSpan("parent").use { rootSpan ->
-            assertTrue(rootSpan.attributes.contains("bugsnag.span.first_class" to true))
+            assertEquals(true, rootSpan.attributes["bugsnag.span.first_class"])
             spanFactory.createCustomSpan("child").use { childSpan ->
                 // All Custom spans are first_class
-                assertTrue(childSpan.attributes.contains("bugsnag.span.first_class" to true))
+                assertEquals(true, childSpan.attributes["bugsnag.span.first_class"])
                 spanFactory.createCustomSpan("override", SpanOptions.setFirstClass(true))
                     .use { overrideSpan ->
-                        assertTrue(overrideSpan.attributes.contains("bugsnag.span.first_class" to true))
+                        assertEquals(true, overrideSpan.attributes["bugsnag.span.first_class"])
                     }
             }
         }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/HttpDeliveryTest.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.test.CollectingSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
 import org.junit.Assert.assertNotEquals

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -37,7 +37,7 @@ class ResourceAttributesTest {
             emptySet(),
         )
 
-        val attributes = createResourceAttributes(configuration).toList().toMap()
+        val attributes = createResourceAttributes(configuration)
 
         assertTrue(attributes["host.arch"] in setOf("amd64", "arm64", "arm32", "x86"))
         assertEquals("linux", attributes["os.type"])
@@ -75,7 +75,7 @@ class ResourceAttributesTest {
             emptySet(),
         )
 
-        val attributes = createResourceAttributes(configuration).toList().toMap()
+        val attributes = createResourceAttributes(configuration)
 
         assertTrue(attributes["host.arch"] in setOf("amd64", "arm64", "arm32", "x86"))
         assertEquals("linux", attributes["os.type"])

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/RetryDeliveryTest.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.StubDelivery

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SendBatchTaskTest.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.internal.processing.Tracer
 import com.bugsnag.android.performance.test.NoopSpanProcessor

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanPayloadEncodingTest.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.SpanKind
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.OtelValidator.assertTraceDataValid

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/TracePayloadTest.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.performance.internal
 
-import com.bugsnag.android.performance.Attributes
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestSpanFactory
 import org.junit.Assert.assertEquals

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/test/StubDelivery.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.performance.test
 
-import com.bugsnag.android.performance.Attributes
+import com.bugsnag.android.performance.internal.Attributes
 import com.bugsnag.android.performance.internal.Delivery
 import com.bugsnag.android.performance.internal.DeliveryResult
 import com.bugsnag.android.performance.internal.NewProbabilityCallback


### PR DESCRIPTION
## Goal
Reduce the API surface and implementation of `Attributes` and `HasAttributes` before they are surfaced as officially public API.

## Design
The original `Attributes` class and `HasAttributes` interface were too tightly coupled, and exposed API that forces additional overheads (converting `Map.Entry` -> `Pair`) with no gain.

This PR reduces the visibility of the `Attributes` implementation, allowing us to make more significant changes later on without breaking changes.

### Breaking Changes
The `Attributes` and `HasAttributes` were both previously public API, but there is no public way to access them currently. This PR aims to reduce the probability that any future breaking changes will be needed.

## Changeset
- `Attributes` no longer implements `Collection<Pair<String, Any>>` which reduces the iteration overhead when writing them as JSON
- `HasAttributes` no longer requires an `Attributes` object, and has become a pure interface (with no function implementations)
- `SpanImpl.setAttribute` methods all check that the Span is still open, and no-op if the span has been ended already

## Testing
Updated the existing tests to conform to the new API