### PR TITLE
capturing Security exception on Android 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Avoid crashing on Android 11 due to https://issuetracker.google.com/issues/175055271.
+  [#276](https://github.com/bugsnag/bugsnag-android-performance/pull/276)
+
 ## 1.6.0 (2024-08-27)
 
 ### Enhancements

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -30,6 +30,7 @@
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
+    <ID>SwallowedException:ContextExtensions.kt$exc: SecurityException</ID>
     <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: OverlappingFileLockException</ID>
     <ID>SwallowedException:ForegroundTracker.kt$exc: RuntimeException</ID>
     <ID>SwallowedException:HttpDelivery.kt$HttpDelivery$e: Exception</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Connectivity.kt
@@ -150,7 +150,7 @@ internal open class ConnectivityApi24(
     private val tm: TelephonyManager? = context.getTelephonyManager()
 
     override var connectivityStatus: ConnectivityStatus =
-        networkCapabilitiesToStatus(cm.getNetworkCapabilities(cm.activeNetwork))
+        networkCapabilitiesToStatus(cm.safeGetNetworkCapabilities(cm.activeNetwork))
         protected set(newStatus) {
             if (field != newStatus) {
                 field = newStatus
@@ -263,7 +263,7 @@ internal open class ConnectivityApi24(
             return
         }
 
-        val capabilities = cm.getNetworkCapabilities(activeNetwork) ?: return
+        val capabilities = cm.safeGetNetworkCapabilities(activeNetwork) ?: return
         connectivityStatus = networkCapabilitiesToStatus(capabilities)
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ContextExtensions.kt
@@ -7,8 +7,12 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
 import android.os.RemoteException
 import android.telephony.TelephonyManager
+import androidx.annotation.RequiresApi
 import com.bugsnag.android.performance.Logger
 
 internal const val RELEASE_STAGE_DEVELOPMENT = "development"
@@ -56,6 +60,18 @@ private inline fun <reified T> Context.safeGetSystemService(name: String): T? {
     return try {
         getSystemService(name) as? T
     } catch (exc: RuntimeException) {
+        null
+    }
+}
+
+/**
+ * work around https://issuetracker.google.com/issues/175055271 on Android 11
+ */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+internal fun ConnectivityManager.safeGetNetworkCapabilities(network: Network?): NetworkCapabilities? {
+    return try {
+        getNetworkCapabilities(network)
+    } catch (exc: SecurityException) {
         null
     }
 }


### PR DESCRIPTION
## Goal
Capturing the exception when getting NetworkCapabilities

## Changeset

Added a `safeGetNetworkCapabilities` which will capture the security exception when `ConnectivityManager` is getting network capabilities