### PR TITLE
feat(config)Use API key subdomain as default Performance endpoint

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -15,7 +15,7 @@ public class PerformanceConfiguration private constructor(public val context: Co
 
     public var apiKey: String = ""
 
-    public var endpoint: String = "https://otlp.bugsnag.com/v1/traces"
+    public var endpoint: String = ""
 
     public var autoInstrumentAppStarts: Boolean = true
 
@@ -121,7 +121,11 @@ public class PerformanceConfiguration private constructor(public val context: Co
         ): PerformanceConfiguration {
             return PerformanceConfiguration(ctx).apply {
                 (apiKeyOverride ?: data?.getString(API_KEY, data.getString(BSG_API_KEY)))
-                    ?.also { apiKey = it }
+                    ?.also {
+                        apiKey = it
+                        endpoint = "https://${apiKey}.otlp.bugsnag.com/v1/traces"
+                    }
+
 
                 data?.getString(ENDPOINT_KEY)
                     ?.also { endpoint = it }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ConfigurationLoaderTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/ConfigurationLoaderTest.kt
@@ -40,7 +40,7 @@ class ConfigurationLoaderTest {
         val config = PerformanceConfiguration.loadFromMetaData(mock(), metadataBundle, null)
 
         assertEquals(bugsnagApiKey, config.apiKey)
-        assertEquals("https://otlp.bugsnag.com/v1/traces", config.endpoint)
+        assertEquals("https://$bugsnagApiKey.otlp.bugsnag.com/v1/traces", config.endpoint)
         assertTrue("expected autoInstrumentAppStarts = true", config.autoInstrumentAppStarts)
         assertEquals(AutoInstrument.FULL, config.autoInstrumentActivities)
         assertEquals(bugsnagReleaseStage, config.releaseStage)


### PR DESCRIPTION
## Goal

Use API key subdomain as default Performance endpoint

## Changeset

Use api key to endpoint when config is loading

## Testing

updated existing test