### PR TITLE
Only consider a frame as slow or frozen if it missed its deadline

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/framerate/FramerateCollector.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/framerate/FramerateCollector.kt
@@ -38,11 +38,13 @@ internal abstract class FramerateCollector(
         // we allow for a 5% overrun when considering "slow" frames
         val adjustedDeadline: Long = (deadline * SLOW_FRAME_ADJUSTMENT).toLong()
 
-        if (totalDuration >= FROZEN_FRAME_TIME) {
-            val frameEndTime = frameTimestampToClockTime(frameStartTime)
-            metricsContainer.addFrozenFrame(frameEndTime - totalDuration, frameEndTime)
-        } else if (totalDuration >= adjustedDeadline) {
-            metricsContainer.slowFrameCount++
+        if (totalDuration >= adjustedDeadline) {
+            if (totalDuration >= FROZEN_FRAME_TIME) {
+                val frameEndTime = frameTimestampToClockTime(frameStartTime)
+                metricsContainer.addFrozenFrame(frameEndTime - totalDuration, frameEndTime)
+            } else {
+                metricsContainer.slowFrameCount++
+            }
         }
 
         metricsContainer.totalFrameCount += dropCountSinceLastInvocation + 1


### PR DESCRIPTION
## Goal
If the OS does not consider a frame to be slow or frozen, we should not report it as such.

## Testing
Relied on existing testing.