### PR TITLE
Compose ViewLoads should appear under Activity/ViewLoads

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,8 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: macos-14
+    env:
+      JAVA_VERSION: '17'
     commands:
       - cd features/fixtures/mazeracer
       - ./gradlew ktlintCheck detekt

--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -32,6 +32,7 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
+    <ID>ReturnCount:SpanImpl.kt$SpanState$fun end(): Boolean</ID>
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>
@@ -51,6 +52,7 @@
     <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
+    <ID>TooGenericExceptionCaught:Timeout.kt$TimeoutExecutorImpl$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:Attributes.kt$Attributes</ID>
@@ -59,6 +61,5 @@
     <ID>TooManyFunctions:JsonTraceWriter.kt$JsonTraceWriter : Closeable</ID>
     <ID>TooManyFunctions:SpanFactory.kt$SpanFactory</ID>
     <ID>TooManyFunctions:SpanTracker.kt$SpanTracker</ID>
-    <ID>TooManyFunctions:Worker.kt$Worker : TimeoutExecutorRunnable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -173,7 +173,6 @@ public object BugsnagPerformance {
 
         // register the Worker with the components that depend on it
         tracer.worker = bsgWorker
-        spanFactory.configureTimeoutExecutor(bsgWorker)
 
         loadModules()
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SendBatchTask.kt
@@ -13,7 +13,7 @@ internal class SendBatchTask(
     override fun execute(): Boolean {
         val nextBatch = tracer.collectNextBatch() ?: return false
         if (nextBatch.isNotEmpty()) {
-            Logger.d("Sending a batch of ${nextBatch.size} spans to $delivery")
+            Logger.d("Sending a batch of ${nextBatch.size} spans from $tracer to $delivery")
         }
         val result = delivery.deliver(nextBatch, resourceAttributes)
         return nextBatch.isNotEmpty() && result is DeliveryResult.Success

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -12,8 +12,7 @@ import com.bugsnag.android.performance.ViewType
 import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
 import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import com.bugsnag.android.performance.internal.processing.AttributeLimits
-import com.bugsnag.android.performance.internal.processing.CollectingTimeoutExecutor
-import com.bugsnag.android.performance.internal.processing.TimeoutExecutor
+import com.bugsnag.android.performance.internal.processing.TimeoutExecutorImpl
 import java.util.UUID
 
 internal typealias AttributeSource = (target: SpanImpl) -> Unit
@@ -24,7 +23,7 @@ public class SpanFactory(
     public val spanAttributeSource: AttributeSource = {},
 ) {
 
-    private var timeoutExecutor: TimeoutExecutor = CollectingTimeoutExecutor()
+    private val timeoutExecutor = TimeoutExecutorImpl()
 
     public var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
 
@@ -39,15 +38,8 @@ public class SpanFactory(
         this.spanProcessor = spanProcessor
         this.attributeLimits = attributeLimits
         this.networkRequestCallback = networkRequestCallback
-    }
 
-    internal fun configureTimeoutExecutor(timeoutExecutor: TimeoutExecutor) {
-        val oldTimeoutExecutor = this.timeoutExecutor
-        this.timeoutExecutor = timeoutExecutor
-
-        // drain any previously collected timeouts to the new executor
-        (oldTimeoutExecutor as? CollectingTimeoutExecutor)
-            ?.drainTo(timeoutExecutor)
+        this.timeoutExecutor.start()
     }
 
     public fun createCustomSpan(

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -16,7 +16,7 @@ import com.bugsnag.android.performance.internal.processing.TimeoutExecutor
 import java.security.SecureRandom
 import java.util.Random
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -52,8 +52,8 @@ public class SpanImpl internal constructor(
 
     internal var isSealed: Boolean = false
 
-    internal val endTime: Long
-        get() = state.endTime
+    internal var endTime: Long = 0L
+        private set
 
     /**
      * Internally SpanImpl objects can be chained together as a fast linked-list structure
@@ -82,7 +82,7 @@ public class SpanImpl internal constructor(
 
     private val state = SpanState()
 
-    private lateinit var conditions: MutableSet<ConditionImpl>
+    private var conditions: MutableSet<ConditionImpl>? = null
 
     init {
         samplingProbability = 1.0
@@ -95,7 +95,9 @@ public class SpanImpl internal constructor(
     }
 
     override fun end(endTime: Long) {
-        if (state.end(endTime)) {
+        if (state.end()) {
+            this.endTime = endTime
+
             startFrameMetrics?.let { framerateMetricsSource?.endMetrics(it, this) }
             if (makeContext) SpanContext.detach(this)
             NotifierIntegration.onSpanEnded(this)
@@ -107,7 +109,7 @@ public class SpanImpl internal constructor(
     }
 
     private fun sendForProcessing() {
-        if (!state.isDiscarded) {
+        if (state.process()) {
             processor.onEnd(this)
         }
     }
@@ -118,12 +120,14 @@ public class SpanImpl internal constructor(
      */
     public fun discard() {
         if (state.discard()) {
-            synchronized(this) {
-                // ensure all of the conditions are released if discarded
-                if (this::conditions.isInitialized) {
-                    conditions.forEach { condition ->
+            if (conditions != null) {
+                synchronized(this) {
+                    // ensure all of the conditions are released if discarded
+                    conditions?.forEach { condition ->
                         condition.cancel()
                     }
+
+                    conditions = null
                 }
             }
 
@@ -134,14 +138,14 @@ public class SpanImpl internal constructor(
 
     public fun block(timeoutMs: Long): Condition? {
         synchronized(this) {
-            if (state.block() || this::conditions.isInitialized) {
-                if (!this::conditions.isInitialized) {
-                    this.conditions = HashSet()
+            if (state.block() || conditions != null) {
+                if (conditions == null) {
+                    conditions = HashSet()
                 }
 
                 val condition = ConditionImpl(this, SystemClock.elapsedRealtime() + timeoutMs)
                 timeoutExecutor.scheduleTimeout(condition)
-                conditions.add(condition)
+                conditions?.add(condition)
                 return condition
             }
         }
@@ -150,13 +154,12 @@ public class SpanImpl internal constructor(
     }
 
     override fun end(): Unit = end(SystemClock.elapsedRealtimeNanos())
+    public fun isSampled(): Boolean = samplingValue <= samplingProbability
 
     override fun isEnded(): Boolean = !state.isOpen
-
-    public fun isSampled(): Boolean = samplingValue <= samplingProbability
     public fun isOpen(): Boolean = state.isOpen
     public fun isBlocked(): Boolean =
-        state.isBlocked || (this::conditions.isInitialized && this.conditions.isNotEmpty())
+        state.isBlocked && (conditions == null || conditions?.isNotEmpty() == true)
 
     internal fun toJson(json: JsonTraceWriter) {
         json.writeSpan(this) {
@@ -167,7 +170,7 @@ public class SpanImpl internal constructor(
             name("startTimeUnixNano")
                 .value(BugsnagClock.elapsedNanosToUnixTime(startTime).toString())
             name("endTimeUnixNano")
-                .value(BugsnagClock.elapsedNanosToUnixTime(state.endTime).toString())
+                .value(BugsnagClock.elapsedNanosToUnixTime(endTime).toString())
 
             if (parentSpanId != 0L) {
                 name("parentSpanId").value(parentSpanId.toHexString())
@@ -205,7 +208,7 @@ public class SpanImpl internal constructor(
             if (state.isOpen) {
                 append(", no endTime")
             } else {
-                append(", endTime=").append(state.endTime)
+                append(", endTime=").append(endTime)
             }
 
             append(')')
@@ -422,7 +425,7 @@ public class SpanImpl internal constructor(
         override fun close(endTime: Long) {
             releaseCondition {
                 if (isUpgraded) {
-                    span.state.endTime = max(endTime, span.state.endTime)
+                    span.endTime = max(endTime, span.endTime)
                 }
             }
         }
@@ -462,12 +465,12 @@ public class SpanImpl internal constructor(
 
                 isValid = false
 
-                span.conditions.remove(this)
+                span.conditions?.remove(this)
                 span.timeoutExecutor.cancelTimeout(this)
 
                 completeRelease()
 
-                if (span.conditions.isEmpty()) {
+                if (span.conditions.isNullOrEmpty() && span.isEnded()) {
                     // the last condition was cancelled, so the Span is now considered ended
                     span.sendForProcessing()
                 }
@@ -481,29 +484,38 @@ public class SpanImpl internal constructor(
 }
 
 /**
- * Encapsulation of the span state field. This is implemented as an `AtomicLong` which can
- * either represent the end time of the span, or its various other states (open, discarded,
- * blocked).
+ * Encapsulation of the span state field. This is implemented as an `AtomicInteger` which can
+ * either represent the various states (open, discarded, blocked) of a span.
  */
 @JvmInline
-internal value class SpanState private constructor(private val state: AtomicLong) {
-    constructor() : this(AtomicLong(NO_END_TIME))
+internal value class SpanState private constructor(private val state: AtomicInteger) {
+    constructor() : this(AtomicInteger(OPEN))
 
-    val isOpen: Boolean get() = state.get().let { it == NO_END_TIME || it == BLOCKED }
-    val isBlocked: Boolean get() = state.get() == BLOCKED
+    val isOpen: Boolean get() = state.get().let { it == OPEN || it == OPEN_BLOCKED }
+    val isBlocked: Boolean get() = state.get().let { it == OPEN_BLOCKED || it == ENDED_BLOCKED }
     val isDiscarded: Boolean get() = state.get() == DISCARDED
-    var endTime: Long
-        get() = max(state.get(), 0L)
-        set(value) {
-            if (value >= 0L) {
-                state.set(value)
-            }
-        }
 
-    fun end(endTime: Long): Boolean {
+    fun process(): Boolean {
         while (true) {
             when (val s = state.get()) {
-                NO_END_TIME, BLOCKED -> if (state.compareAndSet(s, endTime)) {
+                // discarded & already processed spans cannot be processed
+                DISCARDED, PROCESSED -> return false
+                else -> if (state.compareAndSet(s, PROCESSED)) {
+                    return true
+                }
+            }
+        }
+    }
+
+
+    fun end(): Boolean {
+        while (true) {
+            when (val s = state.get()) {
+                OPEN -> if (state.compareAndSet(s, ENDED)) {
+                    return true
+                }
+
+                OPEN_BLOCKED -> if (state.compareAndSet(s, ENDED_BLOCKED)) {
                     return true
                 }
 
@@ -520,7 +532,7 @@ internal value class SpanState private constructor(private val state: AtomicLong
     fun discard(): Boolean {
         while (true) {
             when (val s = state.get()) {
-                NO_END_TIME, BLOCKED -> if (state.compareAndSet(s, DISCARDED)) {
+                OPEN, OPEN_BLOCKED -> if (state.compareAndSet(s, DISCARDED)) {
                     return true
                 }
 
@@ -532,25 +544,28 @@ internal value class SpanState private constructor(private val state: AtomicLong
     fun block(): Boolean {
         while (true) {
             when (val s = state.get()) {
-                NO_END_TIME -> if (state.compareAndSet(s, BLOCKED)) {
+                OPEN -> if (state.compareAndSet(s, OPEN_BLOCKED)) {
                     return true
                 }
 
-                else -> return s == BLOCKED
+                else -> return s == OPEN_BLOCKED
             }
         }
     }
 
     override fun toString(): String = when (state.get()) {
-        NO_END_TIME -> "open"
+        OPEN -> "open"
         DISCARDED -> "discarded"
-        BLOCKED -> "blocked"
+        OPEN_BLOCKED -> "blocked"
         else -> "ended"
     }
 
     companion object {
-        internal const val NO_END_TIME: Long = -1L
-        internal const val DISCARDED: Long = -2L
-        internal const val BLOCKED: Long = -3L
+        internal const val OPEN: Int = -1
+        internal const val DISCARDED: Int = -2
+        internal const val OPEN_BLOCKED: Int = -3
+        internal const val ENDED: Int = -4
+        internal const val ENDED_BLOCKED: Int = -5
+        internal const val PROCESSED = -6
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanTracker.kt
@@ -21,6 +21,8 @@ private const val DEFAULT_SPAN_TRACKER_TABLE_SIZE = 8
  */
 private const val MAX_BINDING_LIST_DEPTH = 3
 
+private const val NO_AUTO_END_TIME = -1L
+
 /**
  * Container for [Span]s that are associated with other objects, which have their own
  * lifecycles (`Activity`, `Fragment`, etc.). SpanTracker encapsulates tracking of the `Span`s
@@ -385,7 +387,7 @@ public class SpanTracker {
         var span: SpanImpl,
     ) : WeakReference<Any>(boundObject, referenceQueue) {
         @JvmField
-        var autoEndTime: Long = SpanState.NO_END_TIME
+        var autoEndTime: Long = NO_AUTO_END_TIME
 
         @JvmField
         var next: SpanBinding? = null
@@ -396,7 +398,7 @@ public class SpanTracker {
                 return false
             }
 
-            if (autoEndTime != SpanState.NO_END_TIME) {
+            if (autoEndTime != NO_AUTO_END_TIME) {
                 span.end(autoEndTime)
             } else {
                 span.end(fallbackEndTime)
@@ -411,7 +413,7 @@ public class SpanTracker {
          * (discarded)[SpanImpl.discard] (depending which is more appropriate).
          */
         fun sweep() {
-            if (autoEndTime == SpanState.NO_END_TIME) {
+            if (autoEndTime == NO_AUTO_END_TIME) {
                 span.discard()
             } else {
                 span.end(autoEndTime)

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/BatchingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/BatchingSpanProcessor.kt
@@ -33,7 +33,7 @@ internal open class BatchingSpanProcessor : SpanProcessor {
      */
     fun takeBatch(): Collection<SpanImpl> {
         val nextBatchChain = batch.getAndSet(null) ?: return emptyList()
-        // unlinkTo separates the chain, allowing any free-floating Spans eligible for GC
+        // unlinkTo separates the chain, making any free-floating Spans eligible for GC
         val batch = nextBatchChain.unlinkTo(ArrayList(currentBatchSize))
         // reduce the tracked batchSize by the number of Spans in this batch
         batchSize.addAndGet(-batch.size)
@@ -61,5 +61,9 @@ internal open class BatchingSpanProcessor : SpanProcessor {
     override fun onEnd(span: Span) {
         if (span !is SpanImpl) return
         addToBatch(span)
+    }
+
+    override fun toString(): String {
+        return "BatchingSpanProcessor[$currentBatchSize]"
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ForwardingSpanProcessor.kt
@@ -37,4 +37,8 @@ internal class ForwardingSpanProcessor : SpanProcessor {
     override fun onEnd(span: Span) {
         backingProcessor.onEnd(span)
     }
+
+    override fun toString(): String {
+        return "ForwardingSpanProcessors[$backingProcessor]"
+    }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
@@ -73,6 +73,6 @@ internal class Tracer(
     }
 
     override fun toString(): String {
-        return "Tracer@${System.identityHashCode(this).toString(36)}[$currentBatchSize]"
+        return "Tracer[$currentBatchSize]"
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Tracer.kt
@@ -2,8 +2,8 @@ package com.bugsnag.android.performance.internal.processing
 
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
-import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.OnSpanEndCallback
+import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.android.performance.internal.ProbabilitySampler
 import com.bugsnag.android.performance.internal.Sampler
@@ -70,5 +70,9 @@ internal class Tracer(
             span.attributes["bugsnag.span.callbacks_duration"] = duration
         }
         return true
+    }
+
+    override fun toString(): String {
+        return "Tracer@${System.identityHashCode(this).toString(36)}[$currentBatchSize]"
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanTest.kt
@@ -64,7 +64,7 @@ class SpanTest {
     @Test
     fun spanAsClosable() {
         val span = createTestSpan().apply { use { sleep(1L) } }
-        assertNotEquals(SpanState.NO_END_TIME, span.endTime)
+        assertNotEquals(SpanState.OPEN, span.endTime)
         assertTrue(span.startTime < span.endTime)
     }
 

--- a/bugsnag-plugin-android-performance-compose/consumer-rules.pro
+++ b/bugsnag-plugin-android-performance-compose/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keepattributes LineNumberTable,SourceFile
+-keep class com.bugsnag.android.performance.compose.ComposeModule

--- a/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/ComposeActivityLifecycleCallbacks.kt
+++ b/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/ComposeActivityLifecycleCallbacks.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.android.performance.compose
+
+import android.app.Activity
+import android.app.Application.ActivityLifecycleCallbacks
+import android.content.Context
+import android.os.Bundle
+import com.bugsnag.android.performance.internal.BugsnagPerformanceInternals
+import com.bugsnag.android.performance.internal.SpanCategory
+import com.bugsnag.android.performance.internal.SpanImpl
+import java.util.Collections
+import java.util.WeakHashMap
+
+public object ComposeActivityLifecycleCallbacks : ActivityLifecycleCallbacks {
+    private const val VIEW_LOAD_BLOCKING_TIMEOUT = 500L
+
+    private val viewLoadConditions =
+        Collections.synchronizedMap(WeakHashMap<Activity, ViewLoad>())
+
+    internal fun createCondition(context: Context): SpanImpl.Condition? {
+        return viewLoadConditions[context]?.createCondition()
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        val contextStack = BugsnagPerformanceInternals.currentSpanContextStack
+        val viewLoadSpan = contextStack.current(SpanCategory.VIEW_LOAD) ?: return
+
+        val blockingCondition = viewLoadSpan.block(VIEW_LOAD_BLOCKING_TIMEOUT)
+            ?: return // if we can't block the span, return it
+
+        viewLoadConditions[activity] = ViewLoad(viewLoadSpan, blockingCondition)
+    }
+
+    override fun onActivityStarted(activity: Activity): Unit = Unit
+    override fun onActivityResumed(activity: Activity): Unit = Unit
+    override fun onActivityPaused(activity: Activity): Unit = Unit
+    override fun onActivityStopped(activity: Activity): Unit = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle): Unit = Unit
+    override fun onActivityDestroyed(activity: Activity): Unit = Unit
+
+    internal data class ViewLoad(
+        val viewLoadSpan: SpanImpl,
+        private var blockingCondition: SpanImpl.Condition?,
+    ) {
+        fun createCondition(): SpanImpl.Condition? {
+            val condition = blockingCondition ?: viewLoadSpan.block(VIEW_LOAD_BLOCKING_TIMEOUT)
+            blockingCondition = null
+            return condition
+        }
+    }
+}

--- a/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/ComposeModule.kt
+++ b/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/ComposeModule.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.performance.compose
+
+import com.bugsnag.android.performance.internal.InstrumentedAppState
+import com.bugsnag.android.performance.internal.Module
+
+public class ComposeModule : Module {
+    private lateinit var instrumentedAppState: InstrumentedAppState
+
+    override fun load(instrumentedAppState: InstrumentedAppState) {
+        this.instrumentedAppState = instrumentedAppState
+        this.instrumentedAppState.app.registerActivityLifecycleCallbacks(
+            ComposeActivityLifecycleCallbacks,
+        )
+    }
+
+    override fun unload() {
+        instrumentedAppState.app.unregisterActivityLifecycleCallbacks(
+            ComposeActivityLifecycleCallbacks,
+        )
+    }
+}

--- a/features/fixtures/mazeracer/app/build.gradle
+++ b/features/fixtures/mazeracer/app/build.gradle
@@ -45,6 +45,12 @@ android {
     lintOptions {
         abortOnError false
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.13"
+    }
 }
 
 dependencies {
@@ -63,9 +69,8 @@ dependencies {
     implementation 'com.bugsnag:bugsnag-android-performance-coroutines:9.9.9'
 
     //compose
-    def composeBom = platform('androidx.compose:compose-bom:2024.05.00')
+    def composeBom = platform('androidx.compose:compose-bom:2024.09.03')
     implementation composeBom
-    androidTestImplementation composeBom
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.material:material-icons-core'

--- a/features/fixtures/mazeracer/app/build.gradle
+++ b/features/fixtures/mazeracer/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.bugsnag.mazeracer'
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.bugsnag.mazeracer"
         minSdk 21
-        targetSdk 32
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -58,8 +58,18 @@ dependencies {
 
     implementation 'com.bugsnag:bugsnag-android-performance:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-okhttp:9.9.9'
+    implementation 'com.bugsnag:bugsnag-android-performance-compose:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-appcompat:9.9.9'
     implementation 'com.bugsnag:bugsnag-android-performance-coroutines:9.9.9'
+
+    //compose
+    def composeBom = platform('androidx.compose:compose-bom:2024.05.00')
+    implementation composeBom
+    androidTestImplementation composeBom
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material:material-icons-core'
+    implementation 'androidx.activity:activity-compose:1.9.2'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -4,7 +4,7 @@
   <CurrentIssues>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$100</ID>
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
-    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$1000L</ID>
+    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$5000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$6</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100</ID>

--- a/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazeracer/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity android:name=".MainActivity" />
 
         <activity android:name=".ActivityViewLoadActivity" />
+        <activity android:name=".ComposeViewLoadActivity" />
         <activity android:name=".NestedSpansActivity" />
         <activity android:name=".AnimatedActivity" />
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
@@ -19,9 +19,10 @@ class ActivityViewLoadActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())
 
     private val autoInstrument: AutoInstrument
-        get() = intent.getStringExtra(AUTO_INSTRUMENT_EXTRA)
-            ?.let { AutoInstrument.valueOf(it) }
-            ?: AutoInstrument.OFF
+        get() =
+            intent.getStringExtra(AUTO_INSTRUMENT_EXTRA)
+                ?.let { AutoInstrument.valueOf(it) }
+                ?: AutoInstrument.OFF
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (autoInstrument == AutoInstrument.OFF) {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ActivityViewLoadActivity.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 
-private const val ON_SCREEN_TIME_MS = 300L
+private const val ON_SCREEN_TIME_MS = 1000L
 
 class ActivityViewLoadActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/AnimatedActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/AnimatedActivity.kt
@@ -19,12 +19,13 @@ class AnimatedActivity : AppCompatActivity(), CoroutineScope by MainScope() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        span = BugsnagPerformance.startSpan(
-            "Slow Animation",
-            SpanOptions.within(null)
-                .makeCurrentContext(true)
-                .setFirstClass(true),
-        )
+        span =
+            BugsnagPerformance.startSpan(
+                "Slow Animation",
+                SpanOptions.within(null)
+                    .makeCurrentContext(true)
+                    .setFirstClass(true),
+            )
 
         setContentView(
             BadPainterView(this) {
@@ -44,7 +45,6 @@ class AnimatedActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         private val onTestComplete: () -> Unit,
     ) : View(context),
         Runnable {
-
         init {
             layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
         }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.Text
 import com.bugsnag.android.performance.compose.MeasuredComposable
 
-private const val ON_SCREEN_TIME_MS = 300L
+private const val ON_SCREEN_TIME_MS = 1000L
 
 class ComposeViewLoadActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
@@ -35,7 +35,7 @@ class ComposeViewLoadActivity : AppCompatActivity() {
 
     companion object {
         fun intent(context: Context): Intent {
-            return Intent(context, ActivityViewLoadActivity::class.java)
+            return Intent(context, ComposeViewLoadActivity::class.java)
         }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/ComposeViewLoadActivity.kt
@@ -1,0 +1,41 @@
+package com.bugsnag.mazeracer
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material3.Text
+import com.bugsnag.android.performance.compose.MeasuredComposable
+
+private const val ON_SCREEN_TIME_MS = 300L
+
+class ComposeViewLoadActivity : AppCompatActivity() {
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MeasuredComposable("Composable") {
+                Text("This is a composable view")
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        handler.postDelayed(
+            { finish() },
+            ON_SCREEN_TIME_MS,
+        )
+    }
+
+    companion object {
+        fun intent(context: Context): Intent {
+            return Intent(context, ActivityViewLoadActivity::class.java)
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/DebugLogger.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/DebugLogger.kt
@@ -4,14 +4,16 @@ import android.util.Log
 import com.bugsnag.android.performance.Logger
 
 object DebugLogger : Logger {
-
     private const val TAG = "Bugsnag"
 
     override fun e(msg: String) {
         Log.e(TAG, msg)
     }
 
-    override fun e(msg: String, throwable: Throwable) {
+    override fun e(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.e(TAG, msg, throwable)
     }
 
@@ -19,7 +21,10 @@ object DebugLogger : Logger {
         Log.w(TAG, msg)
     }
 
-    override fun w(msg: String, throwable: Throwable) {
+    override fun w(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.w(TAG, msg, throwable)
     }
 
@@ -27,7 +32,10 @@ object DebugLogger : Logger {
         Log.i(TAG, msg)
     }
 
-    override fun i(msg: String, throwable: Throwable) {
+    override fun i(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.i(TAG, msg, throwable)
     }
 
@@ -35,7 +43,10 @@ object DebugLogger : Logger {
         Log.d(TAG, msg)
     }
 
-    override fun d(msg: String, throwable: Throwable) {
+    override fun d(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.d(TAG, msg, throwable)
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
@@ -7,7 +7,10 @@ fun log(msg: String) {
     Log.d("BugsnagMazeRacer", msg)
 }
 
-fun log(msg: String, e: Exception) {
+fun log(
+    msg: String,
+    e: Exception,
+) {
     Log.e("BugsnagMazeRacer", msg, e)
 }
 
@@ -18,7 +21,10 @@ object BugsnagLogger : Logger {
         Log.d(TAG, msg)
     }
 
-    override fun d(msg: String, throwable: Throwable) {
+    override fun d(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.d(TAG, msg, throwable)
     }
 
@@ -26,7 +32,10 @@ object BugsnagLogger : Logger {
         Log.i(TAG, msg)
     }
 
-    override fun i(msg: String, throwable: Throwable) {
+    override fun i(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.i(TAG, msg, throwable)
     }
 
@@ -34,7 +43,10 @@ object BugsnagLogger : Logger {
         Log.w(TAG, msg)
     }
 
-    override fun w(msg: String, throwable: Throwable) {
+    override fun w(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.w(TAG, msg, throwable)
     }
 
@@ -42,7 +54,10 @@ object BugsnagLogger : Logger {
         Log.e(TAG, msg)
     }
 
-    override fun e(msg: String, throwable: Throwable) {
+    override fun e(
+        msg: String,
+        throwable: Throwable,
+    ) {
         Log.e(TAG, msg, throwable)
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -81,7 +81,11 @@ class MainActivity : AppCompatActivity() {
         log("MainActivity.onResume complete")
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    override fun onActivityResult(
+        requestCode: Int,
+        resultCode: Int,
+        data: Intent?,
+    ) {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == REQUEST_CODE_FINISH_ON_RETURN) {
@@ -138,19 +142,24 @@ class MainActivity : AppCompatActivity() {
     }
 
     // As per JSONObject.getString but returns and empty string rather than throwing if not present
-    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+    private fun getStringSafely(
+        jsonObject: JSONObject?,
+        key: String,
+    ): String {
         return jsonObject?.optString(key) ?: ""
     }
 
     private fun startBugsnag() {
-        val config = Configuration.load(this).apply {
-            endpoints = EndpointConfiguration(
-                notify = "http://$mazeAddress/notify",
-                sessions = "http://$mazeAddress/session",
-            )
+        val config =
+            Configuration.load(this).apply {
+                endpoints =
+                    EndpointConfiguration(
+                        notify = "http://$mazeAddress/notify",
+                        sessions = "http://$mazeAddress/session",
+                    )
 
-            logger = BugsnagLogger
-        }
+                logger = BugsnagLogger
+            }
         Bugsnag.start(this, config)
     }
 
@@ -286,7 +295,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun prepareConfig(apiKey: String, endpoint: String): PerformanceConfiguration {
+    private fun prepareConfig(
+        apiKey: String,
+        endpoint: String,
+    ): PerformanceConfiguration {
         return PerformanceConfiguration.load(applicationContext, apiKey).also { config ->
             config.endpoint = endpoint
             config.autoInstrumentAppStarts = false
@@ -304,10 +316,11 @@ class MainActivity : AppCompatActivity() {
         val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
 
         val manualMode = apiKeyField.text.isNotEmpty()
-        val apiKey = when {
-            manualMode -> apiKeyField.text.toString()
-            else -> "a35a2a72bd230ac0aa0f52715bbdc6aa"
-        }
+        val apiKey =
+            when {
+                manualMode -> apiKeyField.text.toString()
+                else -> "a35a2a72bd230ac0aa0f52715bbdc6aa"
+            }
 
         if (manualMode) {
             log("Running in manual mode with API key: $apiKey")

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
@@ -12,7 +12,10 @@ class MazeRacerAlarmReceiver : BroadcastReceiver() {
         Log.i("MazeRacer", "MazeRacerAlarmReceiver init")
     }
 
-    override fun onReceive(context: Context?, intent: Intent?) {
+    override fun onReceive(
+        context: Context?,
+        intent: Intent?,
+    ) {
         Log.i("MazeRacer", "MazeRacerAlarmReceiver.onReceive()")
         BugsnagPerformance.startSpan("AlarmReceiver", SpanOptions.setFirstClass(true)).use {
             Thread.sleep(250L)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.withContext
 
 const val DELAY_TIME = 50L
 
+private const val RESUME_CLOSE_TIME = 700L
+
 class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerformanceScope() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,7 +59,9 @@ class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerfor
             // end the custom span
             customRootSpan.end()
 
-            // finish after we end the last span
+            // give any blocked span conditions enough time to cancel
+            delay(RESUME_CLOSE_TIME)
+            // finish - flushing a single batch
             finish()
         }
     }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/NestedSpansActivity.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.withContext
 const val DELAY_TIME = 50L
 
 class NestedSpansActivity : AppCompatActivity(), CoroutineScope by BugsnagPerformanceScope() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_view_load)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
@@ -11,7 +11,6 @@ abstract class Scenario(
     val config: PerformanceConfiguration,
     val scenarioMetadata: String,
 ) {
-
     protected val mainHandler = Handler(Looper.getMainLooper())
     protected val application get() = context.applicationContext as Application
 
@@ -51,10 +50,11 @@ abstract class Scenario(
                 log("Class.forName(\"com.bugsnag.mazeracer.scenarios.$scenarioName\")")
                 val scenarioClass = Class.forName("com.bugsnag.mazeracer.scenarios.$scenarioName")
                 log("$scenarioName.getConstructor")
-                val constructor = scenarioClass.getConstructor(
-                    PerformanceConfiguration::class.java,
-                    String::class.java,
-                )
+                val constructor =
+                    scenarioClass.getConstructor(
+                        PerformanceConfiguration::class.java,
+                        String::class.java,
+                    )
 
                 log("$scenarioName.newInstance($config, $scenarioMetadata)")
                 return constructor.newInstance(config, scenarioMetadata) as Scenario

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/StartupConfiguration.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/StartupConfiguration.kt
@@ -27,15 +27,17 @@ fun Context.readStartupConfig(): PerformanceConfiguration? {
             return null
         }
 
-        val config = PerformanceConfiguration
-            .load(this, prefs.getString("apiKey", "a35a2a72bd230ac0aa0f52715bbdc6aa"))
-            .apply {
-                endpoint = prefs.getString("endpoint", null)!!
-                autoInstrumentAppStarts = prefs.getBoolean("autoInstrumentAppStarts", false)
-                autoInstrumentActivities = AutoInstrument.valueOf(
-                    prefs.getString("autoInstrumentActivities", "OFF")!!
-                )
-            }
+        val config =
+            PerformanceConfiguration
+                .load(this, prefs.getString("apiKey", "a35a2a72bd230ac0aa0f52715bbdc6aa"))
+                .apply {
+                    endpoint = prefs.getString("endpoint", null)!!
+                    autoInstrumentAppStarts = prefs.getBoolean("autoInstrumentAppStarts", false)
+                    autoInstrumentActivities =
+                        AutoInstrument.valueOf(
+                            prefs.getString("autoInstrumentActivities", "OFF")!!,
+                        )
+                }
 
         log("got some config Dave: $config")
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ActivityLoadInstrumentationScenario.kt
@@ -13,8 +13,8 @@ class ActivityLoadInstrumentationScenario(
     init {
         config.autoInstrumentActivities =
             scenarioMetadata.takeIf { it.isNotBlank() }
-            ?.let { AutoInstrument.valueOf(it) }
-            ?: AutoInstrument.FULL
+                ?.let { AutoInstrument.valueOf(it) }
+                ?: AutoInstrument.FULL
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppBackgroundedScenario.kt
@@ -10,9 +10,8 @@ import com.bugsnag.mazeracer.Scenario
 
 class AppBackgroundedScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
     private val handler = Handler(Looper.getMainLooper())
 
     init {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
@@ -12,8 +12,7 @@ class AppStartScenario(
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
-        InternalDebug.spanBatchSizeSendTriggerPoint = 6
-        InternalDebug.workerSleepMs = 1000L
+        InternalDebug.workerSleepMs = 5000L
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
@@ -16,7 +16,6 @@ class BackgroundAppStartScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
     override fun startScenario() {
         config.autoInstrumentAppStarts = true
         config.autoInstrumentActivities = AutoInstrument.FULL

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundSpanScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundSpanScenario.kt
@@ -34,7 +34,10 @@ class BackgroundSpanScenario(
                     )
                 }
 
-                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                override fun onActivityCreated(
+                    activity: Activity,
+                    savedInstanceState: Bundle?,
+                ) {
                     Log.i("BackgroundSpan", "onActivityCreated($activity)")
                 }
 
@@ -50,7 +53,10 @@ class BackgroundSpanScenario(
                     Log.i("BackgroundSpan", "onActivityPaused($activity)")
                 }
 
-                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+                override fun onActivitySaveInstanceState(
+                    activity: Activity,
+                    outState: Bundle,
+                ) {
                     Log.i("BackgroundSpan", "onActivitySaveInstanceState($activity)")
                 }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BatchTimeoutScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BatchTimeoutScenario.kt
@@ -8,7 +8,7 @@ import com.bugsnag.mazeracer.Scenario
 
 class BatchTimeoutScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 100

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ComposeLoadInstrumentationScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ComposeLoadInstrumentationScenario.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.mazeracer.scenarios
 
+import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.mazeracer.ComposeViewLoadActivity
@@ -9,6 +10,10 @@ class ComposeLoadInstrumentationScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
+    init {
+        config.autoInstrumentActivities = AutoInstrument.FULL
+    }
+
     override fun startScenario() {
         BugsnagPerformance.start(config)
         startActivityAndFinish(ComposeViewLoadActivity.intent(context))

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ComposeLoadInstrumentationScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/ComposeLoadInstrumentationScenario.kt
@@ -1,0 +1,16 @@
+package com.bugsnag.mazeracer.scenarios
+
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.mazeracer.ComposeViewLoadActivity
+import com.bugsnag.mazeracer.Scenario
+
+class ComposeLoadInstrumentationScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    override fun startScenario() {
+        BugsnagPerformance.start(config)
+        startActivityAndFinish(ComposeViewLoadActivity.intent(context))
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/CorrelatedErrorScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/CorrelatedErrorScenario.kt
@@ -10,7 +10,6 @@ class CorrelatedErrorScenario(
     config: PerformanceConfiguration,
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
     init {
         InternalDebug.spanBatchSizeSendTriggerPoint = 1
         BugsnagPerformance.start(config)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/FixedSamplingProbabilityScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/FixedSamplingProbabilityScenario.kt
@@ -8,9 +8,8 @@ import com.bugsnag.mazeracer.Scenario
 
 class FixedSamplingProbabilityScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
     init {
         config.samplingProbability = scenarioMetadata.toDoubleOrNull()
         InternalDebug.spanBatchSizeSendTriggerPoint = 1

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/FrameMetricsScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/FrameMetricsScenario.kt
@@ -8,7 +8,6 @@ import com.bugsnag.mazeracer.Scenario
 
 class FrameMetricsScenario(config: PerformanceConfiguration, scenarioMetadata: String) :
     Scenario(config, scenarioMetadata) {
-
     init {
         if (scenarioMetadata.contains("disableInstrumentation")) {
             config.autoInstrumentRendering = false

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/GenerateSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/GenerateSpansScenario.kt
@@ -8,9 +8,8 @@ import com.bugsnag.mazeracer.Scenario
 
 class GenerateSpansScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
-
     var spanId = 1
 
     init {

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/NestedSpansScenario.kt
@@ -9,7 +9,7 @@ import com.bugsnag.mazeracer.Scenario
 
 class NestedSpansScenario(
     config: PerformanceConfiguration,
-    scenarioMetadata: String
+    scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     init {
         config.autoInstrumentAppStarts = true

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpAutoInstrumentNetworkCallbackScenario.kt
@@ -15,24 +15,26 @@ class OkhttpAutoInstrumentNetworkCallbackScenario(
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     override fun startScenario() {
-        config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
-            val url = reqInfo.url ?: return@NetworkRequestInstrumentationCallback
-            if (url.startsWith("http://bs-local.com")) {
-                reqInfo.url = null
-            } else if (url == "https://google.com/") {
-                reqInfo.url = null
-            } else if (url.endsWith("/changeme")) {
-                reqInfo.url = url.dropLast(9) + "/changed"
+        config.networkRequestCallback =
+            NetworkRequestInstrumentationCallback { reqInfo ->
+                val url = reqInfo.url ?: return@NetworkRequestInstrumentationCallback
+                if (url.startsWith("http://bs-local.com")) {
+                    reqInfo.url = null
+                } else if (url == "https://google.com/") {
+                    reqInfo.url = null
+                } else if (url.endsWith("/changeme")) {
+                    reqInfo.url = url.dropLast(9) + "/changed"
+                }
             }
-        }
 
         BugsnagPerformance.start(config)
 
         thread {
             runAndFlush {
-                val client = OkHttpClient.Builder()
-                    .eventListenerFactory(BugsnagPerformanceOkhttp)
-                    .build()
+                val client =
+                    OkHttpClient.Builder()
+                        .eventListenerFactory(BugsnagPerformanceOkhttp)
+                        .build()
 
                 makeCall(client, "https://bugsnag.com/")
                 makeCall(client, "https://bugsnag.com/changeme")
@@ -41,7 +43,10 @@ class OkhttpAutoInstrumentNetworkCallbackScenario(
         }
     }
 
-    fun makeCall(client: OkHttpClient, url: String) {
+    fun makeCall(
+        client: OkHttpClient,
+        url: String,
+    ) {
         val request = Request.Builder().url(url).build()
 
         client.newCall(request).execute().use { response ->

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpManualNetworkCallbackScenario.kt
@@ -15,24 +15,26 @@ class OkhttpManualNetworkCallbackScenario(
     scenarioMetadata: String,
 ) : Scenario(config, scenarioMetadata) {
     override fun startScenario() {
-        config.networkRequestCallback = NetworkRequestInstrumentationCallback { reqInfo ->
-            reqInfo.url?.let { url ->
-                if (url.startsWith("http://bs-local.com")) {
-                    reqInfo.url = null
-                } else if (url == "https://google.com/") {
-                    reqInfo.url = null
-                } else if (url.endsWith("/changeme")) {
-                    reqInfo.url = url.dropLast(9) + "/changed"
+        config.networkRequestCallback =
+            NetworkRequestInstrumentationCallback { reqInfo ->
+                reqInfo.url?.let { url ->
+                    if (url.startsWith("http://bs-local.com")) {
+                        reqInfo.url = null
+                    } else if (url == "https://google.com/") {
+                        reqInfo.url = null
+                    } else if (url.endsWith("/changeme")) {
+                        reqInfo.url = url.dropLast(9) + "/changed"
+                    }
                 }
             }
-        }
 
         BugsnagPerformance.start(config)
 
         thread {
             runAndFlush {
-                val client = OkHttpClient.Builder()
-                    .build()
+                val client =
+                    OkHttpClient.Builder()
+                        .build()
 
                 makeCall(client, "https://bugsnag.com/")
                 makeCall(client, "https://bugsnag.com/changeme")
@@ -41,7 +43,10 @@ class OkhttpManualNetworkCallbackScenario(
         }
     }
 
-    fun makeCall(client: OkHttpClient, url: String) {
+    fun makeCall(
+        client: OkHttpClient,
+        url: String,
+    ) {
         val request = Request.Builder().url(url).build()
 
         val span = BugsnagPerformance.startNetworkRequestSpan(URL(url), "GET")

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpSpanScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/OkhttpSpanScenario.kt
@@ -18,15 +18,17 @@ class OkhttpSpanScenario(
 
         thread {
             runAndFlush {
-                val client = OkHttpClient.Builder()
-                    .eventListenerFactory(BugsnagPerformanceOkhttp.EventListenerFactory)
-                    .build()
-                val request = Request.Builder()
-                    .url(
-                        scenarioMetadata.takeUnless { it.isBlank() }
-                            ?: "https://google.com/?test=true",
-                    )
-                    .build()
+                val client =
+                    OkHttpClient.Builder()
+                        .eventListenerFactory(BugsnagPerformanceOkhttp.EventListenerFactory)
+                        .build()
+                val request =
+                    Request.Builder()
+                        .url(
+                            scenarioMetadata.takeUnless { it.isBlank() }
+                                ?: "https://google.com/?test=true",
+                        )
+                        .build()
 
                 client.newCall(request).execute().use { response ->
                     // Consume and discard the response body.

--- a/features/fixtures/mazeracer/build.gradle
+++ b/features/fixtures/mazeracer/build.gradle
@@ -1,8 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
-    id 'org.jlleitschuh.gradle.ktlint' version '10.1.0' apply false
+    id 'com.android.application' version '8.2.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+    id 'org.jlleitschuh.gradle.ktlint' version '12.1.1' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.17.1' apply false
 }

--- a/features/fixtures/mazeracer/build.gradle
+++ b/features/fixtures/mazeracer/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
     id 'org.jlleitschuh.gradle.ktlint' version '12.1.1' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.17.1' apply false
 }

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -245,3 +245,13 @@ Feature: Automatic creation of spans
       | bugsnag.phase         | stringValue | ActivityResume       |
       | bugsnag.view.name     | stringValue | SplashScreenActivity |
 
+  Scenario: Activity ViewLoad spans contain Compose ViewLoad spans
+    Given I run "ComposeLoadInstrumentationScenario"
+    And I wait to receive a trace
+    * a span named "[ViewLoad/Compose]Composable" contains the attributes:
+      | attribute             | type        | value                |
+      | bugsnag.span.category | stringValue | view_load            |
+      | bugsnag.view.type     | stringValue | compose              |
+      | bugsnag.view.name     | stringValue | SplashScreenActivity |
+    * the "[ViewLoad/Activity]ComposeLoadInstrumentationScenario" span field "spanId" is stored as the value "activity_load_span_id"
+    * the "[ViewLoad/Compose]Composable" span field "parentSpanId" equals the stored value "activity_load_span_id"

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -249,9 +249,9 @@ Feature: Automatic creation of spans
     Given I run "ComposeLoadInstrumentationScenario"
     And I wait to receive a trace
     * a span named "[ViewLoad/Compose]Composable" contains the attributes:
-      | attribute             | type        | value                |
-      | bugsnag.span.category | stringValue | view_load            |
-      | bugsnag.view.type     | stringValue | compose              |
-      | bugsnag.view.name     | stringValue | SplashScreenActivity |
-    * the "[ViewLoad/Activity]ComposeLoadInstrumentationScenario" span field "spanId" is stored as the value "activity_load_span_id"
+      | attribute             | type        | value      |
+      | bugsnag.span.category | stringValue | view_load  |
+      | bugsnag.view.type     | stringValue | compose    |
+      | bugsnag.view.name     | stringValue | Composable |
+    * the "[ViewLoad/Activity]ComposeViewLoadActivity" span field "spanId" is stored as the value "activity_load_span_id"
     * the "[ViewLoad/Compose]Composable" span field "parentSpanId" equals the stored value "activity_load_span_id"


### PR DESCRIPTION
## Goal
When a Compose is used as the content of an Activity any `MeasuredComposable` spans should appear as children of the `Activity/ViewLoad` span.

## Changeset
The `Activity` ViewLoad is kept open with a short timeout (using a `Condition`) to allow `MeasuredComposable` spans to be opened via `Condition.upgrade`.

## Testing
Manually tested and a new end to end test.