### PR TITLE
Expose finalised config via `InstrumentedAppState`

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -39,6 +39,10 @@ public class InstrumentedAppState {
 
     private var framerateMetricsSource: FramerateMetricsSource? = null
 
+    @get:JvmName("getConfig\$internal")
+    internal var config: ImmutableConfig? = null
+        private set
+
     internal fun attach(application: Application) {
         if (this::app.isInitialized) {
             return
@@ -61,6 +65,7 @@ public class InstrumentedAppState {
     }
 
     internal fun configure(configuration: ImmutableConfig): Tracer {
+        config = configuration
         attach(configuration.application)
 
         val bootstrapSpanProcessor = spanProcessor


### PR DESCRIPTION
## Goal

Store and expose the finalised `ImmutableConfig` so that it is accessible from Java. This is not used anywhere internally but is required for the upcoming React Native integration

## Design

Added a new `config` property in `InstrumentedAppState` - this will return `null` if `InstrumentedAppState.configure` (and therefore `BugsnagPerformance.start`) has not been called.

## Testing

This isn't used anywhere yet, but tested manually from a React Native Turbo module 