### PR TITLE
Only report warm appstarts when the app was properly backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Fixed Warm AppStarts being over reported due to app-backgrounding not being fully reported internally
+  [#299](https://github.com/bugsnag/bugsnag-android-performance/pull/299)
+
 ## 1.9.0 (2024-09-30)
 
 ### Changes

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -25,7 +25,6 @@ import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import com.bugsnag.android.performance.internal.isInForeground
 import com.bugsnag.android.performance.internal.processing.ImmutableConfig
 import java.net.URL
-import java.util.ServiceLoader
 
 /**
  * Primary access to the Bugsnag Performance SDK.
@@ -97,7 +96,7 @@ public object BugsnagPerformance {
                 instrumentedAppState.onBugsnagPerformanceStart()
             }
         } else {
-            instrumentedAppState.startupTracker.discardAppStart()
+            instrumentedAppState.startupTracker.disableAppStartTracking()
         }
 
         val application = configuration.application

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -57,6 +57,8 @@ public class InstrumentedAppState {
             defaultAttributeSource.update {
                 it.copy(isInForeground = inForeground)
             }
+
+            startupTracker.isInBackground = !inForeground
         }
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/instrumentation/ActivityLifecycleInstrumentation.kt
@@ -213,5 +213,4 @@ internal class ActivityLifecycleInstrumentation(
     private fun endViewLoadPhase(activity: Activity, phase: ViewLoadPhase) {
         spanTracker.endSpan(activity, phase)
     }
-
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartDisabledScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartDisabledScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.mazeracer.scenarios
+
+import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.PerformanceConfiguration
+import com.bugsnag.mazeracer.Scenario
+import com.bugsnag.mazeracer.saveStartupConfig
+import kotlin.system.exitProcess
+
+private const val PRE_EXIT_DELAY = 500L
+
+class AppStartDisabledScenario(
+    config: PerformanceConfiguration,
+    scenarioMetadata: String,
+) : Scenario(config, scenarioMetadata) {
+    override fun startScenario() {
+        config.autoInstrumentAppStarts = false
+        config.autoInstrumentActivities = AutoInstrument.FULL
+        context.saveStartupConfig(config)
+
+        Thread.sleep(PRE_EXIT_DELAY)
+        // quit the app
+        exitProcess(0)
+    }
+}

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -101,6 +101,21 @@ Feature: Automatic creation of spans
       | bugsnag.view.type     | stringValue | activity     |
       | bugsnag.view.name     | stringValue | MainActivity |
 
+  Scenario: AppStart instrumentation disabled with ViewLoad enabled
+    Given I run "AppStartDisabledScenario"
+    Then I relaunch the app after shutdown
+    * I load scenario "AppStartDisabledScenario"
+    And I wait to receive a trace
+    * I received no span named "[AppStart/AndroidCold]"
+    * I received no span named "[AppStart/AndroidWarm]"
+    * I received no span named "[AppStart/AndroidHot]"
+    * I received no span named "[AppStartPhase/Framework]"
+    * a span named "[ViewLoad/Activity]MainActivity" contains the attributes:
+      | attribute             | type        | value        |
+      | bugsnag.span.category | stringValue | view_load    |
+      | bugsnag.view.type     | stringValue | activity     |
+      | bugsnag.view.name     | stringValue | MainActivity |
+
   @skip_below_android_10
   Scenario: Activity load breakdown with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"

--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -42,6 +42,13 @@ When('I invoke {string} for {string}') do |function, metadata|
   execute_command 'invoke', function, metadata
 end
 
+Then('I received no span named {string}') do |span_name|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  named_spans = spans.select { |s| s['name'].eql?(span_name) }
+
+  Maze.check.equal(0, named_spans.size, "found #{named_spans.size} spans named #{span_name}")
+end
+
 Then("the {string} span field {string} is stored as the value {string}") do |span_name, field, key|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   named_spans = spans.select { |s| s['name'].eql?(span_name) }


### PR DESCRIPTION
## Goal
Avoid over-reporting warm starts.

## Design
Correctly report the backgrounding of the app to the `AppStartTracker`

## Testing
Manually tested and a new end to end test to check the behavior when `autoInstrumentAppStarts = false`