### PR TITLE
Fix Untagged socket violation in HttpDelivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Untagged socket violation when StrictMode is enabled https://github.com/bugsnag/bugsnag-android-performance/issues/297
+  [#306](https://github.com/bugsnag/bugsnag-android-performance/pull/306)
+
 ## 1.9.1 (2024-10-30)
 
 ### Bug fixes

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/HttpDelivery.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.performance.internal
 
+import android.net.TrafficStats
 import androidx.annotation.VisibleForTesting
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.internal.processing.AttributeLimits
@@ -47,6 +48,7 @@ internal open class HttpDelivery(
             return DeliveryResult.Failed(tracePayload, true)
         }
 
+        TrafficStats.setThreadStatsTag(1)
         return try {
             val connection = openConnection()
             with(connection) {
@@ -69,6 +71,8 @@ internal open class HttpDelivery(
             DeliveryResult.Failed(tracePayload, true)
         } catch (e: Exception) {
             DeliveryResult.Failed(tracePayload, false)
+        } finally {
+            TrafficStats.clearThreadStatsTag()
         }
     }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
@@ -2,6 +2,7 @@ package com.bugsnag.mazeracer
 
 import android.app.Application
 import android.content.Context
+import android.os.StrictMode
 import android.util.Log
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.internal.InternalDebug
@@ -23,6 +24,14 @@ class MazeRacerApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectNetwork()
+                .penaltyLog()
+                .penaltyDeath()
+                .build(),
+        )
 
         // if there is stored "startup" config then we start BugsnagPerformance before the scenario
         // this is used to test things like app-start instrumentation


### PR DESCRIPTION
## Goal
Fix https://github.com/bugsnag/bugsnag-android-performance/issues/297 by tagging the socket in the same way as we do in the notifier.

## Testing
Modified the end to end test fixture to treat any networking StrictMode violation as fatal. A later PR will change to `detectAll` to cover all other StrictMode violations.