### PR TITLE
Strict mode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## TDB
+## TBD
 
 ### Bug fixes
 
 * Move remaining I/O to the worker thread in `BugsnagPerformance.start` - avoiding StrictMode violations
-  []()
+  [#310](https://github.com/bugsnag/bugsnag-android-performance/pull/310)
 
 ## 1.10.0 (2024-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TDB
+
+### Bug fixes
+
+* Move remaining I/O to the worker thread in `BugsnagPerformance.start` - avoiding StrictMode violations
+  []()
+
 ## 1.10.0 (2024-11-14)
 
 ### Bug fixes

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/WorkerTest.kt
@@ -22,7 +22,7 @@ class WorkerTest {
     fun testWaitAndWake() {
         val count1 = CountingTask(1)
         val count2 = CountingTask(5)
-        val worker = Worker(emptyList(), listOf(count1, count2))
+        val worker = Worker { listOf(count1, count2) }
 
         worker.start()
         try {
@@ -40,7 +40,7 @@ class WorkerTest {
     fun testWaitAndAwake() {
         val count1 = CountingTask(1)
         val count2 = CountingTask(5)
-        val worker = Worker(emptyList(), listOf(count1, count2))
+        val worker = Worker { listOf(count1, count2) }
 
         worker.start()
         try {
@@ -69,8 +69,7 @@ class WorkerTest {
     @Test
     fun testExceptionHandling() {
         val latch = CountDownLatch(1)
-        val worker = Worker(
-            emptyList(),
+        val worker = Worker {
             listOf(
                 object : Task {
                     override fun execute(): Boolean {
@@ -83,8 +82,8 @@ class WorkerTest {
                         return false
                     }
                 },
-            ),
-        )
+            )
+        }
 
         // this test succeeds if the latch releases, as it means that the exception in the first
         // task was correctly handled without blocking the second task

--- a/features/fixtures/mazeracer/app/detekt-baseline.xml
+++ b/features/fixtures/mazeracer/app/detekt-baseline.xml
@@ -6,7 +6,6 @@
     <ID>MagicNumber:AppBackgroundedScenario.kt$AppBackgroundedScenario$120_000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$5000L</ID>
     <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$500L</ID>
-    <ID>MagicNumber:AppStartScenario.kt$AppStartScenario$6</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$1000L</ID>
     <ID>MagicNumber:BackgroundAppStartScenario.kt$BackgroundAppStartScenario$100L</ID>

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Log.kt
@@ -9,7 +9,7 @@ fun log(msg: String) {
 
 fun log(
     msg: String,
-    e: Exception,
+    e: Throwable,
 ) {
     Log.e("BugsnagMazeRacer", msg, e)
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -11,11 +11,16 @@ import android.view.Window
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.withResumed
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.PerformanceConfiguration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.File
 import java.io.IOException
@@ -51,35 +56,40 @@ class MainActivity : AppCompatActivity() {
             sendBroadcast(closeDialog)
         }
 
-        prefs = getPreferences(Context.MODE_PRIVATE)
-
         log("Set up clearUserData click handler")
         val clearUserData = findViewById<Button>(R.id.clearUserData)
         clearUserData.setOnClickListener {
-            clearStoredApiKey()
-            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-            apiKeyField.text.clear()
-            log("Cleared user data")
+            lifecycle.coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    clearStoredApiKey()
+                }
+
+                val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
+                apiKeyField.text.clear()
+                log("Cleared user data")
+            }
         }
 
-        if (apiKeyStored()) {
-            log("Using stored API key")
-            val apiKey = getStoredApiKey()
-            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-            apiKeyField.text.clear()
-            apiKeyField.text.append(apiKey)
+        lifecycle.coroutineScope.launch {
+            prefs = withContext(Dispatchers.IO) { getPreferences(Context.MODE_PRIVATE) }
+
+            if (apiKeyStored()) {
+                log("Using stored API key")
+                val apiKey = getStoredApiKey()
+                val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
+                apiKeyField.text.clear()
+                apiKeyField.text.append(apiKey)
+            }
+
+            withResumed {
+                log("MainActivity is resumed - startCommandRunner if ${!polling}")
+                if (!polling) {
+                    startCommandRunner()
+                }
+            }
         }
+
         log("MainActivity.onCreate complete")
-    }
-
-    override fun onResume() {
-        super.onResume()
-        log("MainActivity.onResume called")
-
-        if (!polling) {
-            startCommandRunner()
-        }
-        log("MainActivity.onResume complete")
     }
 
     override fun onActivityResult(
@@ -158,6 +168,11 @@ class MainActivity : AppCompatActivity() {
                         notify = "http://$mazeAddress/notify",
                         sessions = "http://$mazeAddress/session",
                     )
+
+                addOnError { event ->
+                    event.originalError?.let { log("Reporting error", it) }
+                    true
+                }
 
                 logger = BugsnagLogger
             }
@@ -282,11 +297,12 @@ class MainActivity : AppCompatActivity() {
             try {
                 val errorMessage = urlConnection.errorStream.use { it.reader().readText() }
                 log(
-                    "Failed to GET $commandUrl (HTTP ${urlConnection.responseCode} " +
-                            "${urlConnection.responseMessage}):\n" +
-                            "${"-".repeat(errorMessage.width)}\n" +
-                            "$errorMessage\n" +
-                            "-".repeat(errorMessage.width),
+                    """
+                    Failed to GET $commandUrl (HTTP ${urlConnection.responseCode} ${urlConnection.responseMessage}):
+                    ${"-".repeat(errorMessage.width)}
+                    $errorMessage
+                    ${"-".repeat(errorMessage.width)}
+                    """.trimIndent(),
                 )
             } catch (e: Exception) {
                 log("Failed to retrieve error message from connection", e)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -42,7 +42,6 @@ class MainActivity : AppCompatActivity() {
         log("MainActivity.onCreate called")
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         setContentView(R.layout.activity_main)
-        prefs = getPreferences(Context.MODE_PRIVATE)
 
         // Attempt to dismiss any system dialogs (such as "MazeRunner crashed")
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
@@ -51,6 +50,8 @@ class MainActivity : AppCompatActivity() {
             val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
             sendBroadcast(closeDialog)
         }
+
+        prefs = getPreferences(Context.MODE_PRIVATE)
 
         log("Set up clearUserData click handler")
         val clearUserData = findViewById<Button>(R.id.clearUserData)
@@ -282,10 +283,10 @@ class MainActivity : AppCompatActivity() {
                 val errorMessage = urlConnection.errorStream.use { it.reader().readText() }
                 log(
                     "Failed to GET $commandUrl (HTTP ${urlConnection.responseCode} " +
-                        "${urlConnection.responseMessage}):\n" +
-                        "${"-".repeat(errorMessage.width)}\n" +
-                        "$errorMessage\n" +
-                        "-".repeat(errorMessage.width),
+                            "${urlConnection.responseMessage}):\n" +
+                            "${"-".repeat(errorMessage.width)}\n" +
+                            "$errorMessage\n" +
+                            "-".repeat(errorMessage.width),
                 )
             } catch (e: Exception) {
                 log("Failed to retrieve error message from connection", e)

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerAlarmReceiver.kt
@@ -20,5 +20,7 @@ class MazeRacerAlarmReceiver : BroadcastReceiver() {
         BugsnagPerformance.startSpan("AlarmReceiver", SpanOptions.setFirstClass(true)).use {
             Thread.sleep(250L)
         }
+
+        PerformanceTestUtils.flushBatch()
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MazeRacerApplication.kt
@@ -25,6 +25,13 @@ class MazeRacerApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // if there is stored "startup" config then we start BugsnagPerformance before the scenario
+        // this is used to test things like app-start instrumentation
+        readStartupConfig()?.let { config ->
+            InternalDebug.workerSleepMs = 2000L
+            BugsnagPerformance.start(config)
+        }
+
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy.Builder()
                 .detectNetwork()
@@ -32,12 +39,5 @@ class MazeRacerApplication : Application() {
                 .penaltyDeath()
                 .build(),
         )
-
-        // if there is stored "startup" config then we start BugsnagPerformance before the scenario
-        // this is used to test things like app-start instrumentation
-        readStartupConfig()?.let { config ->
-            InternalDebug.workerSleepMs = 2000L
-            BugsnagPerformance.start(config)
-        }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/PerformanceTestUtils.java
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/PerformanceTestUtils.java
@@ -1,0 +1,28 @@
+package com.bugsnag.mazeracer;
+
+import android.annotation.SuppressLint;
+
+import com.bugsnag.android.performance.BugsnagPerformance;
+import com.bugsnag.android.performance.internal.InstrumentedAppState;
+import com.bugsnag.android.performance.internal.SpanProcessor;
+import com.bugsnag.android.performance.internal.processing.Tracer;
+
+public class PerformanceTestUtils {
+    private PerformanceTestUtils() {
+    }
+
+    /**
+     * @noinspection KotlinInternalInJava
+     */
+    @SuppressLint("RestrictedApi")
+    public static void flushBatch() {
+        LogKt.log("PerformanceTestUtils.flushBatch()");
+        InstrumentedAppState appState = BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal();
+        SpanProcessor processor = appState.getSpanProcessor();
+
+        if (processor instanceof Tracer) {
+            Tracer tracer = (Tracer) processor;
+            tracer.forceCurrentBatch();
+        }
+    }
+}

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/Scenario.kt
@@ -6,11 +6,13 @@ import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import com.bugsnag.android.performance.PerformanceConfiguration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 
 abstract class Scenario(
     val config: PerformanceConfiguration,
     val scenarioMetadata: String,
-) {
+) : CoroutineScope by MainScope() {
     protected val mainHandler = Handler(Looper.getMainLooper())
     protected val application get() = context.applicationContext as Application
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/StartupConfiguration.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/StartupConfiguration.kt
@@ -3,19 +3,22 @@ package com.bugsnag.mazeracer
 import android.content.Context
 import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.PerformanceConfiguration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-fun Context.saveStartupConfig(config: PerformanceConfiguration) {
-    log("saveStartupConfig: $config")
+suspend fun Context.saveStartupConfig(config: PerformanceConfiguration) =
+    withContext(Dispatchers.IO) {
+        log("saveStartupConfig: $config")
 
-    applicationContext.getSharedPreferences("StartupConfig", Context.MODE_PRIVATE)
-        .edit()
-        .putBoolean("configured", true)
-        .putString("apiKey", config.apiKey)
-        .putString("endpoint", config.endpoint)
-        .putBoolean("autoInstrumentAppStarts", config.autoInstrumentAppStarts)
-        .putString("autoInstrumentActivities", config.autoInstrumentActivities.name)
-        .commit()
-}
+        applicationContext.getSharedPreferences("StartupConfig", Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("configured", true)
+            .putString("apiKey", config.apiKey)
+            .putString("endpoint", config.endpoint)
+            .putBoolean("autoInstrumentAppStarts", config.autoInstrumentAppStarts)
+            .putString("autoInstrumentActivities", config.autoInstrumentActivities.name)
+            .commit()
+    }
 
 fun Context.readStartupConfig(): PerformanceConfiguration? {
     log("readStartupConfig()")
@@ -50,6 +53,6 @@ fun Context.readStartupConfig(): PerformanceConfiguration? {
             .remove("endpoint")
             .remove("autoInstrumentAppStarts")
             .remove("autoInstrumentActivities")
-            .commit()
+            .apply()
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartDisabledScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartDisabledScenario.kt
@@ -4,6 +4,8 @@ import com.bugsnag.android.performance.AutoInstrument
 import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.mazeracer.Scenario
 import com.bugsnag.mazeracer.saveStartupConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.system.exitProcess
 
 private const val PRE_EXIT_DELAY = 500L
@@ -15,10 +17,13 @@ class AppStartDisabledScenario(
     override fun startScenario() {
         config.autoInstrumentAppStarts = false
         config.autoInstrumentActivities = AutoInstrument.FULL
-        context.saveStartupConfig(config)
 
-        Thread.sleep(PRE_EXIT_DELAY)
-        // quit the app
-        exitProcess(0)
+        launch {
+            context.saveStartupConfig(config)
+
+            delay(PRE_EXIT_DELAY)
+            // quit the app
+            exitProcess(0)
+        }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/AppStartScenario.kt
@@ -5,6 +5,8 @@ import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.android.performance.internal.InternalDebug
 import com.bugsnag.mazeracer.Scenario
 import com.bugsnag.mazeracer.saveStartupConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.system.exitProcess
 
 class AppStartScenario(
@@ -18,10 +20,13 @@ class AppStartScenario(
     override fun startScenario() {
         config.autoInstrumentAppStarts = true
         config.autoInstrumentActivities = AutoInstrument.FULL
-        context.saveStartupConfig(config)
 
-        Thread.sleep(500L)
-        // quit the app
-        exitProcess(0)
+        launch {
+            context.saveStartupConfig(config)
+
+            delay(500L)
+            // quit the app
+            exitProcess(0)
+        }
     }
 }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/scenarios/BackgroundAppStartScenario.kt
@@ -10,6 +10,8 @@ import com.bugsnag.android.performance.PerformanceConfiguration
 import com.bugsnag.mazeracer.MazeRacerAlarmReceiver
 import com.bugsnag.mazeracer.Scenario
 import com.bugsnag.mazeracer.saveStartupConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.system.exitProcess
 
 class BackgroundAppStartScenario(
@@ -19,23 +21,26 @@ class BackgroundAppStartScenario(
     override fun startScenario() {
         config.autoInstrumentAppStarts = true
         config.autoInstrumentActivities = AutoInstrument.FULL
-        context.saveStartupConfig(config)
 
-        // ask for the entire app to be woken up in 1 second, but with a broadcast (not activity)
-        val alarmService = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmService.set(
-            AlarmManager.ELAPSED_REALTIME_WAKEUP,
-            SystemClock.elapsedRealtime() + 1000L,
-            PendingIntent.getBroadcast(
-                context,
-                100,
-                Intent(context, MazeRacerAlarmReceiver::class.java),
-                PendingIntent.FLAG_IMMUTABLE,
-            ),
-        )
+        launch {
+            context.saveStartupConfig(config)
 
-        Thread.sleep(100L)
-        // quit the app to allow for a full restart
-        exitProcess(0)
+            // ask for the entire app to be woken up in 1 second, but with a broadcast (not activity)
+            val alarmService = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            alarmService.set(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + 1000L,
+                PendingIntent.getBroadcast(
+                    context,
+                    100,
+                    Intent(context, MazeRacerAlarmReceiver::class.java),
+                    PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
+
+            delay(100L)
+            // quit the app to allow for a full restart
+            exitProcess(0)
+        }
     }
 }


### PR DESCRIPTION
## Goal
Move all startup I/O to the background worker thread and avoid StrictMode disk access violations.

## Design
Replaced the list of `startupTasks` in the `Worker` with a single lambda function which is called to create the list of `Task` objects that the `Worker` needs to run.

This effectively moves most of the `BugsnagPerformance.start` implementation to the background worker thread, along with the construction of the `Persistence` class and all the I/O required.

## Testing
Added `StrictMode.ThreadPolicy.detectAll()` to the MazeRunner fixture, and modified the test fixture & scenarios to avoid `StrictMode` violations. Most significantly `Scenario` now implements `CoroutineScope` to make it easier for scenarios that rely on disk I/O to save/load data on an `IO` thread instead of the main thread.