### PR TITLE
Add compose to the list of published modules

### DIFF
--- a/dockerfiles/Dockerfile.android-publisher
+++ b/dockerfiles/Dockerfile.android-publisher
@@ -10,6 +10,7 @@ COPY build.gradle.kts settings.gradle.kts /app/
 # Copy sdk source files
 COPY bugsnag-android-performance/ bugsnag-android-performance/
 COPY bugsnag-plugin-android-performance-appcompat/ bugsnag-plugin-android-performance-appcompat/
+COPY bugsnag-plugin-android-performance-compose/ bugsnag-plugin-android-performance-compose/
 COPY bugsnag-plugin-android-performance-coroutines/ bugsnag-plugin-android-performance-coroutines/
 COPY bugsnag-plugin-android-performance-okhttp/ bugsnag-plugin-android-performance-okhttp/
 COPY scripts/ scripts/


### PR DESCRIPTION
## Goal
Add `bugsnag-plugin-android-performance-compose` to the modules in the CI publishing container.
