### PR TITLE
Change SpanCategory from being an enum to a value class of String

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanCategory.kt
@@ -2,12 +2,15 @@ package com.bugsnag.android.performance.internal
 
 import androidx.annotation.RestrictTo
 
+@JvmInline
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public enum class SpanCategory(public val category: String) {
-    CUSTOM("custom"),
-    VIEW_LOAD("view_load"),
-    VIEW_LOAD_PHASE("view_load_phase"),
-    NETWORK("network"),
-    APP_START("app_start"),
-    APP_START_PHASE("app_start_phase"),
+public value class SpanCategory internal constructor(public val category: String) {
+    public companion object {
+        public val CUSTOM: SpanCategory = SpanCategory("custom")
+        public val VIEW_LOAD: SpanCategory = SpanCategory("view_load")
+        public val VIEW_LOAD_PHASE: SpanCategory = SpanCategory("view_load_phase")
+        public val NETWORK: SpanCategory = SpanCategory("network")
+        public val APP_START: SpanCategory = SpanCategory("app_start")
+        public val APP_START_PHASE: SpanCategory = SpanCategory("app_start_phase")
+    }
 }


### PR DESCRIPTION
## Goal
Allow more flexible span categories by replacing the `enum` with a `String`.

## Design
Replaced the `SpanCategory` enum with a `value class` of `String`, retaining a type and set of well-known `SpanCategory` objects while allowing external systems to specify their own span categories safely.

## Testing
Relied on existing tests and code.