### PR TITLE
Expose span creation, start times and attribute entries to Java

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Attributes.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Attributes.kt
@@ -6,7 +6,7 @@ import androidx.annotation.RestrictTo
 public class Attributes {
     private val content = mutableMapOf<String, Any>()
 
-    @get:JvmSynthetic
+    @get:JvmName("getEntries\$internal")
     internal val entries: Collection<Map.Entry<String, Any>>
         inline get() = content.entries
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -42,6 +42,7 @@ public class SpanFactory(
         this.timeoutExecutor.start()
     }
 
+    @JvmOverloads
     public fun createCustomSpan(
         name: String,
         options: SpanOptions = SpanOptions.DEFAULTS,

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -25,7 +25,10 @@ public class SpanImpl internal constructor(
     name: String,
     internal val category: SpanCategory,
     internal val kind: SpanKind,
+
+    @get:JvmName("getStartTime\$internal")
     internal val startTime: Long,
+
     override val traceId: UUID,
     override val spanId: Long = nextSpanId(),
     public val parentSpanId: Long,


### PR DESCRIPTION
## Goal

Allow external systems to create spans and access start times and attributes on created spans

## Design

Adds JVM annotations to `SpanFactory.createCustomSpan`, `SpanImpl.startTime` and `Attributes.entries`

## Testing

Tested manually