### PR TITLE
Support converting unix nanoseconds to elapsedRealtimeNanos

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/BugsnagClock.kt
@@ -58,6 +58,12 @@ internal object BugsnagClock {
     fun elapsedNanosToUnixTime(elapsedRealtimeNanos: Long) = elapsedRealtimeNanos + bootTimeNano
 
     /**
+     * Covert a given time from Unix time with nanosecond precision into
+     * [SystemClock.elapsedRealtimeNanos]
+     */
+    fun unixNanoTimeToElapsedRealtime(unixNanoTime: Long) = unixNanoTime - bootTimeNano
+
+    /**
      * `System.currentTimeMillis` but as nanosecond precision time.
      */
     fun currentUnixNanoTime(): Long = elapsedNanosToUnixTime(SystemClock.elapsedRealtimeNanos())


### PR DESCRIPTION
## Goal

Adds a utility function to `BugsnagClock` to convert a given time from Unix time with nanosecond precision into `SystemClock.elapsedRealtimeNanos`.

This allows external systems to specify start and end times relative to the internal clock.
