### PR TITLE
Explicitly state default Buildkite queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,6 +115,7 @@ steps:
   - label: 'Publish :rocket:'
     if: build.branch == "main"
     depends_on: 'android-common'
+    timeout_in_minutes: 30
     env:
       BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX: bugsnag-android-publish
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: opensource
+
 steps:
 
   - label: ':android: Coding standards checks'


### PR DESCRIPTION
## Goal

Explicitly state the default Buildkite queue, rather than rely on the queue configure in the Buildkite UI itself.

## Testing

Covered by CI.