### PR TITLE
Add restrictions on default github token access

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,5 +1,7 @@
 name: Sign release assets
 
+permissions: read-all
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
## Goal

Restricts the permissions the signing workflow token has to read only.