### PR TITLE
Split up the span ending and processing

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -96,9 +96,8 @@ public class SpanImpl internal constructor(
 
     override fun end(endTime: Long) {
         if (state.end()) {
-            this.endTime = endTime
+            markEndTime(endTime)
 
-            startFrameMetrics?.let { framerateMetricsSource?.endMetrics(it, this) }
             if (makeContext) SpanContext.detach(this)
             NotifierIntegration.onSpanEnded(this)
 
@@ -108,7 +107,14 @@ public class SpanImpl internal constructor(
         }
     }
 
-    private fun sendForProcessing() {
+    @JvmName("markEndTime\$internal")
+    internal fun markEndTime(endTime: Long) {
+        this.endTime = endTime
+        startFrameMetrics?.let { framerateMetricsSource?.endMetrics(it, this) }
+    }
+
+    @JvmName("sendForProcessing\$internal")
+    internal fun sendForProcessing() {
         if (state.process()) {
             processor.onEnd(this)
         }


### PR DESCRIPTION
## Goal
Split the span ending and processing logic for first-party modules.

## Testing
Relied on existing tests