### PR TITLE
Make `SpanImpl.endTime` accessible from Java

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -55,6 +55,7 @@ public class SpanImpl internal constructor(
 
     internal var isSealed: Boolean = false
 
+    @get:JvmName("getEndTime\$internal")
     internal var endTime: Long = 0L
         private set
 


### PR DESCRIPTION
## Goal

Allow external modules to read the end time on created spans

## Testing

Relied on existing tests