### PR TITLE
Abstract Span Metrics out of SpanImpl

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -32,7 +32,10 @@
     <ID>MagicNumber:SpanKind.kt$SpanKind.CONSUMER$5</ID>
     <ID>MagicNumber:SpanKind.kt$SpanKind.PRODUCER$4</ID>
     <ID>ReturnCount:RetryDeliveryTask.kt$RetryDeliveryTask$override fun execute(): Boolean</ID>
+    <ID>ReturnCount:SpanFactory.kt$SpanFactory$private fun createSpanMetrics( isFirstClass: Boolean?, instrumentRendering: Boolean?, ): SpanMetricsSnapshot?</ID>
+    <ID>ReturnCount:SpanImpl.kt$SpanState$fun block(): Boolean</ID>
     <ID>ReturnCount:SpanImpl.kt$SpanState$fun end(): Boolean</ID>
+    <ID>ReturnCount:SpanImpl.kt$SpanState$fun ending(): Boolean</ID>
     <ID>SwallowedException:BugsnagClock.kt$BugsnagClock$ex: Exception</ID>
     <ID>SwallowedException:Connectivity.kt$ConnectivityApi24$e: Exception</ID>
     <ID>SwallowedException:ContextExtensions.kt$exc: RuntimeException</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/framerate/FramerateMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/framerate/FramerateMetricsSource.kt
@@ -13,7 +13,7 @@ import androidx.annotation.RequiresApi
 import com.bugsnag.android.performance.BugsnagPerformance
 import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanOptions
-import com.bugsnag.android.performance.internal.MetricSource
+import com.bugsnag.android.performance.internal.metrics.MetricSource
 import com.bugsnag.android.performance.internal.SpanImpl
 import java.util.WeakHashMap
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MetricSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MetricSource.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android.performance.internal
+package com.bugsnag.android.performance.internal.metrics
 
 import androidx.annotation.RestrictTo
 import com.bugsnag.android.performance.Span

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/SpanMetricsSnapshot.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/SpanMetricsSnapshot.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.android.performance.internal.metrics
+
+import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
+
+/**
+ * Container for all of the possible metrics types that can attached to a [Span].
+ */
+internal class SpanMetricsSnapshot(
+    private val renderingMetricsSource: MetricSource<FramerateMetricsSnapshot>?,
+) {
+    private val renderingMetricsSnapshot: FramerateMetricsSnapshot? =
+        renderingMetricsSource?.createStartMetrics()
+
+    fun finish(spanImpl: SpanImpl) {
+        renderingMetricsSnapshot?.let { renderingMetricsSource?.endMetrics(it, spanImpl) }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
@@ -4,6 +4,7 @@ import com.bugsnag.android.performance.Span
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
 import com.bugsnag.android.performance.internal.framerate.TimestampPairBuffer
+import com.bugsnag.android.performance.internal.metrics.MetricSource
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -45,7 +46,7 @@ class SpanFactoryTest {
             spanFactory.createCustomSpan(
                 "First Class",
                 baseOptions.setFirstClass(true),
-            ).startFrameMetrics,
+            ).metrics,
         )
 
         assertNotNull(
@@ -55,7 +56,7 @@ class SpanFactoryTest {
                 baseOptions
                     .setFirstClass(false)
                     .withRenderingMetrics(true),
-            ).startFrameMetrics,
+            ).metrics,
         )
 
         assertNotNull(
@@ -65,7 +66,7 @@ class SpanFactoryTest {
                 baseOptions
                     .setFirstClass(true)
                     .withRenderingMetrics(true),
-            ).startFrameMetrics,
+            ).metrics,
         )
 
         assertNull(
@@ -73,7 +74,7 @@ class SpanFactoryTest {
             spanFactory.createCustomSpan(
                 "Scrolling",
                 baseOptions.setFirstClass(false),
-            ).startFrameMetrics,
+            ).metrics,
         )
 
         assertNull(
@@ -83,7 +84,7 @@ class SpanFactoryTest {
                 baseOptions
                     .setFirstClass(true)
                     .withRenderingMetrics(false),
-            ).startFrameMetrics,
+            ).metrics,
         )
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanStateTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanStateTest.kt
@@ -1,0 +1,119 @@
+package com.bugsnag.android.performance.internal
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpanStateTest {
+    @Test
+    fun simple() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.ending())
+        assertTrue(state.end())
+        assertEnded(state)
+        assertTrue(state.process())
+    }
+
+    @Test
+    fun discardOpen() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.discard())
+        assertDiscarded(state)
+        assertFalse(state.process())
+    }
+
+    @Test
+    fun discardInEnd() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.ending())
+        assertTrue(state.discard())
+        assertDiscarded(state)
+        assertFalse(state.end())
+        assertDiscarded(state)
+        assertFalse(state.process())
+    }
+
+    @Test
+    fun blockOpen() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.block())
+        assertTrue(state.ending())
+        assertTrue(state.end())
+        assertEndedBlocked(state)
+    }
+
+    @Test
+    fun blockInEnd() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.ending())
+        assertTrue(state.block())
+        assertTrue(state.end())
+        assertEndedBlocked(state)
+    }
+
+    @Test
+    fun fail_discardAfterEnd() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.ending())
+        assertTrue(state.end())
+
+        assertFalse("span has ended and cannot be discarded", state.discard())
+    }
+
+    @Test
+    fun fail_blockAfterEnd() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.ending())
+        assertTrue(state.end())
+
+        assertFalse("span has ended and cannot be blocked", state.block())
+    }
+
+    @Test
+    fun fail_discardAndBlock() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.discard())
+        assertFalse(state.block())
+    }
+
+    @Test
+    fun fail_discardAndEnd() {
+        val state = SpanState()
+        assertOpen(state)
+        assertTrue(state.discard())
+        assertFalse(state.ending())
+        assertFalse(state.end())
+    }
+
+    private fun assertOpen(state: SpanState) {
+        assertTrue("state should be open: $state", state.isOpen)
+        assertFalse("state should not be discarded: $state", state.isDiscarded)
+        assertFalse("state should not be blocked: $state", state.isBlocked)
+    }
+
+    private fun assertEnded(state: SpanState) {
+        assertFalse("state should not be open: $state", state.isOpen)
+        assertFalse("state should not be discarded: $state", state.isDiscarded)
+        assertFalse("state should not be blocked: $state", state.isBlocked)
+    }
+
+    private fun assertDiscarded(state: SpanState) {
+        assertTrue("state should be discarded: $state", state.isDiscarded)
+        assertFalse("state should not be open: $state", state.isOpen)
+        assertFalse("state should not be blocked: $state", state.isBlocked)
+    }
+
+    private fun assertEndedBlocked(state: SpanState) {
+        assertTrue("state should be blocked: $state", state.isBlocked)
+        assertFalse("state should not be discarded: $state", state.isDiscarded)
+        assertFalse("state should not be open: $state", state.isOpen)
+    }
+}


### PR DESCRIPTION
## Goal
Allow for multiple metrics per span, by abstracting Span Metrics out of `SpanImpl`

## Design
Created a new `SpanMetrics` class which serves as a container for the `MetricsSource`s and snapshots applicable to a given span.

## Changes
- added the `SpanMetrics` container class
- updated `SpanState` to allow spans to be blocked *during* `end()` (by metrics or integrations)

## Testing
New tests added for the `SpanState` to check all of its state flows, updated existing tests to handle the change from frame metrics -> span metrics