### PR TITLE
Span Task Worker Thread

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -52,7 +52,7 @@
     <ID>TooGenericExceptionCaught:ImmutableConfig.kt$ImmutableConfig.Companion$ex: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:Module.kt$Module.Loader$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:PerformanceConfiguration.kt$PerformanceConfiguration.Loader$exc: Exception</ID>
-    <ID>TooGenericExceptionCaught:Timeout.kt$TimeoutExecutorImpl$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:SpanTaskWorker.kt$SpanTaskWorker$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Worker.kt$Worker$ex: Exception</ID>
     <ID>TooManyFunctions:Attributes.kt$Attributes</ID>
@@ -61,5 +61,6 @@
     <ID>TooManyFunctions:JsonTraceWriter.kt$JsonTraceWriter : Closeable</ID>
     <ID>TooManyFunctions:SpanFactory.kt$SpanFactory</ID>
     <ID>TooManyFunctions:SpanTracker.kt$SpanTracker</ID>
+    <ID>UseCheckOrError:SpanTaskWorkerTest.kt$SpanTaskWorkerTest.&lt;no name provided>$throw IllegalStateException("oops")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -12,7 +12,7 @@ import com.bugsnag.android.performance.ViewType
 import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
 import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import com.bugsnag.android.performance.internal.processing.AttributeLimits
-import com.bugsnag.android.performance.internal.processing.TimeoutExecutorImpl
+import com.bugsnag.android.performance.internal.processing.SpanTaskWorker
 import java.util.UUID
 
 internal typealias AttributeSource = (target: SpanImpl) -> Unit
@@ -23,7 +23,7 @@ public class SpanFactory(
     public val spanAttributeSource: AttributeSource = {},
 ) {
 
-    private val timeoutExecutor = TimeoutExecutorImpl()
+    private val timeoutExecutor = SpanTaskWorker()
 
     public var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/SpanTaskWorker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/SpanTaskWorker.kt
@@ -41,7 +41,7 @@ internal class SpanTaskWorker : Runnable, TimeoutExecutor {
         }
 
         running = true
-        thread = Thread(this, "Bugsnag Span Worker")
+        thread = Thread(this, "Bugsnag Span Task Worker")
         thread?.start()
     }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/SpanTaskWorker.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/SpanTaskWorker.kt
@@ -1,0 +1,111 @@
+package com.bugsnag.android.performance.internal.processing
+
+import android.os.SystemClock
+import com.bugsnag.android.performance.Logger
+
+import java.util.concurrent.DelayQueue
+import java.util.concurrent.Delayed
+import java.util.concurrent.TimeUnit
+
+internal interface ScheduledAction : Delayed, Runnable {
+    override fun compareTo(other: Delayed): Int {
+        val delay = getDelay(TimeUnit.NANOSECONDS)
+        val otherDelay = other.getDelay(TimeUnit.NANOSECONDS)
+        return when {
+            delay < otherDelay -> -1
+            delay > otherDelay -> 1
+            else -> 0
+        }
+    }
+}
+
+internal class SpanTaskWorker : Runnable, TimeoutExecutor {
+    /*
+     * The SpanTaskWorker is a Timer/ScheduledExecutor/HandlerThread style class, but allows tasks
+     * to be added and removed before the backing thread is actually started. Once it has been
+     * started any past tasks are executed immediately. This suits us nicely since our configuration
+     * only typically settles some time after the first actions have already been taken.
+     */
+
+    @Volatile
+    private var running = false
+
+    private var thread: Thread? = null
+
+    private val actions = DelayQueue<ScheduledAction>()
+
+    @Synchronized
+    fun start() {
+        if (running) {
+            return
+        }
+
+        running = true
+        thread = Thread(this, "Bugsnag Span Worker")
+        thread?.start()
+    }
+
+    @Synchronized
+    fun stop() {
+        if (!running) {
+            return
+        }
+
+        running = false
+        thread?.interrupt()
+        thread = null
+    }
+
+    override fun run() {
+        while (running) {
+            try {
+                actions.take().run()
+            } catch (ie: InterruptedException) {
+                // ignore and continue, the thread may have been stopped
+            } catch (ex: Exception) {
+                Logger.w("unhandled exception in timeout", ex)
+            }
+        }
+    }
+
+    override fun scheduleTimeout(timeout: Timeout) {
+        actions.add(timeout)
+    }
+
+    override fun cancelTimeout(timeout: Timeout) {
+        actions.remove(timeout)
+    }
+
+    fun addSampler(sampler: Runnable, sampleRateMs: Long = 1000L) {
+        actions.add(Sampler(sampleRateMs, sampler))
+    }
+
+    fun removeSampler(sampler: Runnable) {
+        actions.removeAll { it is Sampler && it.sampler === sampler }
+    }
+
+    private inner class Sampler(
+        val sampleRateMs: Long,
+        val sampler: Runnable,
+    ) : ScheduledAction {
+        private val baseTime = SystemClock.elapsedRealtime()
+
+        private var runCount = 1L
+
+        override fun getDelay(unit: TimeUnit): Long {
+            val currentTime = SystemClock.elapsedRealtime()
+            val expectedNextTime = baseTime + (runCount * sampleRateMs)
+
+            return unit.convert(expectedNextTime - currentTime, TimeUnit.MILLISECONDS)
+        }
+
+        override fun run() {
+            try {
+                sampler.run()
+            } finally {
+                runCount++
+                actions.add(this)
+            }
+        }
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Timeout.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/Timeout.kt
@@ -1,12 +1,9 @@
 package com.bugsnag.android.performance.internal.processing
 
 import android.os.SystemClock
-import com.bugsnag.android.performance.Logger
-import java.util.concurrent.DelayQueue
-import java.util.concurrent.Delayed
 import java.util.concurrent.TimeUnit
 
-internal interface Timeout : Runnable, Delayed {
+internal interface Timeout : ScheduledAction {
     /**
      * The time that this `Timeout` is "due" relative to the [SystemClock.elapsedRealtime] clock.
      */
@@ -22,70 +19,9 @@ internal interface Timeout : Runnable, Delayed {
     override fun getDelay(unit: TimeUnit): Long {
         return unit.convert(relativeMs, TimeUnit.MILLISECONDS)
     }
-
-    override fun compareTo(other: Delayed): Int {
-        val delay = getDelay(TimeUnit.NANOSECONDS)
-        val otherDelay = other.getDelay(TimeUnit.NANOSECONDS)
-        return when {
-            delay < otherDelay -> -1
-            delay > otherDelay -> 1
-            else -> 0
-        }
-    }
 }
 
 internal interface TimeoutExecutor {
     fun scheduleTimeout(timeout: Timeout)
     fun cancelTimeout(timeout: Timeout)
-}
-
-internal class TimeoutExecutorImpl : Runnable, TimeoutExecutor {
-    @Volatile
-    private var running = false
-
-    private var thread: Thread? = null
-
-    private val timeouts = DelayQueue<Timeout>()
-
-    @Synchronized
-    fun start() {
-        if (running) {
-            return
-        }
-
-        running = true
-        thread = Thread(this, "Bugsnag Timeouts Thread")
-        thread?.start()
-    }
-
-    @Synchronized
-    fun stop() {
-        if (!running) {
-            return
-        }
-
-        running = false
-        thread?.interrupt()
-        thread = null
-    }
-
-    override fun run() {
-        while (running) {
-            try {
-                timeouts.take().run()
-            } catch (ie: InterruptedException) {
-                // ignore and continue, the thread may have been stopped
-            } catch (ex: Exception) {
-                Logger.w("unhandled exception in timeout", ex)
-            }
-        }
-    }
-
-    override fun scheduleTimeout(timeout: Timeout) {
-        timeouts.add(timeout)
-    }
-
-    override fun cancelTimeout(timeout: Timeout) {
-        timeouts.remove(timeout)
-    }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/SpanTaskWorkerTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/processing/SpanTaskWorkerTest.kt
@@ -1,0 +1,113 @@
+package com.bugsnag.android.performance.internal.processing
+
+import android.os.SystemClock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowSystemClock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+class SpanTaskWorkerTest {
+
+    private var worker: SpanTaskWorker? = null
+
+    @Before
+    fun setup() {
+        worker = SpanTaskWorker()
+    }
+
+    @After
+    fun tearDown() {
+        worker?.stop()
+        worker = null
+    }
+
+    @Test(timeout = 500L)
+    fun populateBeforeStart() {
+        val w = worker!!
+
+        val latch = CountDownLatch(2)
+
+        val t1 = TestTimeout(5L, latch)
+        val t2 = TestTimeout(10L, latch)
+
+        w.scheduleTimeout(t1)
+        w.scheduleTimeout(t2)
+
+        ShadowSystemClock.advanceBy(20L, TimeUnit.MILLISECONDS)
+
+        assertEquals(0, t1.runCount)
+        assertEquals(0, t2.runCount)
+
+        w.start()
+        latch.await()
+
+        assertEquals(1, t1.runCount)
+        assertEquals(1, t2.runCount)
+    }
+
+    @Test
+    fun samplersRunAtFixedRate() {
+        val w = worker!!
+        var runCount = 0
+
+        val sampler = Runnable {
+            runCount++
+        }
+
+        w.addSampler(sampler, 2L)
+        w.start()
+
+        repeat(10) {
+            ShadowSystemClock.advanceBy(1, TimeUnit.MILLISECONDS)
+            Thread.sleep(1L)
+        }
+
+        assertEquals(5, runCount)
+    }
+
+    @Test
+    fun errorTask() {
+        val w = worker!!
+
+        val latch = CountDownLatch(2)
+
+        val t1 = object : TestTimeout(5L, latch) {
+            override fun run() {
+                super.run()
+                throw IllegalStateException("oops")
+            }
+        }
+
+        val t2 = TestTimeout(10L, latch)
+
+        w.scheduleTimeout(t1)
+        w.scheduleTimeout(t2)
+        w.start()
+
+        ShadowSystemClock.advanceBy(20L, TimeUnit.MILLISECONDS)
+        latch.await()
+
+        assertEquals(1, t1.runCount)
+        assertEquals(1, t2.runCount)
+    }
+
+    private open class TestTimeout(
+        timeoutMs: Long,
+        private val latch: CountDownLatch? = null,
+    ) : Timeout {
+        var runCount = 0
+
+        override val target: Long = timeoutMs + SystemClock.elapsedRealtime()
+
+        override fun run() {
+            runCount++
+            latch?.countDown()
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Refactor the Condition timeout thread (previously `TimeoutExecutorImpl`) as a more generic worker capable of handling both the timeouts, and regular sampling tasks.

## Testing
Added new unit test coverage of the additional functionality.