### PR TITLE
Add buffer to store metrics samples

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/FixedRingBuffer.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/FixedRingBuffer.kt
@@ -1,0 +1,95 @@
+package com.bugsnag.android.performance.internal.util
+
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * A simple pre-allocated ring buffer designed to hold sample data for various metrics. All of the
+ * contents are pre-allocated on init, and are updated by [put]. As such we assume the contents
+ * is mutable.
+ *
+ * This structure is not thread-safe, external synchronization must be used when required.
+ */
+internal class FixedRingBuffer<T>(
+    private val values: Array<T>,
+) {
+    private var tail = 0
+
+    /**
+     * The number of items currently "added" to this [FixedRingBuffer], and the maximum number of
+     * items that can be returned by [forEach].
+     */
+    val size: Int get() = min(values.size, tail)
+
+    /**
+     * The current "pointer" or "tail" for this [FixedRingBuffer], this should be treated as an
+     * opaque value and only be used as arguments to the [forEach] function.
+     */
+    val currentIndex: Int
+        get() = tail
+
+    /**
+     * Returns the "next" (tail) item in the buffer, this function can be used instead of [put]
+     * if more complex update logic is required.
+     */
+    fun next(): T {
+        val index = tail % values.size
+        tail++
+        return values[index]
+    }
+
+    /**
+     * "add" an item to this [FixedRingBuffer]
+     */
+    inline fun put(update: (T) -> Unit) {
+        update(next())
+    }
+
+    fun countItemsBetween(from: Int, to: Int): Int {
+        val realMin = tail - values.size
+
+        // if the "to" value is no longer in the buffer, we have no data that can be delivered
+        if (to < realMin) {
+            return 0
+        }
+
+        // calculate the actual number of samples that can be iterated
+        return min(to - max(from, realMin), size)
+    }
+
+    /**
+     * Loop through all of the items between `from` (inclusive) and `to` (exclusive) if all of the
+     * available items are still in the buffer. If `to - from` is larger than the buffer the
+     * entire buffer will be iterated over resulting in only the most recent values being passed
+     * to [consumer].
+     */
+    inline fun forEach(from: Int, to: Int, consumer: (T) -> Unit) {
+        // calculate the actual number of samples that can be iterated
+        val count = countItemsBetween(from, to)
+        val start = to - count
+
+        for (i in 0 until count) {
+            val index = (start + i) % values.size
+            consumer(values[index])
+        }
+    }
+
+    inline fun forEachIndexed(from: Int, to: Int, consumer: (index: Int, T) -> Unit) {
+        // calculate the actual number of samples that can be iterated
+        val count = countItemsBetween(from, to)
+        val start = to - count
+
+        for (i in 0 until count) {
+            val index = (start + i) % values.size
+            consumer(i, values[index])
+        }
+    }
+}
+
+@Suppress("FunctionNaming")
+internal inline fun <reified T> FixedRingBuffer(
+    size: Int,
+    init: (index: Int) -> T,
+): FixedRingBuffer<T> {
+    return FixedRingBuffer(Array(size) { index -> init(index) })
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/FixedRingBufferTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/FixedRingBufferTest.kt
@@ -1,0 +1,93 @@
+package com.bugsnag.android.performance.internal.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class FixedRingBufferTest {
+    @Test
+    fun cannotIterateEmpty() {
+        val fixedRingBuffer = FixedRingBuffer(64, ::Content)
+        fixedRingBuffer.forEach(0, 10) {
+            fail("empty buffers should not call forEach")
+        }
+
+        fixedRingBuffer.forEach(96, 128) {
+            fail("empty buffers should not call forEach")
+        }
+    }
+
+    @Test
+    fun iteratesOnUndersized() {
+        val fixedRingBuffer = FixedRingBuffer(64, ::Content)
+        repeat(4) { index -> fixedRingBuffer.put { it.value = index } }
+        val start = fixedRingBuffer.currentIndex
+        repeat(4) { index -> fixedRingBuffer.put { it.value = index + 100 } }
+        val end = fixedRingBuffer.currentIndex
+        repeat(10) { index -> fixedRingBuffer.put { it.value = index + 1000 } }
+
+        var expectedValue = 100
+        fixedRingBuffer.forEach(start, end) { item ->
+            assertEquals(expectedValue, item.value)
+            expectedValue++
+        }
+
+        assertEquals(104, expectedValue)
+    }
+
+    @Test
+    fun iteratesOnOversize() {
+        val fixedRingBuffer = FixedRingBuffer(64, ::Content)
+        repeat(128) { index -> fixedRingBuffer.put { it.value = index } }
+        val start = fixedRingBuffer.currentIndex
+        repeat(16) { index -> fixedRingBuffer.put { it.value = index + 100 } }
+        val end = fixedRingBuffer.currentIndex
+        repeat(10) { index -> fixedRingBuffer.put { it.value = index + 1000 } }
+
+        var expectedValue = 100
+        fixedRingBuffer.forEach(start, end) { item ->
+            assertEquals(expectedValue, item.value)
+            expectedValue++
+        }
+
+        assertEquals(116, expectedValue)
+    }
+
+    @Test
+    fun iteratesFullBufferOnOversize() {
+        val fixedRingBuffer = FixedRingBuffer(64, ::Content)
+        repeat(128) { index -> fixedRingBuffer.put { it.value = index } }
+        val start = fixedRingBuffer.currentIndex
+        repeat(64) { index -> fixedRingBuffer.put { it.value = index + 100 } }
+        val end = fixedRingBuffer.currentIndex
+        repeat(10) { index -> fixedRingBuffer.put { it.value = index + 1000 } }
+
+        // we've added 10 more items to the buffer, so we can only iterate over 54 of our expected
+        // values now
+        var expectedValue = 110
+        fixedRingBuffer.forEach(start, end) { item ->
+            assertEquals(expectedValue, item.value)
+            expectedValue++
+        }
+
+        assertEquals(164, expectedValue)
+    }
+
+    @Test
+    fun cannotIterateOutdated() {
+        val fixedRingBuffer = FixedRingBuffer(64, ::Content)
+        repeat(8) { index -> fixedRingBuffer.put { it.value = index } }
+        val start = fixedRingBuffer.currentIndex
+        repeat(10) { index -> fixedRingBuffer.put { it.value = index + 1000 } }
+        val end = fixedRingBuffer.currentIndex
+        repeat(256) { index -> fixedRingBuffer.put { it.value = index + 100 } }
+
+        fixedRingBuffer.forEach(start, end) {
+            fail("forEach should not work for samples too far in the past")
+        }
+    }
+
+    data class Content(
+        var value: Int = 0,
+    )
+}


### PR DESCRIPTION
## Goal
Implement a fixed-size data structure (ring buffer in this case) for storing metrics samples for later attaching to spans.

## Testing
New unit tests added