### PR TITLE
metrics option added to configuration and span options

### DIFF
--- a/bugsnag-android-performance/detekt-baseline.xml
+++ b/bugsnag-android-performance/detekt-baseline.xml
@@ -6,6 +6,7 @@
     <ID>ComplexMethod:SpanOptions.kt$SpanOptions$override fun equals(other: Any?): Boolean</ID>
     <ID>DestructuringDeclarationWithTooManyEntries:ActivityLifecycleInstrumentationTest.kt$ActivityLifecycleInstrumentationTest$val (create, viewLoad, start, resume) = spans</ID>
     <ID>LongMethod:BugsnagPerformance.kt$BugsnagPerformance$private fun startUnderLock(configuration: ImmutableConfig)</ID>
+    <ID>LongMethod:SpanFactoryTest.kt$SpanFactoryTest$@Test fun testRenderMetricsOptions()</ID>
     <ID>LongMethod:SpanJsonTest.kt$SpanJsonTest$@Test fun testJsonEncoding()</ID>
     <ID>LongParameterList:SpanFactory.kt$SpanFactory$( name: String, kind: SpanKind, category: SpanCategory, startTime: Long, parentContext: SpanContext?, isFirstClass: Boolean?, makeContext: Boolean, instrumentRendering: Boolean?, spanProcessor: SpanProcessor, )</ID>
     <ID>MagicNumber:Encodings.kt$0xff</ID>

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/EnabledMetrics.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/EnabledMetrics.kt
@@ -1,0 +1,44 @@
+package com.bugsnag.android.performance
+
+/**
+ * Sets which metrics (if any) are gathered and reported
+ */
+public class EnabledMetrics(
+    /**
+     * Determines whether rendering metrics (slow and frozen frames) are gathered and reported
+     */
+    public var rendering: Boolean = false,
+
+    /**
+     * Determines whether CPU use is gathered and reported. When enabled, the CPU use is
+     * sampled periodically for the app process and main thread.
+     */
+    public var cpu: Boolean = false,
+
+    /**
+     * Determines whether memory consumption is gathered and reported.
+     */
+    public var memory: Boolean = false,
+) {
+    public constructor(enable: Boolean) : this(enable, enable, enable)
+
+    internal fun copy() = EnabledMetrics(rendering, cpu, memory)
+
+    override fun equals(other: Any?): Boolean {
+        return other is EnabledMetrics &&
+                rendering == other.rendering &&
+                cpu == other.cpu &&
+                memory == other.memory
+    }
+
+    override fun hashCode(): Int {
+        var result = rendering.hashCode()
+        result = 31 * result + cpu.hashCode()
+        result = 31 * result + memory.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "EnabledMetrics(rendering=$rendering, cpu=$cpu, memory=$memory)"
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/PerformanceConfiguration.kt
@@ -21,7 +21,15 @@ public class PerformanceConfiguration private constructor(public val context: Co
 
     public var autoInstrumentActivities: AutoInstrument = AutoInstrument.FULL
 
-    public var autoInstrumentRendering: Boolean = false
+    public var enabledMetrics: EnabledMetrics = EnabledMetrics(false)
+
+    @Deprecated(
+        message = "use enabledMetrics.rendering",
+        replaceWith = ReplaceWith("enabledMetrics.rendering"),
+    )
+    public var autoInstrumentRendering: Boolean
+        get() = enabledMetrics.rendering
+        set(value) { enabledMetrics.rendering = value }
 
     public var releaseStage: String? = null
 
@@ -90,7 +98,7 @@ public class PerformanceConfiguration private constructor(public val context: Co
             "endpoint='$endpoint', " +
             "autoInstrumentAppStarts=$autoInstrumentAppStarts, " +
             "autoInstrumentActivities=$autoInstrumentActivities, " +
-            "autoInstrumentRendering=$autoInstrumentRendering, " +
+            "enabledMetrics=$enabledMetrics, " +
             "releaseStage=$releaseStage, " +
             "versionCode=$versionCode, " +
             "appVersion=$appVersion, " +

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanMetrics.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanMetrics.kt
@@ -1,21 +1,32 @@
 package com.bugsnag.android.performance
 
 /**
- * Determines which metrics are reported for an individual span. `null` values indicate whatever
- * the default behaviour is (typically metrics are reported only for [first class](SpanOptions.setFirstClass) spans).
+ * Determines which metrics are reported for an individual span. `null` values indicate default
+ * behaviour where metrics are reported only for first class ([SpanOptions.setFirstClass])
+ * spans.
  *
- * If a metric is not being gathered (due to being turned off with [EnabledMetrics]) then enabling it for individual
- * spans will have no effect.
+ * If a metric is not being gathered (due to being turned off with [EnabledMetrics]) then enabling
+ * it for individual spans will have no effect.
  *
  * @see PerformanceConfiguration.enabledMetrics
  * @see SpanOptions.withMetrics
  */
 public class SpanMetrics(
+    /**
+     * Determines whether rendering metrics (slow and frozen frames) are reported for the span.
+     */
     public val rendering: Boolean? = null,
+
+    /**
+     * Determines whether CPU use is reported for the span.
+     */
     public val cpu: Boolean? = null,
+
+    /**
+     * Determines whether memory consumption is reported for the span.
+     */
     public val memory: Boolean? = null,
 ) {
-
     override fun equals(other: Any?): Boolean {
         return other is SpanMetrics &&
                 rendering == other.rendering &&

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanMetrics.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanMetrics.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android.performance
+
+/**
+ * Determines which metrics are reported for an individual span. `null` values indicate whatever
+ * the default behaviour is (typically metrics are reported only for [first class](SpanOptions.setFirstClass) spans).
+ *
+ * If a metric is not being gathered (due to being turned off with [EnabledMetrics]) then enabling it for individual
+ * spans will have no effect.
+ *
+ * @see PerformanceConfiguration.enabledMetrics
+ * @see SpanOptions.withMetrics
+ */
+public class SpanMetrics(
+    public val rendering: Boolean? = null,
+    public val cpu: Boolean? = null,
+    public val memory: Boolean? = null,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        return other is SpanMetrics &&
+                rendering == other.rendering &&
+                cpu == other.cpu &&
+                memory == other.memory
+    }
+
+    override fun hashCode(): Int {
+        var result = rendering.hashCode()
+        result = 31 * result + cpu.hashCode()
+        result = 31 * result + memory.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SpanMetrics(rendering=$rendering, cpu=$cpu, memory=$memory)"
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -69,7 +69,7 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         _isFirstClass,
-        _spanMetrics
+        _spanMetrics,
     )
 
     public fun within(parentContext: SpanContext?): SpanOptions = SpanOptions(
@@ -78,7 +78,7 @@ public class SpanOptions private constructor(
         parentContext,
         makeContext,
         _isFirstClass,
-        _spanMetrics
+        _spanMetrics,
     )
 
     public fun makeCurrentContext(makeContext: Boolean): SpanOptions = SpanOptions(
@@ -87,7 +87,7 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         _isFirstClass,
-        _spanMetrics
+        _spanMetrics,
     )
 
     public fun setFirstClass(isFirstClass: Boolean): SpanOptions = SpanOptions(
@@ -96,7 +96,7 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         isFirstClass,
-        _spanMetrics
+        _spanMetrics,
     )
 
     @Deprecated(
@@ -113,18 +113,27 @@ public class SpanOptions private constructor(
                     rendering = instrumentRendering,
                     cpu = _spanMetrics.cpu,
                     memory = _spanMetrics.memory,
-                )
+                ),
             )
         } else withMetrics(SpanMetrics(rendering = instrumentRendering))
     }
 
-    public fun withMetrics(spanMetrics: SpanMetrics?): SpanOptions = SpanOptions(
+    /**
+     * Set the metrics that should be captured with the spans. Adding metrics that have been
+     * disabled via [PerformanceConfiguration.enabledMetrics] will have no effect (as they are
+     * not being captured). Calling this with an explicit `null` (`withMetrics(null)`) will capture
+     * only the default metrics for the span (see [SpanMetrics] for more details).
+     */
+    @JvmOverloads
+    public fun withMetrics(
+        spanMetrics: SpanMetrics? = SpanMetrics(rendering = true, cpu = true, memory = true),
+    ): SpanOptions = SpanOptions(
         optionsSet or OPT_METRICS,
         _startTime,
         _parentContext,
         makeContext,
         _isFirstClass,
-        spanMetrics
+        spanMetrics,
     )
 
     override fun equals(other: Any?): Boolean {
@@ -143,12 +152,10 @@ public class SpanOptions private constructor(
             && this.makeContext != other.makeContext
         ) return false
 
-        @Suppress("RedundantIf")
         if ((isOptionSet(OPT_IS_FIRST_CLASS) || other.isOptionSet(OPT_IS_FIRST_CLASS))
             && this.isFirstClass != other.isFirstClass
         ) return false
 
-        @Suppress("RedundantIf")
         if ((isOptionSet(OPT_METRICS) || other.isOptionSet(OPT_METRICS))
             && this.spanMetrics != other.spanMetrics
         ) return false
@@ -220,7 +227,7 @@ public class SpanOptions private constructor(
                 null,
                 makeContext = true,
                 isFirstClass = false,
-                null
+                null,
             )
 
         @JvmName("createWithStartTime")

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/SpanOptions.kt
@@ -23,7 +23,7 @@ public class SpanOptions private constructor(
     parentContext: SpanContext?,
     public val makeContext: Boolean,
     isFirstClass: Boolean,
-    instrumentRendering: Boolean,
+    spanMetrics: SpanMetrics?,
 ) {
     private val _startTime: Long = startTime
 
@@ -31,7 +31,7 @@ public class SpanOptions private constructor(
 
     private val _parentContext: SpanContext? = parentContext
 
-    private val _instrumentRendering: Boolean = instrumentRendering
+    private val _spanMetrics: SpanMetrics? = spanMetrics
 
     /**
      * Return the time (relative to [SystemClock.elapsedRealtimeNanos]) that new `Span`s will
@@ -52,7 +52,10 @@ public class SpanOptions private constructor(
             else SpanContext.current
 
     public val instrumentRendering: Boolean?
-        get() = _instrumentRendering.takeIf { isOptionSet(OPT_INSTRUMENT_RENDERING) }
+        get() = _spanMetrics?.rendering
+
+    public val spanMetrics: SpanMetrics?
+        get() = _spanMetrics
 
     /**
      * Override the start time of new `Span`s created with these `SpanOptions`. This is useful when
@@ -66,7 +69,7 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         _isFirstClass,
-        _instrumentRendering,
+        _spanMetrics
     )
 
     public fun within(parentContext: SpanContext?): SpanOptions = SpanOptions(
@@ -75,7 +78,7 @@ public class SpanOptions private constructor(
         parentContext,
         makeContext,
         _isFirstClass,
-        _instrumentRendering,
+        _spanMetrics
     )
 
     public fun makeCurrentContext(makeContext: Boolean): SpanOptions = SpanOptions(
@@ -84,7 +87,7 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         _isFirstClass,
-        _instrumentRendering,
+        _spanMetrics
     )
 
     public fun setFirstClass(isFirstClass: Boolean): SpanOptions = SpanOptions(
@@ -93,16 +96,35 @@ public class SpanOptions private constructor(
         _parentContext,
         makeContext,
         isFirstClass,
-        _instrumentRendering,
+        _spanMetrics
     )
 
-    public fun withRenderingMetrics(instrumentRendering: Boolean): SpanOptions = SpanOptions(
-        optionsSet or OPT_INSTRUMENT_RENDERING,
+    @Deprecated(
+        message = "use spanMetrics.rendering",
+        replaceWith = ReplaceWith(
+            expression = "withMetrics(SpanMetrics(rendering = instrumentRendering))",
+            imports = ["com.bugsnag.android.performance.SpanMetrics"],
+        ),
+    )
+    public fun withRenderingMetrics(instrumentRendering: Boolean): SpanOptions {
+        return if (_spanMetrics != null) {
+            withMetrics(
+                SpanMetrics(
+                    rendering = instrumentRendering,
+                    cpu = _spanMetrics.cpu,
+                    memory = _spanMetrics.memory,
+                )
+            )
+        } else withMetrics(SpanMetrics(rendering = instrumentRendering))
+    }
+
+    public fun withMetrics(spanMetrics: SpanMetrics?): SpanOptions = SpanOptions(
+        optionsSet or OPT_METRICS,
         _startTime,
         _parentContext,
         makeContext,
         _isFirstClass,
-        instrumentRendering,
+        spanMetrics
     )
 
     override fun equals(other: Any?): Boolean {
@@ -127,8 +149,8 @@ public class SpanOptions private constructor(
         ) return false
 
         @Suppress("RedundantIf")
-        if ((isOptionSet(OPT_INSTRUMENT_RENDERING) || other.isOptionSet(OPT_INSTRUMENT_RENDERING))
-            && this.instrumentRendering != other.instrumentRendering
+        if ((isOptionSet(OPT_METRICS) || other.isOptionSet(OPT_METRICS))
+            && this.spanMetrics != other.spanMetrics
         ) return false
 
         return true
@@ -139,7 +161,6 @@ public class SpanOptions private constructor(
         result = 31 * result + (parentContext?.hashCode() ?: 0)
         result = 31 * result + makeContext.hashCode()
         result = 31 * result + _isFirstClass.hashCode()
-        result = 31 * result + _instrumentRendering.hashCode()
         return result
     }
 
@@ -168,8 +189,8 @@ public class SpanOptions private constructor(
             append("isFirstClass=").append(_isFirstClass).append(',')
         }
 
-        if (isOptionSet(OPT_INSTRUMENT_RENDERING)) {
-            append("instrumentRendering=").append(instrumentRendering).append(',')
+        if (isOptionSet(OPT_METRICS)) {
+            append("metrics=").append(_spanMetrics).append(',')
         }
 
         // if we are here, the last character will always be ',' - replace it with ']'
@@ -185,7 +206,7 @@ public class SpanOptions private constructor(
         private const val OPT_PARENT_CONTEXT = 2
         private const val OPT_MAKE_CONTEXT = 4
         private const val OPT_IS_FIRST_CLASS = 8
-        private const val OPT_INSTRUMENT_RENDERING = 16
+        private const val OPT_METRICS = 16
 
         /**
          * The default set of `SpanOptions` with no overrides set. Use this as a starting-point to
@@ -199,7 +220,7 @@ public class SpanOptions private constructor(
                 null,
                 makeContext = true,
                 isFirstClass = false,
-                instrumentRendering = true,
+                null
             )
 
         @JvmName("createWithStartTime")
@@ -224,5 +245,11 @@ public class SpanOptions private constructor(
         @JvmStatic
         public fun withRenderingMetrics(instrumentRendering: Boolean): SpanOptions =
             DEFAULTS.withRenderingMetrics(instrumentRendering)
+
+        @JvmName("createWithMetrics")
+        @JvmOverloads
+        @JvmStatic
+        public fun withMetrics(metrics: SpanMetrics? = SpanMetrics(true, true, true)): SpanOptions =
+            DEFAULTS.withMetrics(metrics)
     }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -101,7 +101,7 @@ public class InstrumentedAppState {
             (bootstrapSpanProcessor as? ForwardingSpanProcessor)?.discard()
         }
 
-        if (!configuration.autoInstrumentRendering && framerateMetricsSource != null) {
+        if (!configuration.enabledMetrics.rendering && framerateMetricsSource != null) {
             spanFactory.framerateMetricsSource = null
             app.unregisterActivityLifecycleCallbacks(framerateMetricsSource)
             framerateMetricsSource = null

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ImmutableConfig.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/processing/ImmutableConfig.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.os.Build
 import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.EnabledMetrics
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.NetworkRequestInstrumentationCallback
 import com.bugsnag.android.performance.PerformanceConfiguration
@@ -23,7 +24,7 @@ internal data class ImmutableConfig(
     val endpoint: String,
     val autoInstrumentAppStarts: Boolean,
     val autoInstrumentActivities: AutoInstrument,
-    val autoInstrumentRendering: Boolean,
+    val enabledMetrics: EnabledMetrics,
     val serviceName: String,
     val releaseStage: String,
     val enabledReleaseStages: Set<String>?,
@@ -50,7 +51,7 @@ internal data class ImmutableConfig(
             ?: "https://${configuration.apiKey}.otlp.bugsnag.com/v1/traces",
         configuration.autoInstrumentAppStarts,
         configuration.autoInstrumentActivities,
-        configuration.autoInstrumentRendering,
+        configuration.enabledMetrics.copy(),
         configuration.serviceName ?: configuration.context.packageName,
         getReleaseStage(configuration),
         configuration.enabledReleaseStages?.toSet(),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ImmutableConfigTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.EnabledMetrics
 import com.bugsnag.android.performance.Logger
 import com.bugsnag.android.performance.OnSpanEndCallback
 import com.bugsnag.android.performance.PerformanceConfiguration
@@ -26,6 +27,9 @@ import org.mockito.kotlin.verify
 import java.util.regex.Pattern
 
 class ImmutableConfigTest {
+
+    val enabledMetricsSample: EnabledMetrics = EnabledMetrics(true)
+
     @Before
     fun setupLogger() {
         Logger.delegate = NoopLogger
@@ -39,7 +43,8 @@ class ImmutableConfigTest {
             enabledReleaseStages = setOf("staging", "production")
             autoInstrumentAppStarts = false
             autoInstrumentActivities = AutoInstrument.START_ONLY
-            autoInstrumentRendering = false
+            enabledMetrics = enabledMetricsSample
+            enabledMetrics.rendering = false
             versionCode = 543L
             appVersion = "9.8.1"
             tracePropagationUrls = emptySet<Pattern>()
@@ -51,13 +56,14 @@ class ImmutableConfigTest {
         assertEquals(perfConfig.apiKey, immutableConfig.apiKey)
         assertEquals(perfConfig.endpoint, immutableConfig.endpoint)
         assertEquals(perfConfig.autoInstrumentAppStarts, immutableConfig.autoInstrumentAppStarts)
-        assertEquals(perfConfig.autoInstrumentRendering, immutableConfig.autoInstrumentRendering)
+        assertEquals(perfConfig.enabledMetrics.rendering, immutableConfig.enabledMetrics.rendering)
         assertEquals(TEST_PACKAGE_NAME, immutableConfig.serviceName)
         assertEquals(perfConfig.releaseStage, immutableConfig.releaseStage)
         assertEquals(perfConfig.enabledReleaseStages, immutableConfig.enabledReleaseStages)
         assertEquals(perfConfig.versionCode, immutableConfig.versionCode)
         assertEquals(perfConfig.appVersion, immutableConfig.appVersion)
         assertEquals(perfConfig.tracePropagationUrls, immutableConfig.tracePropagationUrls)
+        assertEquals(perfConfig.enabledMetrics, immutableConfig.enabledMetrics)
     }
 
     @Test
@@ -204,6 +210,7 @@ class ImmutableConfigTest {
             versionCode = 543L
             appVersion = "9.8.1"
             tracePropagationUrls = emptySet<Pattern>()
+            enabledMetrics = enabledMetricsSample
         }
 
         val spanEndCallback1 = DummyCallback()

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/ResourceAttributesTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.performance.internal
 
 import android.app.Application
 import com.bugsnag.android.performance.AutoInstrument
+import com.bugsnag.android.performance.EnabledMetrics
 import com.bugsnag.android.performance.internal.processing.ImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -26,7 +27,7 @@ class ResourceAttributesTest {
             "",
             true,
             AutoInstrument.FULL,
-            true,
+            EnabledMetrics(true, true, true),
             "bugsnag.performance.android",
             "development",
             setOf("production"),
@@ -70,7 +71,7 @@ class ResourceAttributesTest {
             "",
             true,
             AutoInstrument.FULL,
-            true,
+            EnabledMetrics(true, true, true),
             "bugsnag.performance.android",
             "production",
             setOf("production"),

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.performance.internal
 
 import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.SpanMetrics
 import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
 import com.bugsnag.android.performance.internal.framerate.TimestampPairBuffer
@@ -20,6 +21,11 @@ class SpanFactoryTest {
     private lateinit var frameMetrics: MetricSource<FramerateMetricsSnapshot>
 
     private lateinit var spanFactory: SpanFactory
+
+    private val spanMetricsWithRendering =
+        SpanMetrics(rendering = true, cpu = false, memory = false)
+    private val spanMetricsWithoutRendering =
+        SpanMetrics(rendering = false, cpu = false, memory = false)
 
     @Before
     fun setup() {
@@ -55,7 +61,7 @@ class SpanFactoryTest {
                 "Scrolling",
                 baseOptions
                     .setFirstClass(false)
-                    .withRenderingMetrics(true),
+                    .withMetrics(spanMetricsWithRendering),
             ).metrics,
         )
 
@@ -65,7 +71,17 @@ class SpanFactoryTest {
                 "Scrolling",
                 baseOptions
                     .setFirstClass(true)
-                    .withRenderingMetrics(true),
+                    .withMetrics(spanMetricsWithRendering),
+            ).metrics,
+        )
+
+        assertNotNull(
+            "setFirstClass(true).withRenderingMetrics(true) should have rendering metrics",
+            spanFactory.createCustomSpan(
+                "Scrolling",
+                baseOptions
+                    .setFirstClass(true)
+                    .withMetrics(null),
             ).metrics,
         )
 
@@ -84,6 +100,16 @@ class SpanFactoryTest {
                 baseOptions
                     .setFirstClass(true)
                     .withRenderingMetrics(false),
+            ).metrics,
+        )
+
+        assertNull(
+            "SpanOptions.setFirstClass(true).withRenderingMetrics(false) should not have rendering metrics",
+            spanFactory.createCustomSpan(
+                "Scrolling",
+                baseOptions
+                    .setFirstClass(true)
+                    .withMetrics(spanMetricsWithoutRendering),
             ).metrics,
         )
     }


### PR DESCRIPTION
## Goal
Introduce device metrics configuration options to allow configuration of rendering, cpu and memory metrics capturing and reporting.

## Changeset

- Add `EnableMetrics` to `PerformanceConfiguration` and `SpanMetrics` to `SpanOptions`. Both metrics class contain rendering, CPU and memory enable options allowing either global or per-span configuration.
- Deprecated the older `instrumentRendering` configuration options (with suggested replacements).

## Testing
Updated existing tests to use the new options