### PR TITLE
Add LoadingIndicator composable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Changes
+
+* Added LoadingIndicator composable as a way to easily extend ViewLoad end times to interactivity
+  [https://github.com/bugsnag/bugsnag-android-performance/pull/336](https://github.com/bugsnag/bugsnag-android-performance/pull/336)
+
 ## 1.11.0 (2025-01-20)
 
 ### Changes

--- a/bugsnag-plugin-android-performance-compose/detekt-baseline.xml
+++ b/bugsnag-plugin-android-performance-compose/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>FunctionNaming:LoadingIndicator.kt$@Composable public fun LoadingIndicator( modifier: Modifier = Modifier, content: (@Composable BoxScope.() -> Unit)? = null, )</ID>
     <ID>FunctionNaming:MeasuredComposable.kt$@Composable public fun MeasuredComposable( name: String, modifier: Modifier = Modifier, content: @Composable BoxScope.() -> Unit, )</ID>
     <ID>MatchingDeclarationName:MeasuredComposable.kt$ValueContainer&lt;T></ID>
   </CurrentIssues>

--- a/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/BugsnagPerformanceHooks.java
+++ b/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/BugsnagPerformanceHooks.java
@@ -19,4 +19,14 @@ class BugsnagPerformanceHooks {
         forwardingSpanProcessor.forwardTo(target);
         return target.takeBatch();
     }
+
+    static long durationOf(SpanImpl span) {
+        long endTime = span.getEndTime$internal();
+
+        if (endTime <= 0) {
+            return 0;
+        }
+
+        return endTime - span.getStartTime$internal();
+    }
 }

--- a/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/BugsnagPerformanceTestingExtensions.kt
+++ b/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/BugsnagPerformanceTestingExtensions.kt
@@ -12,3 +12,9 @@ import com.bugsnag.android.performance.internal.SpanImpl
 fun BugsnagPerformance.takeCurrentBatch(): Collection<SpanImpl> {
     return BugsnagPerformanceHooks.takeCurrentBatch()
 }
+
+val Span.duration: Long
+    get() = BugsnagPerformanceHooks.durationOf(this as SpanImpl)
+
+val Span.durationMillis: Long
+    get() = duration / 1_000_000L

--- a/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/compose/LoadingIndicatorTest.kt
+++ b/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/compose/LoadingIndicatorTest.kt
@@ -1,0 +1,108 @@
+package com.bugsnag.android.performance.compose
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bugsnag.android.performance.BugsnagPerformance
+import com.bugsnag.android.performance.Span
+import com.bugsnag.android.performance.ViewType
+import com.bugsnag.android.performance.durationMillis
+import com.bugsnag.android.performance.takeCurrentBatch
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val LOADING_MESSAGE = "Loading..."
+private const val VIEW_LOAD_EXTENDED_TIME = 100L
+
+@RunWith(AndroidJUnit4::class)
+class LoadingIndicatorTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setupTest() {
+        // clear any pending spans from the batch before each test runs
+        BugsnagPerformance.takeCurrentBatch()
+    }
+
+    @Test
+    fun extendsViewLoadSpanWithContent() = testExtendedViewLoad {
+        LoadingIndicatorWrapper {
+            LoadingIndicator {
+                Text(LOADING_MESSAGE)
+            }
+        }
+    }
+
+    @Test
+    fun extendsViewLoadSpanWithoutContent() = testExtendedViewLoad {
+        LoadingIndicatorWrapper {
+            LoadingIndicator()
+            Text(LOADING_MESSAGE)
+        }
+    }
+
+    private inline fun testExtendedViewLoad(crossinline loadingIndicator: @Composable () -> Unit) =
+        runBlocking {
+            var viewLoadSpan: Span? = null
+
+            composeTestRule.setContent {
+                viewLoadSpan = BugsnagPerformance.startViewLoadSpan(
+                    ViewType.COMPOSE,
+                    "TestView",
+                )
+
+                loadingIndicator()
+            }
+
+            composeTestRule.awaitIdle()
+            viewLoadSpan!!.end()
+
+            assertTrue("ViewLoad should have ended", viewLoadSpan!!.isEnded())
+
+            with(composeTestRule) {
+                // wait for the LoadingIndicator to appear
+                waitUntil {
+                    onAllNodes(hasText(LOADING_MESSAGE)).fetchSemanticsNodes().isNotEmpty()
+                }
+                // wait for it to finish and disappear again
+                waitUntil { onAllNodes(hasText(LOADING_MESSAGE)).fetchSemanticsNodes().isEmpty() }
+                awaitIdle()
+            }
+
+            assertTrue(
+                "LoadingIndicator should have extended the ViewLoad " +
+                    "duration >=${VIEW_LOAD_EXTENDED_TIME}ms " +
+                    "(was ${viewLoadSpan!!.durationMillis}ms)",
+                viewLoadSpan!!.durationMillis >= VIEW_LOAD_EXTENDED_TIME,
+            )
+        }
+}
+
+@Composable
+private fun LoadingIndicatorWrapper(loadingIndicator: @Composable () -> Unit) {
+    var loading by remember { mutableStateOf(true) }
+
+    if (loading) {
+        loadingIndicator()
+    }
+
+    LaunchedEffect(Unit) {
+        // we actually wait slightly longer than expected to account for slight differences in the
+        // clocks used, and rounding losses in the nano->milli conversion
+        delay(VIEW_LOAD_EXTENDED_TIME + (VIEW_LOAD_EXTENDED_TIME / 4))
+        loading = false
+    }
+}

--- a/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/compose/MeasuredComposableTest.kt
+++ b/bugsnag-plugin-android-performance-compose/src/androidTest/java/com/bugsnag/android/performance/compose/MeasuredComposableTest.kt
@@ -26,7 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class ComposeTest {
+internal class MeasuredComposableTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
@@ -37,7 +37,7 @@ internal class ComposeTest {
     }
 
     @Test
-    fun myUIComponentTest() {
+    fun measuredScreenLoad() {
         composeTestRule.setContent {
             MeasuredComposable(name = "Parent") {
                 LoginScreen()

--- a/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/LoadingIndicator.kt
+++ b/bugsnag-plugin-android-performance-compose/src/main/java/com/bugsnag/android/performance/compose/LoadingIndicator.kt
@@ -1,0 +1,63 @@
+package com.bugsnag.android.performance.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import com.bugsnag.android.performance.internal.BugsnagPerformanceInternals
+import com.bugsnag.android.performance.internal.SpanCategory
+
+private const val CONDITION_TIMEOUT = 100L
+
+/**
+ * A LoadingIndicator is an invisible composable that will block any ViewLoad span from ending
+ * until the LoadingIndicator has been disposed. This provides an easy and effective way to
+ * accurately measure the time-to-interactivity for any Activity, Fragment or composable (when
+ * using [MeasuredComposable]).
+ *
+ * A screen may include any number of LoadingIndicators, and the screen is considered to be
+ * "loading" as long as at least one remains active.
+ *
+ * Typically this composable can wrap or be embedded within the content of a loading placeholder or
+ * loading status indicator. For example:
+ *
+ * ```kotlin
+ * if (loading) {
+ *   LoadingIndicator {
+ *     CircularProgressIndicator()
+ *   }
+ * }
+ *
+ * // LoadingIndicator can also be embedded within a placeholder composable
+ * @Composable
+ * fun UserProfilePlaceholder() {
+ *   LoadingIndicator()
+ *   // other placeholder content
+ * }
+ * ```
+ *
+ * @param modifier any modifier to be passed down to the Box that will wrap [content]
+ * @param content option content for this LoadingIndicator
+ */
+@Composable
+public fun LoadingIndicator(
+    modifier: Modifier = Modifier,
+    content: (@Composable BoxScope.() -> Unit)? = null,
+) {
+    DisposableEffect(Unit) {
+        val contextStack = BugsnagPerformanceInternals.currentSpanContextStack
+        val viewLoad = contextStack.current(SpanCategory.VIEW_LOAD)
+        val condition = viewLoad?.block(CONDITION_TIMEOUT)?.apply { upgrade() }
+
+        onDispose {
+            condition?.close()
+        }
+    }
+
+    if (content != null) {
+        Box(modifier) {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Allow Compose UIs to easily mark their real "loading time" using a simple `LoadingIndicator` composable.

## Design
As long as at least one `LoadingIndicator` is part of composition any active ViewLoad will remain open. Once all `LoadingIndicator`s have been disposed the `ViewLoad` ends at the timestamp of the last disposal.

## Testing
Manual testing and a new unit test