### PR TITLE
memory metrics

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/InstrumentedAppState.kt
@@ -10,6 +10,8 @@ import com.bugsnag.android.performance.internal.instrumentation.AbstractActivity
 import com.bugsnag.android.performance.internal.instrumentation.ActivityLifecycleInstrumentation
 import com.bugsnag.android.performance.internal.instrumentation.ForegroundState
 import com.bugsnag.android.performance.internal.instrumentation.LegacyActivityInstrumentation
+import com.bugsnag.android.performance.internal.metrics.AbstractSampledMetricsSource.Companion.SAMPLE_DELAY_ONE_SECOND
+import com.bugsnag.android.performance.internal.metrics.MemoryMetricsSource
 import com.bugsnag.android.performance.internal.processing.ForwardingSpanProcessor
 import com.bugsnag.android.performance.internal.processing.ImmutableConfig
 import com.bugsnag.android.performance.internal.processing.Tracer
@@ -38,6 +40,7 @@ public class InstrumentedAppState {
         private set
 
     private var framerateMetricsSource: FramerateMetricsSource? = null
+    private var memoryMetricsSource: MemoryMetricsSource? = null
 
     @get:JvmName("getConfig\$internal")
     internal var config: ImmutableConfig? = null
@@ -50,6 +53,9 @@ public class InstrumentedAppState {
 
         app = application
         app.registerActivityLifecycleCallbacks(activityInstrumentation)
+
+        memoryMetricsSource = MemoryMetricsSource(application, SAMPLE_DELAY_ONE_SECOND)
+        spanFactory.memoryMetricsSource = memoryMetricsSource
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             framerateMetricsSource = FramerateMetricsSource()

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -11,7 +11,9 @@ import com.bugsnag.android.performance.SpanOptions
 import com.bugsnag.android.performance.ViewType
 import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapshot
 import com.bugsnag.android.performance.internal.integration.NotifierIntegration
+import com.bugsnag.android.performance.internal.metrics.AbstractSampledMetricsSource.Companion.SAMPLE_DELAY_ONE_SECOND
 import com.bugsnag.android.performance.internal.metrics.CpuMetricsSource
+import com.bugsnag.android.performance.internal.metrics.MemoryMetricsSource
 import com.bugsnag.android.performance.internal.metrics.MetricSource
 import com.bugsnag.android.performance.internal.metrics.SpanMetricsSnapshot
 import com.bugsnag.android.performance.internal.processing.AttributeLimits
@@ -33,6 +35,7 @@ public class SpanFactory(
     internal var attributeLimits: AttributeLimits? = null
     internal var framerateMetricsSource: MetricSource<FramerateMetricsSnapshot>? = null
     internal var cpuMetricsSource: CpuMetricsSource? = null
+    internal var memoryMetricsSource: MemoryMetricsSource? = null
 
     internal fun configure(
         spanProcessor: SpanProcessor,
@@ -45,9 +48,11 @@ public class SpanFactory(
 
         this.spanTaskWorker.start()
 
-        val cpuMetricsSource = CpuMetricsSource(samplingDelayMs = ONE_SECOND)
-        this.spanTaskWorker.addSampler(cpuMetricsSource, ONE_SECOND)
+        val cpuMetricsSource = CpuMetricsSource(samplingDelayMs = SAMPLE_DELAY_ONE_SECOND)
+        this.spanTaskWorker.addSampler(cpuMetricsSource, SAMPLE_DELAY_ONE_SECOND)
         this.cpuMetricsSource = cpuMetricsSource
+
+        memoryMetricsSource?.let { this.spanTaskWorker.addSampler(it, SAMPLE_DELAY_ONE_SECOND) }
     }
 
     @JvmOverloads
@@ -275,16 +280,24 @@ public class SpanFactory(
             isFirstClass == true
         }
 
-        return if (localRenderingMetricsSource != null || localCpuMetricsSource != null) {
-            SpanMetricsSnapshot(localRenderingMetricsSource, localCpuMetricsSource)
+        val localMemoryMetricsSource = memoryMetricsSource?.takeIf {
+            isFirstClass == true
+        }
+
+        return if (
+            localRenderingMetricsSource != null ||
+            localCpuMetricsSource != null ||
+            localMemoryMetricsSource != null
+        ) {
+            SpanMetricsSnapshot(
+                localRenderingMetricsSource,
+                localCpuMetricsSource,
+                localMemoryMetricsSource,
+            )
         } else {
             null
         }
     }
 
     private fun UUID.isValidTraceId() = mostSignificantBits != 0L || leastSignificantBits != 0L
-
-    private companion object {
-        const val ONE_SECOND = 1000L
-    }
 }

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/AbstractSampledMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/AbstractSampledMetricsSource.kt
@@ -49,6 +49,10 @@ internal abstract class AbstractSampledMetricsSource<T : LinkedMetricsSnapshot<T
             }
         }
     }
+
+    internal companion object {
+        const val SAMPLE_DELAY_ONE_SECOND = 1000L
+    }
 }
 
 internal open class LinkedMetricsSnapshot<T : LinkedMetricsSnapshot<T>> {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MemoryMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MemoryMetricsSource.kt
@@ -1,0 +1,154 @@
+package com.bugsnag.android.performance.internal.metrics
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Process
+import android.util.AndroidException
+import com.bugsnag.android.performance.internal.BugsnagClock
+import com.bugsnag.android.performance.internal.getActivityManager
+import com.bugsnag.android.performance.internal.util.FixedRingBuffer
+
+internal class MemoryMetricsSource(
+    private val appContext: Context,
+    samplingDelayMs: Long,
+    maxSampleCount: Int = DEFAULT_SAMPLE_COUNT,
+) : AbstractSampledMetricsSource<MemoryMetricsSnapshot>(samplingDelayMs), Runnable {
+    private val buffer = FixedRingBuffer(maxSampleCount) { MemorySampleData() }
+
+    private val runtime = Runtime.getRuntime()
+    private val activityManager = appContext.getActivityManager()
+
+    private val deviceMemory by lazy {
+        calculateTotalMemory()
+    }
+
+    override fun captureSample() {
+        val timestamp = BugsnagClock.currentUnixNanoTime()
+        buffer.put { sample ->
+            sample.freeMemory = runtime.freeMemory()
+            sample.totalMemory = runtime.totalMemory()
+            sample.timestamp = timestamp
+
+            val memoryInfo = activityManager?.getProcessMemoryInfo(intArrayOf(Process.myPid()))
+            val memoryInfoSample = memoryInfo?.getOrNull(0)?.takeIf { memoryInfo.size == 1 }
+            if (memoryInfoSample != null) {
+                sample.pss =
+                    (memoryInfoSample.dalvikPss + memoryInfoSample.nativePss + memoryInfoSample.otherPss) * KILOBYTE
+            } else {
+                sample.pss = -1
+            }
+        }
+    }
+
+    override fun populatedWaitingTargets() {
+        val endIndex = buffer.currentIndex
+        takeSnapshotsAwaitingSample().forEach { snapshot ->
+            val target = snapshot.target
+            if (target != null) {
+                val from = snapshot.bufferIndex
+                val to = endIndex
+                val sampleCount = buffer.countItemsBetween(from, to)
+
+                val deviceMemorySamples = LongArray(sampleCount)
+                var deviceUsedMemoryTotal = 0L
+                var deviceUsedMemoryCount = 0
+
+                val artMemoryTimestamps = LongArray(sampleCount)
+                val artUsedMemorySamples = LongArray(sampleCount)
+                var artSizeMemory = 0L
+                var artUsedMemoryTotal = 0L
+                var artUsedMemoryCount = 0
+
+                buffer.forEachIndexed(from, to) { index, sample ->
+                    artMemoryTimestamps[index] = sample.timestamp
+                    deviceMemorySamples[index] = sample.pss
+
+                    val artUsedMemory = sample.totalMemory - sample.freeMemory
+                    if (artUsedMemory > 0) {
+                        artUsedMemorySamples[index] = artUsedMemory
+                        artUsedMemoryTotal += artUsedMemory
+                        artUsedMemoryCount++
+                    }
+
+                    if (sample.pss > 0) {
+                        deviceUsedMemoryTotal += sample.pss
+                        deviceUsedMemoryCount++
+                    }
+
+                    if (sample.totalMemory > artSizeMemory) {
+                        artSizeMemory = sample.totalMemory
+                    }
+                }
+
+                target.attributes["bugsnag.system.memory.spaces.space_names"] =
+                    SPACE_NAMES
+
+                deviceMemory?.also {
+                    target.attributes["bugsnag.device.physical_device_memory"] = it
+                    target.attributes["bugsnag.system.memory.spaces.device.size"] = it
+                }
+                target.attributes["bugsnag.system.memory.spaces.device.used"] = deviceMemorySamples
+                target.attributes["bugsnag.system.memory.spaces.device.mean"] =
+                    deviceUsedMemoryTotal / deviceUsedMemoryCount
+
+                target.attributes["bugsnag.system.memory.spaces.art.size"] = artSizeMemory
+                target.attributes["bugsnag.system.memory.spaces.art.used"] = artUsedMemorySamples
+                target.attributes["bugsnag.system.memory.spaces.art.mean"] =
+                    artUsedMemoryTotal / artUsedMemoryCount
+                target.attributes["bugsnag.system.memory.timestamps"] = artMemoryTimestamps
+
+                snapshot.blocking?.cancel()
+            }
+        }
+    }
+
+    override fun createStartMetrics(): MemoryMetricsSnapshot {
+        return MemoryMetricsSnapshot(buffer.currentIndex)
+    }
+
+    private fun calculateTotalMemory(): Long? {
+        val totalMemory = appContext.getActivityManager()
+            ?.let { am -> ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) } }
+            ?.totalMem
+        if (totalMemory != null) {
+            return totalMemory
+        }
+
+        // we try falling back to a reflective API
+        return runCatching {
+            @Suppress("PrivateApi")
+            AndroidException::class.java.getDeclaredMethod("getTotalMemory").invoke(null) as Long?
+        }.getOrNull()
+    }
+
+    private data class MemorySampleData(
+        @JvmField
+        var freeMemory: Long = 0L,
+
+        @JvmField
+        var totalMemory: Long = 0L,
+
+        @JvmField
+        var pss: Long = 0L,
+
+        @JvmField
+        var timestamp: Long = 0L,
+    )
+
+    private companion object {
+        /**
+         * Default number of memory samples that can be stored at once (10 minutes, with 1
+         * sample each second).
+         */
+        const val DEFAULT_SAMPLE_COUNT = 60 * 10
+
+        const val KILOBYTE = 1024L
+
+        val SPACE_NAMES = arrayOf("device", "art")
+    }
+}
+
+internal data class MemoryMetricsSnapshot(
+    @JvmField
+    internal val bufferIndex: Int,
+) : LinkedMetricsSnapshot<MemoryMetricsSnapshot>()

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/SpanMetricsSnapshot.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/SpanMetricsSnapshot.kt
@@ -9,6 +9,7 @@ import com.bugsnag.android.performance.internal.framerate.FramerateMetricsSnapsh
 internal class SpanMetricsSnapshot(
     private val renderingMetricsSource: MetricSource<FramerateMetricsSnapshot>?,
     private val cpuMetricsSource: MetricSource<CpuMetricsSnapshot>?,
+    private val memoryMetricsSource: MetricSource<MemoryMetricsSnapshot>?,
 ) {
     private val renderingMetricsSnapshot: FramerateMetricsSnapshot? =
         renderingMetricsSource?.createStartMetrics()
@@ -16,8 +17,12 @@ internal class SpanMetricsSnapshot(
     private val cpuMetricsCpuMetricsSnapshot: CpuMetricsSnapshot? =
         cpuMetricsSource?.createStartMetrics()
 
+    private val memoryMetricsMemoryMetricsSnapshot: MemoryMetricsSnapshot? =
+        memoryMetricsSource?.createStartMetrics()
+
     fun finish(spanImpl: SpanImpl) {
         renderingMetricsSnapshot?.let { renderingMetricsSource?.endMetrics(it, spanImpl) }
         cpuMetricsCpuMetricsSnapshot?.let { cpuMetricsSource?.endMetrics(it, spanImpl) }
+        memoryMetricsMemoryMetricsSnapshot?.let { memoryMetricsSource?.endMetrics(it, spanImpl) }
     }
 }

--- a/features/frame_metrics.feature
+++ b/features/frame_metrics.feature
@@ -19,6 +19,10 @@ Scenario: Slow & Frozen Frames are reported
   * the "Slow Animation" span has array attribute named "bugsnag.system.cpu_measures_main_thread"
   * the "Slow Animation" span has array attribute named "bugsnag.system.cpu_measures_timestamps"
 
+  * the "Slow Animation" span has array attribute named "bugsnag.system.memory.spaces.device.used"
+  * the "Slow Animation" span has array attribute named "bugsnag.system.memory.spaces.art.used"
+  * the "Slow Animation" span has array attribute named "bugsnag.system.memory.timestamps"
+
 Scenario: Rending Instrumentation can be turned off
   When I run "FrameMetricsScenario" configured as "disableInstrumentation"
   * I wait to receive a trace


### PR DESCRIPTION
## Goal
Add sampled memory metrics to all `firstClass` spans.

## Design
Added the new `MemoryMetricsSource`  at a fixed interval (1 second) and adds all relevant Memory android run time use and device use to all `firstClass` spans.

## Testing
Updated existing end-to-end tests to expect memory metrics.