### PR TITLE
Allow cancelled/ended conditions to be upgraded

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanImpl.kt
@@ -440,17 +440,15 @@ public class SpanImpl internal constructor(
             }
         }
 
-        override fun upgrade(): SpanContext? {
+        override fun upgrade(): SpanContext {
             synchronized(span) {
-                if (!isValid) {
-                    return null
+                if (!isUpgraded) {
+                    span.timeoutExecutor.cancelTimeout(this)
+                    isUpgraded = true
                 }
-
-                span.timeoutExecutor.cancelTimeout(this)
-                isUpgraded = true
-
-                return span
             }
+
+            return span
         }
 
         override fun run() {

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanBlockingTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanBlockingTest.kt
@@ -5,7 +5,6 @@ import com.bugsnag.android.performance.test.TestSpanFactory
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -131,9 +130,7 @@ class SpanBlockingTest {
         assertFalse(span.isBlocked())
         assertTrue(spanProcessor.isEmpty())
 
-        assertNull(condition1!!.upgrade())
-
-        condition1.close()
+        condition1!!.close()
         assertFalse(span.isOpen())
         assertFalse(span.isBlocked())
         assertTrue(spanProcessor.isEmpty())

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -92,6 +92,7 @@ class MainActivity : AppCompatActivity() {
         log("MainActivity.onCreate complete")
     }
 
+    @Suppress("deprecated")
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,


### PR DESCRIPTION
## Goal
Allow span `Condition`s that have been cancelled to also be "upgraded" in order for new children to be added.

## Testing
Updated tests to handle the new case