### PR TITLE
Use Maze Runner Appium API

### DIFF
--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -105,15 +105,16 @@ end
 When("I relaunch the app after shutdown") do
   max_attempts = 20
   attempts = 0
-  state = Maze.driver.app_state('com.bugsnag.mazeracer')
+  manager = Maze::Api::Appium::AppManager.new
+  state = manager.state
   until (attempts >= max_attempts) || state == :not_running
     attempts += 1
-    state = Maze.driver.app_state('com.bugsnag.mazeracer')
+    state = manager.state
     sleep 0.5
   end
   $logger.warn "App state #{state} instead of not_running after 10s" unless state == :not_running
 
-  Maze.driver.activate_app Maze.driver.app_id
+  manager.activate
 end
 
 def spans_from_request_list list


### PR DESCRIPTION
## Goal

Use the Maze Runner Appium API instead of `Maze.driver` directly, so that failed Appium drivers are detected and reported.

## Testing

Covered by CI.