### PR TITLE
Fix the CPU metrics property names

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/CpuMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/CpuMetricsSource.kt
@@ -97,12 +97,12 @@ internal class CpuMetricsSource(
                 target.attributes["bugsnag.system.cpu_measures_timestamps"] = cpuTimestamps
 
                 if (cpuUseSampleCount > 0) {
-                    target.attributes["bugsnag.metrics.cpu_mean_total"] =
+                    target.attributes["bugsnag.system.cpu_mean_total"] =
                         cpuUseTotal / cpuUseSampleCount
                 }
 
                 if (mainThreadSampleCount > 0) {
-                    target.attributes["bugsnag.metrics.cpu_mean_main_thread"] =
+                    target.attributes["bugsnag.system.cpu_mean_main_thread"] =
                         mainThreadCpuTotal / mainThreadSampleCount
                 }
 

--- a/features/device_metrics.feature
+++ b/features/device_metrics.feature
@@ -5,8 +5,8 @@ Feature: Device Metrics
     * I wait to receive a trace
 
     # Check CPU Metrics on first class spans
-    * the "FirstClass" span has double attribute named "bugsnag.metrics.cpu_mean_total"
-    * the "FirstClass" span has double attribute named "bugsnag.metrics.cpu_mean_main_thread"
+    * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_total"
+    * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_main_thread"
     * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_overhead"
 
     * the "FirstClass" span has array attribute named "bugsnag.system.cpu_measures_total"
@@ -27,8 +27,8 @@ Feature: Device Metrics
     * the "FirstClass" span has array attribute named "bugsnag.system.memory.timestamps"
 
     # Check that no metrics are reported on the "No Metrics" span
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -46,8 +46,8 @@ Feature: Device Metrics
     * the "No Metrics" span has no "bugsnag.system.memory.timestamps" attribute
     
     # Check that no metrics are reported on the "Not FirstClass" span
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -65,8 +65,8 @@ Feature: Device Metrics
     * the "Not FirstClass" span has no "bugsnag.system.memory.timestamps" attribute
     
     # Check that only CPU Metrics are recorded on the "CPU Metrics Only" span
-    * the "CPU Metrics Only" span has double attribute named "bugsnag.metrics.cpu_mean_total"
-    * the "CPU Metrics Only" span has double attribute named "bugsnag.metrics.cpu_mean_main_thread"
+    * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_total"
+    * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_main_thread"
     * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_overhead"
 
     * the "CPU Metrics Only" span has array attribute named "bugsnag.system.cpu_measures_total"
@@ -85,8 +85,8 @@ Feature: Device Metrics
     * the "CPU Metrics Only" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that only Memory Metrics are recorded on the "Memory Metrics Only" span
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -109,8 +109,8 @@ Feature: Device Metrics
     * I wait to receive a trace
 
     # Check CPU Metrics on first class spans
-    * the "FirstClass" span has double attribute named "bugsnag.metrics.cpu_mean_total"
-    * the "FirstClass" span has double attribute named "bugsnag.metrics.cpu_mean_main_thread"
+    * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_total"
+    * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_main_thread"
     * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_overhead"
 
     * the "FirstClass" span has array attribute named "bugsnag.system.cpu_measures_total"
@@ -130,8 +130,8 @@ Feature: Device Metrics
     * the "FirstClass" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that no metrics are reported on the "No Metrics" span
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -149,8 +149,8 @@ Feature: Device Metrics
     * the "No Metrics" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that no metrics are reported on the "Not FirstClass" span
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -168,8 +168,8 @@ Feature: Device Metrics
     * the "Not FirstClass" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that only CPU Metrics are recorded on the "CPU Metrics Only" span
-    * the "CPU Metrics Only" span has double attribute named "bugsnag.metrics.cpu_mean_total"
-    * the "CPU Metrics Only" span has double attribute named "bugsnag.metrics.cpu_mean_main_thread"
+    * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_total"
+    * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_main_thread"
     * the "CPU Metrics Only" span has double attribute named "bugsnag.system.cpu_mean_overhead"
 
     * the "CPU Metrics Only" span has array attribute named "bugsnag.system.cpu_measures_total"
@@ -188,8 +188,8 @@ Feature: Device Metrics
     * the "CPU Metrics Only" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that no metrics are recorded on the "Memory Metrics Only" span for this case
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -211,8 +211,8 @@ Feature: Device Metrics
     * I wait to receive a trace
 
     # Check there are no CPU Metrics on first class spans
-    * the "FirstClass" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "FirstClass" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "FirstClass" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "FirstClass" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "FirstClass" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "FirstClass" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "FirstClass" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -232,8 +232,8 @@ Feature: Device Metrics
     * the "FirstClass" span has array attribute named "bugsnag.system.memory.timestamps"
     
     # Check that no metrics are reported on the "No Metrics" span
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "No Metrics" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "No Metrics" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "No Metrics" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -251,8 +251,8 @@ Feature: Device Metrics
     * the "No Metrics" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that no metrics are reported on the "Not FirstClass" span
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Not FirstClass" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Not FirstClass" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -270,8 +270,8 @@ Feature: Device Metrics
     * the "Not FirstClass" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that there are no CPU Metrics are recorded on the "CPU Metrics Only" span (not gathered)
-    * the "CPU Metrics Only" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "CPU Metrics Only" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "CPU Metrics Only" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "CPU Metrics Only" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "CPU Metrics Only" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "CPU Metrics Only" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "CPU Metrics Only" span has no "bugsnag.system.cpu_measures_main_thread" attribute
@@ -289,8 +289,8 @@ Feature: Device Metrics
     * the "CPU Metrics Only" span has no "bugsnag.system.memory.timestamps" attribute
 
     # Check that only Memory Metrics are recorded on the "Memory Metrics Only" span
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_total" attribute
-    * the "Memory Metrics Only" span has no "bugsnag.metrics.cpu_mean_main_thread" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_total" attribute
+    * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_main_thread" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_mean_overhead" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_total" attribute
     * the "Memory Metrics Only" span has no "bugsnag.system.cpu_measures_main_thread" attribute


### PR DESCRIPTION
## Goal
The CPU metrics had some properties named `bugsnag.metrics.*` instead of the expected `bugsnag.system.*`

## Testing
Manual testing and updated the end-to-end tests