### PR TITLE
Fix off-by-one error in Device metrics

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/CpuMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/CpuMetricsSource.kt
@@ -8,6 +8,7 @@ import android.system.OsConstants
 import com.bugsnag.android.performance.internal.BugsnagClock
 import com.bugsnag.android.performance.internal.Loopers
 import com.bugsnag.android.performance.internal.util.FixedRingBuffer
+import kotlin.math.max
 
 internal class CpuMetricsSource(
     samplingDelayMs: Long,
@@ -35,7 +36,7 @@ internal class CpuMetricsSource(
     }
 
     override fun createStartMetrics(): CpuMetricsSnapshot {
-        return CpuMetricsSnapshot(buffer.currentIndex)
+        return CpuMetricsSnapshot(max(buffer.currentIndex - 1, 0))
     }
 
     override fun captureSample() {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MemoryMetricsSource.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/metrics/MemoryMetricsSource.kt
@@ -7,6 +7,7 @@ import android.util.AndroidException
 import com.bugsnag.android.performance.internal.BugsnagClock
 import com.bugsnag.android.performance.internal.getActivityManager
 import com.bugsnag.android.performance.internal.util.FixedRingBuffer
+import kotlin.math.max
 
 internal class MemoryMetricsSource(
     private val appContext: Context,
@@ -113,7 +114,7 @@ internal class MemoryMetricsSource(
     }
 
     override fun createStartMetrics(): MemoryMetricsSnapshot {
-        return MemoryMetricsSnapshot(buffer.currentIndex)
+        return MemoryMetricsSnapshot(max(buffer.currentIndex - 1, 0))
     }
 
     private fun calculateTotalMemory(): Long? {


### PR DESCRIPTION
## Goal
When capturing the "starting point" for CPU or Memory metrics, we need to capture the sample taken before the span is opened.

## Testing
Relied on existing end-to-end tests passing consistently (where they previously flaked due to timing)