### PR TITLE
Stop using deprecated Cucumber step

### DIFF
--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -47,7 +47,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait for 6 spans
+    And I wait to receive 6 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -88,7 +88,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait for 2 spans
+    And I wait to receive 2 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -119,7 +119,7 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
-    And I wait for 5 spans
+    And I wait to receive 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -153,7 +153,7 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
-    And I wait for 5 spans
+    And I wait to receive 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -186,7 +186,7 @@ Feature: Automatic creation of spans
 
   Scenario: AppStart/AndroidCold is discarded for background starts
     Given I run "BackgroundAppStartScenario"
-    And I wait for 1 span
+    And I wait to receive 1 span
     * a span named "AlarmReceiver" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
@@ -207,7 +207,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait for 9 spans
+    And I wait to receive 9 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |

--- a/features/instrumentation.feature
+++ b/features/instrumentation.feature
@@ -47,7 +47,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive 6 spans
+    And I wait to receive at least 6 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -88,7 +88,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive 2 spans
+    And I wait to receive at least 2 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -119,7 +119,7 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
-    And I wait to receive 5 spans
+    And I wait to receive at least 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -153,7 +153,7 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
-    And I wait to receive 5 spans
+    And I wait to receive at least 5 spans
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -186,7 +186,7 @@ Feature: Automatic creation of spans
 
   Scenario: AppStart/AndroidCold is discarded for background starts
     Given I run "BackgroundAppStartScenario"
-    And I wait to receive 1 span
+    And I wait to receive at least 1 span
     * a span named "AlarmReceiver" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
@@ -207,7 +207,7 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive 9 spans
+    And I wait to receive at least 9 spans
     * a span named "[AppStart/AndroidCold]" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -86,7 +86,7 @@ Feature: Manual creation of spans
   Scenario: Send on App backgrounded
     Given I run "AppBackgroundedScenario"
     And I send the app to the background for 5 seconds
-    And I wait to receive 1 span
+    And I wait to receive at least 1 span
     Then a span name equals "Span 1"
 
   # Skip pending PLAT-11356
@@ -94,13 +94,13 @@ Feature: Manual creation of spans
   Scenario: Spans logged in the background
     Given I run "BackgroundSpanScenario"
     And I send the app to the background for 5 seconds
-    And I wait to receive 1 span
+    And I wait to receive at least 1 span
     Then a span name equals "BackgroundSpan"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.app.in_foreground" is false
 
   Scenario: Span attributes are limited based on config
     Given I run "AttributeLimitsScenario"
-    And I wait to receive 1 span
+    And I wait to receive at least 1 span
     Then a span name equals "Custom Span"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string array attribute "arrayAttribute" equals the array:
       | this is a *** 68 CHARS TRUNCATED |

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -86,7 +86,7 @@ Feature: Manual creation of spans
   Scenario: Send on App backgrounded
     Given I run "AppBackgroundedScenario"
     And I send the app to the background for 5 seconds
-    And I wait for 1 span
+    And I wait to receive 1 span
     Then a span name equals "Span 1"
 
   # Skip pending PLAT-11356
@@ -94,13 +94,13 @@ Feature: Manual creation of spans
   Scenario: Spans logged in the background
     Given I run "BackgroundSpanScenario"
     And I send the app to the background for 5 seconds
-    And I wait for 1 span
+    And I wait to receive 1 span
     Then a span name equals "BackgroundSpan"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.app.in_foreground" is false
 
   Scenario: Span attributes are limited based on config
     Given I run "AttributeLimitsScenario"
-    And I wait for 1 span
+    And I wait to receive 1 span
     Then a span name equals "Custom Span"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string array attribute "arrayAttribute" equals the array:
       | this is a *** 68 CHARS TRUNCATED |

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -26,7 +26,7 @@ Feature: OkHttp EventListener
 
   Scenario: Auto-Instrument Network with Callback
     Given I run "OkhttpAutoInstrumentNetworkCallbackScenario"
-    And I wait for 2 spans
+    And I wait to receive 2 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"
@@ -39,7 +39,7 @@ Feature: OkHttp EventListener
 
   Scenario: Manual-Instrument Network with Callback
     Given I run "OkhttpManualNetworkCallbackScenario"
-    And I wait for 2 spans
+    And I wait to receive 2 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"

--- a/features/okhttp_spans.feature
+++ b/features/okhttp_spans.feature
@@ -26,7 +26,7 @@ Feature: OkHttp EventListener
 
   Scenario: Auto-Instrument Network with Callback
     Given I run "OkhttpAutoInstrumentNetworkCallbackScenario"
-    And I wait to receive 2 spans
+    And I wait to receive at least 2 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"
@@ -39,7 +39,7 @@ Feature: OkHttp EventListener
 
   Scenario: Manual-Instrument Network with Callback
     Given I run "OkhttpManualNetworkCallbackScenario"
-    And I wait to receive 2 spans
+    And I wait to receive at least 2 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"


### PR DESCRIPTION
## Goal

Stop using deprecated Cucumber step.

## Design

The step used instead is functionally equivalent - expecting at least the number of spans given.  The replace step will be removed in the next major version of Maze Runner.

## Testing

Covered by CI.