### PR TITLE
Allow easy cross-layer span parenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Changes
+
+* Introduced `RemoteSpanContext` to allow cross-layer parenting of spans, along with easy encoding of `traceparent` headers
+  [#378](https://github.com/bugsnag/bugsnag-android-performance/pull/378)
+
 ## 1.13.0 (2025-04-24)
 
 ### Changes

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -160,8 +160,10 @@ public object BugsnagPerformance {
                 }
 
                 tracer.sampler = sampler
+                spanFactory.sampler = sampler
             } else {
                 tracer.sampler = DiscardingSampler
+                spanFactory.sampler = DiscardingSampler
             }
 
             workerTasks.add(SendBatchTask(delivery, tracer, resourceAttributes))

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/RemoteSpanContext.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/RemoteSpanContext.kt
@@ -1,0 +1,133 @@
+package com.bugsnag.android.performance
+
+import com.bugsnag.android.performance.RemoteSpanContext.Companion.encodeAsTraceParent
+import com.bugsnag.android.performance.internal.SpanImpl
+import com.bugsnag.android.performance.internal.appendHexLong
+import com.bugsnag.android.performance.internal.appendHexUUID
+import com.bugsnag.android.performance.internal.parseUnsignedLong
+
+import java.util.UUID
+
+/**
+ * A `SpanContext` implementation that can be constructed from a different system such as a server,
+ * or a different app layer (such as JavaScript running in a [WebView] or cross-platform framework).
+ *
+ * @see [parseTraceParent]
+ * @see [parseTraceParentOrNull]
+ */
+public class RemoteSpanContext(
+    override val spanId: Long,
+    override val traceId: UUID,
+) : SpanContext {
+
+    /**
+     * Returns a string representation of the span context in the W3C `traceparent` header format.
+     *
+     * @see [encodeAsTraceParent]
+     */
+    override fun toString(): String {
+        return encodeAsTraceParent()
+    }
+
+    /**
+     * Compares this [SpanContext] to another object. Two [SpanContext] objects are considered equal
+     * if they have the same `spanId` and `traceId`.
+     */
+    override fun equals(other: Any?): Boolean {
+        return other is SpanContext &&
+                other.spanId == spanId &&
+                other.traceId == traceId
+    }
+
+    override fun hashCode(): Int {
+        return spanId.hashCode() xor traceId.hashCode()
+    }
+
+    public companion object {
+        private val traceParentRegex =
+            Regex("^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9]{2}$")
+
+        private const val TRACE_ID_MID = 16
+        private const val TRACE_ID_END = 32
+
+        @JvmStatic
+        public fun encodeAsTraceParent(context: SpanContext): String {
+            return context.encodeAsTraceParent()
+        }
+
+        /**
+         * Parses a `traceparent` header string into a [RemoteSpanContext] object. This expects the
+         * string to be in the W3C traceparent header format defined as part of the
+         * [W3C Trace Context](https://www.w3.org/TR/trace-context/#traceparent-header)
+         * specification (version `00`).
+         *
+         * Trace flags are currently ignored (but must still be valid).
+         *
+         * @throws IllegalArgumentException if the string cannot be parsed
+         * @see [parseTraceParentOrNull]
+         */
+        @JvmStatic
+        public fun parseTraceParent(traceParent: String): RemoteSpanContext {
+            return parseTraceParentOrNull(traceParent)
+                ?: throw IllegalArgumentException("Invalid traceparent string")
+        }
+
+        /**
+         * Parses a `traceparent` header string into a [RemoteSpanContext] object. This expects the
+         * string to be in the W3C traceparent header format defined as part of the
+         * [W3C Trace Context](https://www.w3.org/TR/trace-context/#traceparent-header)
+         * specification (version `00`).
+         *
+         * Trace flags are currently ignored (but must still be valid).
+         *
+         * Returns `null` if the string cannot be parsed.
+         *
+         * @see [parseTraceParent]
+         */
+        @JvmStatic
+        public fun parseTraceParentOrNull(traceParent: String): RemoteSpanContext? {
+            val match = traceParentRegex.matchEntire(traceParent)
+                ?: return null
+
+            val (traceIdHex, spanIdHex) = match.destructured
+            val traceId = UUID(
+                traceIdHex.substring(0, TRACE_ID_MID).parseUnsignedLong(),
+                traceIdHex.substring(TRACE_ID_MID, TRACE_ID_END).parseUnsignedLong(),
+            )
+            val spanId = spanIdHex.parseUnsignedLong()
+
+            return RemoteSpanContext(
+                spanId = spanId,
+                traceId = traceId,
+            )
+        }
+    }
+}
+
+private const val TRACEPARENT_LENGTH = 55
+
+private fun buildTraceParentHeader(
+    traceId: UUID,
+    parentSpanId: Long,
+    sampled: Boolean,
+): String {
+    return buildString(TRACEPARENT_LENGTH) {
+        append("00-")
+        appendHexUUID(traceId)
+        append('-')
+        appendHexLong(parentSpanId)
+        append('-')
+        append(if (sampled) "01" else "00")
+    }
+}
+
+/**
+ * Returns a string representation of the span context in the W3C `traceparent` header format.
+ */
+public fun SpanContext.encodeAsTraceParent(): String {
+    return buildTraceParentHeader(
+        traceId = traceId,
+        parentSpanId = spanId,
+        sampled = if (this is SpanImpl) isSampled() else true,
+    )
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Encodings.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Encodings.kt
@@ -47,3 +47,7 @@ internal fun StringBuilder.appendHexString(bytes: ByteArray): StringBuilder {
     bytes.forEach { appendHexPair(it.toInt() and 0xff) }
     return this
 }
+
+internal fun String.parseUnsignedLong(): Long {
+    return java.lang.Long.parseUnsignedLong(this, 16)
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/Sampler.kt
@@ -8,6 +8,14 @@ internal interface Sampler {
     }
 
     fun shouldKeepSpan(span: SpanImpl): Boolean
+
+    /**
+     * The probability that any given [Span] is retained during sampling as a value between 0 and 1.
+     * Defaults to 1.0 but the implementation should override this value to return an equivalent
+     * value to the current sampling probability (if possible).
+     */
+    val sampleProbability: Double
+        get() = 1.0
 }
 
 /**
@@ -17,6 +25,7 @@ internal interface Sampler {
 internal object DiscardingSampler : Sampler {
     override fun sampled(spans: Collection<SpanImpl>): Collection<SpanImpl> = emptyList()
     override fun shouldKeepSpan(span: SpanImpl): Boolean = false
+    override val sampleProbability: Double get() = 0.0
 }
 
 internal class ProbabilitySampler(
@@ -24,7 +33,7 @@ internal class ProbabilitySampler(
      * The probability that any given [Span] is retained during sampling as a value between 0 and 1.
      */
     @FloatRange(from = 0.0, to = 1.0)
-    var sampleProbability: Double,
+    override var sampleProbability: Double,
 ) : Sampler {
     // Side effect: Sets span.samplingProbability to the current probability
     override fun shouldKeepSpan(span: SpanImpl): Boolean {

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/SpanFactory.kt
@@ -16,6 +16,7 @@ import com.bugsnag.android.performance.internal.integration.NotifierIntegration
 import com.bugsnag.android.performance.internal.metrics.MetricsContainer
 import com.bugsnag.android.performance.internal.processing.AttributeLimits
 import com.bugsnag.android.performance.internal.processing.SpanTaskWorker
+import com.bugsnag.android.performance.internal.processing.Tracer
 import java.util.UUID
 
 internal typealias AttributeSource = (target: SpanImpl) -> Unit
@@ -29,6 +30,8 @@ public class SpanFactory internal constructor(
 ) {
 
     public var networkRequestCallback: NetworkRequestInstrumentationCallback? = null
+
+    internal var sampler: Sampler? = null
 
     internal var attributeLimits: AttributeLimits? = null
 
@@ -265,6 +268,8 @@ public class SpanFactory internal constructor(
         if (isFirstClass != null) {
             span.attributes["bugsnag.span.first_class"] = isFirstClass
         }
+
+        span.samplingProbability = sampler?.sampleProbability ?: 1.0
 
         spanAttributeSource(span)
 

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/RemoteSpanContextTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/RemoteSpanContextTest.kt
@@ -1,0 +1,88 @@
+package com.bugsnag.android.performance
+
+import com.bugsnag.android.performance.test.NoopSpanProcessor
+import com.bugsnag.android.performance.test.TestSpanFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+internal class RemoteSpanContextTest {
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun setUp() {
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun testEncodeSpanContext() {
+        val spanContext = RemoteSpanContext(
+            traceId = UUID.fromString("12345678-90ab-cdef-1234-567890abcdef"),
+            spanId = 0x1234567890abcdefL,
+        )
+
+        val traceParent = spanContext.encodeAsTraceParent()
+        assertEquals("00-1234567890abcdef1234567890abcdef-1234567890abcdef-01", traceParent)
+    }
+
+    @Test
+    fun testUnsampledSpanContext() {
+        val span = spanFactory.newSpan(
+            traceId = UUID.fromString("12345678-90ab-cdef-1234-567890abcdef"),
+            spanId = 0x1234567890abcdefL,
+            processor = NoopSpanProcessor,
+        )
+
+        // make sure the span is unsampled by forcing probability to 0
+        span.samplingProbability = 0.0
+
+        val traceParent = span.encodeAsTraceParent()
+        assertEquals("00-1234567890abcdef1234567890abcdef-1234567890abcdef-00", traceParent)
+    }
+
+    @Test
+    fun encodeAndDecode() {
+        val spanContext = RemoteSpanContext(
+            traceId = UUID.fromString("12345678-90ab-cdef-1234-567890abcdef"),
+            spanId = 0x1234567890abcdefL,
+        )
+
+        val traceParent = spanContext.encodeAsTraceParent()
+        val decoded = RemoteSpanContext.parseTraceParent(traceParent)
+
+        assertEquals(spanContext, decoded)
+    }
+
+    @Test
+    fun testNegativeIdEncoding() {
+        val spanContext = RemoteSpanContext(
+            traceId = UUID(-1L, -1L),
+            spanId = -1L,
+        )
+
+        val traceParent = spanContext.encodeAsTraceParent()
+        assertEquals("00-ffffffffffffffffffffffffffffffff-ffffffffffffffff-01", traceParent)
+    }
+
+    @Test
+    fun invalidEncoding_UppercaseHex() {
+        val spanContext = RemoteSpanContext.parseTraceParentOrNull(
+            "00-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF-FFFFFFFFFFFFFFFF-01",
+        )
+        assertNull(spanContext)
+    }
+
+    @Test
+    fun invalidEncoding_NonHex() {
+        val invalidTraceParent = "00-1234567890abcdef1234567890abcdef-1234567890abcdez-01"
+        assertNull(RemoteSpanContext.parseTraceParentOrNull(invalidTraceParent))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun invalidEncoding_ThrowsException() {
+        val invalidTraceParent = "01-1234567890abcdef1234567890abcdef-1234567890abcdef-01"
+        RemoteSpanContext.parseTraceParent(invalidTraceParent)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/SpanFactoryTest.kt
@@ -9,6 +9,7 @@ import com.bugsnag.android.performance.internal.framerate.TimestampPairBuffer
 import com.bugsnag.android.performance.internal.metrics.MetricSource
 import com.bugsnag.android.performance.test.NoopSpanProcessor
 import com.bugsnag.android.performance.test.TestMetricsContainer
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -123,5 +124,13 @@ class SpanFactoryTest {
                     .withMetrics(spanMetricsWithoutRendering),
             ).metrics,
         )
+    }
+
+    @Test
+    fun testSamplingProbability() {
+        spanFactory.sampler = ProbabilitySampler(0.5)
+
+        val span = spanFactory.createCustomSpan("Test", baseOptions)
+        assertEquals(0.5, span.samplingProbability, 0.01)
     }
 }


### PR DESCRIPTION
## Goal
Allow easy cross-layer span parenting so that spans can be nested under spans from remote servers or non-native app layers (such as JavaScript in a WebView).

## Design
Introduced the new `RemoteSpanContext` class that encapsulates encoding & parsing of `SpanContext`s in the `traceparent` header format. The encoding can be applied to any `SpanContext` object, and the strings can be parsed into `RemoteSpanContext` objects.

## Testing
New unit tests added