### PR TITLE
Introduce SpanControlProviderr

### DIFF
--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/BugsnagPerformance.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.net.Uri
 import android.os.SystemClock
 import com.bugsnag.android.performance.BugsnagPerformance.start
+import com.bugsnag.android.performance.internal.controls.CompositeSpanControlProvider
+import com.bugsnag.android.performance.controls.SpanQuery
 import com.bugsnag.android.performance.internal.Connectivity
 import com.bugsnag.android.performance.internal.DiscardingSampler
 import com.bugsnag.android.performance.internal.HttpDelivery
@@ -43,6 +45,8 @@ public object BugsnagPerformance {
     private lateinit var worker: Worker
 
     private val spanFactory get() = instrumentedAppState.spanFactory
+
+    private val spanControlProvider = CompositeSpanControlProvider()
 
     /**
      * Initialise the Bugsnag Performance SDK. This should be called within your
@@ -312,6 +316,20 @@ public object BugsnagPerformance {
         synchronized(this) {
             instrumentedAppState.startupTracker.onFirstClassLoadReported()
         }
+    }
+
+    /**
+     * Attempt to retrieve the span controls for a given [SpanQuery]. This is used to access
+     * specialised behaviours for specific span types.
+     *
+     * @param query the span query to retrieve controls for
+     * @return the span controls for the given query, or null if none exists or the query cannot
+     *      be fulfilled
+     */
+    @JvmStatic
+    public fun <C> getSpanControls(query: SpanQuery<C>): C? {
+        @Suppress("UNCHECKED_CAST")
+        return spanControlProvider[query as SpanQuery<Any>] as C
     }
 }
 

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/controls/SpanControlProvider.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/controls/SpanControlProvider.kt
@@ -17,8 +17,8 @@ public interface SpanQuery<out C>
  */
 public interface SpanControlProvider<C> {
     /**
-     * If possible retrieves the span controls the given [query]. If the query cannot be fulfilled
-     * by this provider, null is returned.
+     * If possible retrieves the span controls for the given [query]. If the query cannot be
+     * fulfilled by this provider, null is returned.
      *
      * @param query The query to be used to retrieve the span control
      * @return the span control for the query, or null if no match is found or the query cannot be

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/controls/SpanControlProvider.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/controls/SpanControlProvider.kt
@@ -1,0 +1,28 @@
+package com.bugsnag.android.performance.controls
+
+/**
+ * Marker interface for classes that can be used with [SpanControlProvider]. This interface does
+ * not define any specific methods or properties.
+ *
+ * @param C The type of span control returned for this query
+ */
+public interface SpanQuery<out C>
+
+/**
+ * Provides a way to retrieve a span control based on a [SpanQuery]. Span controls are specialised
+ * objects that allow for the manipulation of spans without directly referencing the [Span] object,
+ * allowing for specialized operations to be performed on spans.
+ *
+ * @param C The type of span control returned by the provider
+ */
+public interface SpanControlProvider<C> {
+    /**
+     * If possible retrieves the span controls the given [query]. If the query cannot be fulfilled
+     * by this provider, null is returned.
+     *
+     * @param query The query to be used to retrieve the span control
+     * @return the span control for the query, or null if no match is found or the query cannot be
+     *      fulfilled by this provider
+     */
+    public operator fun <Q : SpanQuery<C>> get(query: Q): C?
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/controls/CompositeSpanControlProvider.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/controls/CompositeSpanControlProvider.kt
@@ -1,0 +1,98 @@
+package com.bugsnag.android.performance.internal.controls
+
+import com.bugsnag.android.performance.controls.SpanControlProvider
+import com.bugsnag.android.performance.controls.SpanQuery
+
+import com.bugsnag.android.performance.internal.util.Prioritized
+
+import java.util.concurrent.locks.ReentrantLock
+
+import kotlin.concurrent.withLock
+
+/**
+ * A compositing [SpanControlProvider] that delegates to a list of other [SpanControlProvider]s.
+ * This class is thread-safe and can be used to manage multiple span control providers in a
+ * single instance.
+ *
+ * Each `SpanControlProvider` is wrapped as [Prioritized] to allow for ordering of the providers.
+ * The `SpanControlProvider`s are sorted by priority, so providers with higher priority values
+ * will be run *before* those with lower priorities. Priority values can be duplicated (i.e. two
+ * `SpanControlProvider`s can have the same priority), in which case the order of
+ * the providers is the order in which they were added.
+ */
+internal class CompositeSpanControlProvider : SpanControlProvider<Any> {
+    @Volatile
+    private var providers: Array<Prioritized<SpanControlProvider<Any>>> = emptyArray()
+
+    private val lock = ReentrantLock()
+
+    val size: Int
+        get() = providers.size
+
+    /**
+     * Adds a [SpanControlProvider] to the list of providers if it is not already present. Any
+     * existing `SpanControlProvider` will be ignored (as determined by [Object.equals]). The list
+     * of providers is sorted by priority after the addition.
+     *
+     * @param provider The [SpanControlProvider] to add and its priority
+     */
+    fun addProvider(provider: Prioritized<SpanControlProvider<*>>) {
+        lock.withLock {
+            @Suppress("UNCHECKED_CAST")
+            val castProvider = provider as Prioritized<SpanControlProvider<Any>>
+            if (providers.any { it.value == castProvider.value }) {
+                return
+            }
+
+            val newProviders = providers + castProvider
+            newProviders.sort()
+            providers = newProviders
+        }
+    }
+
+    /**
+     * Adds a collection of [SpanControlProvider]s to the list of providers if they are not
+     * already present. Any existing `SpanControlProvider` will be ignored (as determined by
+     * [Object.equals]). The list of providers is sorted by priority after the addition.
+     *
+     * @param newProviders The collection of [SpanControlProvider]s to add and their priorities
+     */
+    fun addProviders(newProviders: Collection<Prioritized<SpanControlProvider<*>>>) {
+        lock.withLock {
+            val newProviderArray = providers.copyOf(providers.size + newProviders.size)
+            var index = providers.size
+
+            for (provider in newProviders) {
+                @Suppress("UNCHECKED_CAST")
+                val castProvider = provider as Prioritized<SpanControlProvider<Any>>
+                if (providers.none { it.value == castProvider.value }) {
+                    newProviderArray[index++] = castProvider
+                }
+            }
+
+            if (index == newProviderArray.size) {
+                newProviderArray.sort()
+                @Suppress("UNCHECKED_CAST")
+                providers = newProviderArray as Array<Prioritized<SpanControlProvider<Any>>>
+            } else {
+                newProviderArray.sort(0, index)
+                @Suppress("UNCHECKED_CAST")
+                providers = newProviderArray.copyOf(index)
+                        as Array<Prioritized<SpanControlProvider<Any>>>
+            }
+        }
+    }
+
+    override operator fun <Q : SpanQuery<Any>> get(query: Q): Any? {
+        val providerList = providers
+
+        for (provider in providerList) {
+            val result = provider.value[query]
+            if (result != null) {
+                return result
+            }
+        }
+
+        return null
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/Prioritized.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/Prioritized.kt
@@ -1,0 +1,15 @@
+package com.bugsnag.android.performance.internal.util
+
+/**
+ * A simple data class that wraps a value with a priority. This can be used to sort lists of
+ * non-comparable objects, where it may be desirable for priorities to be duplicated (ie. two
+ * objects can have the same priority).
+ *
+ * Priorities are sorted in descending order, so higher priority values will be sorted first. For
+ * example, a priority of 10 will appear before a priority of 5 when using a natural sort.
+ */
+internal data class Prioritized<T>(val priority: Int, val value: T) : Comparable<Prioritized<T>> {
+    override fun compareTo(other: Prioritized<T>): Int {
+        return other.priority - priority
+    }
+}

--- a/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/Prioritized.kt
+++ b/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/util/Prioritized.kt
@@ -1,5 +1,8 @@
 package com.bugsnag.android.performance.internal.util
 
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
 /**
  * A simple data class that wraps a value with a priority. This can be used to sort lists of
  * non-comparable objects, where it may be desirable for priorities to be duplicated (ie. two
@@ -11,5 +14,75 @@ package com.bugsnag.android.performance.internal.util
 internal data class Prioritized<T>(val priority: Int, val value: T) : Comparable<Prioritized<T>> {
     override fun compareTo(other: Prioritized<T>): Int {
         return other.priority - priority
+    }
+}
+
+/**
+ * A simple thread-safe set of [Prioritized] values. This is a mutable collection that allows
+ * adding values which may have duplicate priorities, but may *not* have duplicate values.
+ * Attempting to add a value that already exists in the set will be ignored.
+ *
+ * This class does not implement [MutableSet] as it does not truly match the contract, specifically
+ * equality is based on the values of the [Prioritized] elements while not considering their
+ * priorities. A true set implementation would consider {priority, value} when taking equality into
+ * account.
+ */
+internal class PrioritizedSet<T> {
+    @Volatile
+    @PublishedApi
+    internal var values: Array<Prioritized<T>> = emptyArray()
+        private set
+
+    private val lock = ReentrantLock()
+
+    val size: Int
+        get() = values.size
+
+    fun add(element: Prioritized<T>): Boolean {
+        lock.withLock {
+            if (values.any { it.value == element.value }) {
+                return false
+            }
+
+            val newProviders = values + element
+            newProviders.sort()
+            values = newProviders
+        }
+
+        return true
+    }
+
+    fun addAll(elements: Collection<Prioritized<T>>): Boolean {
+        lock.withLock {
+            val newValuesArray = values.copyOf(values.size + elements.size)
+            var index = values.size
+
+            for (prioritized in elements) {
+                if (values.none { it.value == prioritized.value }) {
+                    newValuesArray[index++] = prioritized
+                }
+            }
+
+            if (index == values.size) {
+                // no elements were added
+                return false
+            } else if (index == newValuesArray.size) {
+                newValuesArray.sort()
+                @Suppress("UNCHECKED_CAST")
+                values = newValuesArray as Array<Prioritized<T>>
+            } else {
+                newValuesArray.sort(0, index)
+                @Suppress("UNCHECKED_CAST")
+                values = newValuesArray.copyOf(index) as Array<Prioritized<T>>
+            }
+        }
+
+        return true
+    }
+
+    inline fun forEach(action: (T) -> Unit) {
+        for (prioritized in values) {
+            action(prioritized.value)
+        }
     }
 }

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/controls/CompositeSpanControlProviderTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/controls/CompositeSpanControlProviderTest.kt
@@ -1,0 +1,138 @@
+package com.bugsnag.android.performance.internal.controls
+
+import com.bugsnag.android.performance.controls.SpanControlProvider
+import com.bugsnag.android.performance.controls.SpanQuery
+import com.bugsnag.android.performance.internal.util.Prioritized
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class CompositeSpanControlProviderTest {
+    @Test
+    fun testNoProviders() {
+        val compositeProvider = CompositeSpanControlProvider()
+        assertNull(compositeProvider[DummySpanQuery(1)])
+        assertNull(compositeProvider[UnsupportedSpanQuery])
+    }
+
+    @Test
+    fun testCompositeSpanProvider() {
+        val compositeSpanControlProvider = CompositeSpanControlProvider().apply {
+            addProvider(Prioritized(1, DummySpanControlProvider(DummySpanQuery(1))))
+            addProvider(Prioritized(1, DummySpanControlProvider(DummySpanQuery(2))))
+            addProvider(Prioritized(1, DummySpanControlProvider(DummySpanQuery(3))))
+        }
+
+        assertEquals(
+            DummySpanControl(1),
+            compositeSpanControlProvider[DummySpanQuery(1)],
+        )
+
+        assertEquals(
+            DummySpanControl(2),
+            compositeSpanControlProvider[DummySpanQuery(2)],
+        )
+
+        assertEquals(
+            DummySpanControl(3),
+            compositeSpanControlProvider[DummySpanQuery(3)],
+        )
+
+        assertNull(compositeSpanControlProvider[DummySpanQuery(4)])
+        assertNull(compositeSpanControlProvider[UnsupportedSpanQuery])
+    }
+
+    @Test
+    fun testPrioritizedCompositeSpanProvider() {
+        val compositeSpanControlProvider = CompositeSpanControlProvider().apply {
+            addProvider(
+                Prioritized(
+                    2,
+                    DummySpanControlProvider(
+                        DummySpanQuery(1),
+                        DummySpanControl(987),
+                    ),
+                ),
+            )
+            addProvider(Prioritized(1, DummySpanControlProvider(DummySpanQuery(1))))
+            addProvider(Prioritized(1, DummySpanControlProvider(DummySpanQuery(2))))
+        }
+
+        assertEquals(DummySpanControl(987), compositeSpanControlProvider[DummySpanQuery(1)])
+    }
+
+    @Test
+    fun testDuplicateProviders() {
+        val provider1 = DummySpanControlProvider(DummySpanQuery(1))
+        val provider2 = DummySpanControlProvider(DummySpanQuery(2))
+        val provider3 = DummySpanControlProvider(DummySpanQuery(1))
+
+        val compositeSpanControlProvider = CompositeSpanControlProvider().apply {
+            addProvider(Prioritized(1, provider1))
+            addProvider(Prioritized(1, provider2))
+            addProvider(Prioritized(1, provider3))
+
+            addProvider(Prioritized(2, provider1))
+            addProvider(Prioritized(3, provider1))
+            addProvider(Prioritized(4, provider1))
+        }
+
+        assertEquals(3, compositeSpanControlProvider.size)
+    }
+
+    @Test
+    fun testAddMultipleProviders() {
+        val provider1 = DummySpanControlProvider(DummySpanQuery(1))
+        val provider2 = DummySpanControlProvider(DummySpanQuery(2))
+        val provider3 = DummySpanControlProvider(DummySpanQuery(3))
+        val provider4 = DummySpanControlProvider(DummySpanQuery(4))
+
+        val compositeSpanControlProvider = CompositeSpanControlProvider().apply {
+            addProvider(Prioritized(1, provider1))
+            addProvider(Prioritized(1, provider2))
+
+            addProviders(
+                listOf(
+                    Prioritized(2, provider1),
+                    Prioritized(3, provider2),
+                    Prioritized(4, provider1),
+                    Prioritized(4, provider3),
+                ),
+            )
+
+            addProvider(Prioritized(1, provider3))
+
+            addProviders(
+                listOf(
+                    Prioritized(4, provider4),
+                ),
+            )
+        }
+
+        assertEquals(4, compositeSpanControlProvider.size)
+        assertEquals(DummySpanControl(1), compositeSpanControlProvider[DummySpanQuery(1)])
+        assertEquals(DummySpanControl(2), compositeSpanControlProvider[DummySpanQuery(2)])
+        assertEquals(DummySpanControl(3), compositeSpanControlProvider[DummySpanQuery(3)])
+        assertEquals(DummySpanControl(4), compositeSpanControlProvider[DummySpanQuery(4)])
+        assertNull(compositeSpanControlProvider[UnsupportedSpanQuery])
+    }
+
+    data class DummySpanControl(val value: Int)
+    data class DummySpanQuery(val value: Int) : SpanQuery<DummySpanControl>
+    object UnsupportedSpanQuery : SpanQuery<String>
+
+    class DummySpanControlProvider(
+        private val expectedKey: DummySpanQuery,
+        private val returnControls: DummySpanControl = DummySpanControl(
+            expectedKey.value,
+        ),
+    ) : SpanControlProvider<DummySpanControl> {
+        override operator fun <Q : SpanQuery<DummySpanControl>> get(query: Q): DummySpanControl? {
+            if (query is DummySpanQuery && query == expectedKey) {
+                return returnControls
+            }
+
+            return null
+        }
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/PrioritizedSetTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/PrioritizedSetTest.kt
@@ -1,0 +1,98 @@
+package com.bugsnag.android.performance.internal.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrioritizedSetTest {
+    @Test
+    fun testEmptySet() {
+        val set = PrioritizedSet<String>()
+        assertEquals(0, set.size)
+    }
+
+    @Test
+    fun testAddingSingleElement() {
+        val set = PrioritizedSet<String>()
+        assertTrue(set.add(Prioritized(1, "test")))
+        assertEquals(1, set.size)
+    }
+
+    @Test
+    fun testDuplicateValueIsIgnored() {
+        val set = PrioritizedSet<String>()
+        assertTrue(set.add(Prioritized(1, "test")))
+        assertFalse(set.add(Prioritized(2, "test"))) // Same value, different priority
+        assertEquals(1, set.size)
+    }
+
+    @Test
+    fun testPriorityOrdering() {
+        val set = PrioritizedSet<String>()
+        set.add(Prioritized(1, "low"))
+        set.add(Prioritized(3, "high"))
+        set.add(Prioritized(2, "medium"))
+
+        val values = mutableListOf<String>()
+        set.forEach { values.add(it) }
+
+        assertEquals(listOf("high", "medium", "low"), values)
+    }
+
+    @Test
+    fun testAddAllWithDuplicates() {
+        val set = PrioritizedSet<String>()
+        set.add(Prioritized(1, "existing"))
+
+        val newElements = listOf(
+            Prioritized(2, "existing"), // Should be ignored
+            Prioritized(3, "new1"),
+            Prioritized(4, "new2"),
+        )
+
+        assertTrue(set.addAll(newElements))
+        assertEquals(3, set.size)
+
+        val values = mutableListOf<String>()
+        set.forEach { values.add(it) }
+        assertEquals(listOf("new2", "new1", "existing"), values)
+    }
+
+    @Test
+    fun testAddAllWithAllDuplicates() {
+        val set = PrioritizedSet<String>()
+        set.add(Prioritized(1, "test"))
+
+        val newElements = listOf(
+            Prioritized(2, "test"),
+            Prioritized(3, "test"),
+        )
+
+        assertFalse(set.addAll(newElements))
+        assertEquals(1, set.size)
+    }
+
+    @Test
+    fun testAddAllEmpty() {
+        val set = PrioritizedSet<String>()
+        assertFalse(set.addAll(emptyList()))
+        assertEquals(0, set.size)
+    }
+
+    @Test
+    fun testSamePriorityOrdering() {
+        val set = PrioritizedSet<String>()
+        set.add(Prioritized(0, "fourth"))
+        set.add(Prioritized(1, "first"))
+        set.add(Prioritized(0, "fifth"))
+        set.add(Prioritized(1, "second"))
+        set.add(Prioritized(5, "zero"))
+        set.add(Prioritized(1, "third"))
+
+        val values = mutableListOf<String>()
+        set.forEach { values.add(it) }
+        assertEquals(6, set.size)
+        assertEquals(listOf("zero", "first", "second", "third", "fourth", "fifth"), values)
+    }
+}

--- a/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/PrioritizedTest.kt
+++ b/bugsnag-android-performance/src/test/java/com/bugsnag/android/performance/internal/util/PrioritizedTest.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.performance.internal.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrioritizedTest {
+    @Test
+    fun testNaturalSort() {
+        val values = arrayOf(
+            Prioritized(5, "V"),
+            Prioritized(10, "X"),
+            Prioritized(11, "XI"),
+            Prioritized(10, "X-2"),
+            Prioritized(14, "XIV"),
+        )
+        values.sort()
+
+        assertEquals("XIV", values[0].value)
+        assertEquals("XI", values[1].value)
+        assertEquals("X", values[2].value)
+        assertEquals("X-2", values[3].value)
+        assertEquals("V", values[4].value)
+    }
+}


### PR DESCRIPTION
## Goal
Offer a centralized interface for abstract span access where the `Span` objects may not be directly reachable.

## Changeset
Introduced `SpanQuery` and `SpanControlProvider` that can be implemented to fulfil various types of span access.

Implemented a `CompositeSpanControlProvider` that keeps a prioritized list of `SpanControlProvider`s and queries each of them in order, offering an easy single point of access to several providers at once.

Added the `BugsnagPerformance.getSpanControls` function to allow centralised access to any known `SpanControlProviders`, avoiding the need to directly reference any single `SpanControlProvider`. `SpanControlProvider` objects are not required to be registered like this, and could still be used instance-by-instance as well.

## Testing
New unit tests were added for the `CompositeSpanControlProvider` which is the first implementation of the interface and pattern.