### PR TITLE
Update Sonatype Release Script

### DIFF
--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -1,15 +1,72 @@
 #!/usr/bin/env bash
 
-echo $KEY > ~/temp_key
-base64 --decode ~/temp_key > /publishKey.gpg
-mkdir "~/.gradle/"
-echo "signing.keyId=$KEY_ID" >> ~/.gradle/gradle.properties
-echo "signing.password=$KEY_PASS" >> ~/.gradle/gradle.properties
-echo "signing.secretKeyRingFile=/publishKey.gpg" >> ~/.gradle/gradle.properties
-echo "NEXUS_USERNAME=$PUBLISH_USER" >> ~/.gradle/gradle.properties
-echo "NEXUS_PASSWORD=$PUBLISH_PASS" >> ~/.gradle/gradle.properties
-echo "nexusUsername=$PUBLISH_USER" >> ~/.gradle/gradle.properties
-echo "nexusPassword=$PUBLISH_PASS" >> ~/.gradle/gradle.properties
+set -euo pipefail
 
-/app/gradlew assembleRelease publish --no-daemon --max-workers=1 && \
- echo "Go to https://oss.sonatype.org/ to release the final artefact. For the full release instructions, please read https://github.com/bugsnag/bugsnag-android-performance/blob/next/docs/RELEASING.md"
+# === Variables ===
+GRADLE_DIR="$HOME/.gradle"
+KEY_FILE="$HOME/temp_key"
+KEY_RING="/publishKey.gpg"
+GRADLE_PROPERTIES="$GRADLE_DIR/gradle.properties"
+
+# === GPG Key Setup ===
+echo "$KEY" > "$KEY_FILE"
+base64 --decode "$KEY_FILE" > "$KEY_RING"
+
+# === Gradle Configuration ===
+mkdir -p "$GRADLE_DIR"
+{
+  echo "signing.keyId=$KEY_ID"
+  echo "signing.password=$KEY_PASS"
+  echo "signing.secretKeyRingFile=$KEY_RING"
+  echo "NEXUS_USERNAME=$PUBLISH_USER"
+  echo "NEXUS_PASSWORD=$PUBLISH_PASS"
+  echo "nexusUsername=$PUBLISH_USER"
+  echo "nexusPassword=$PUBLISH_PASS"
+} >> "$GRADLE_PROPERTIES"
+
+# === Build and Publish ===
+/app/gradlew assembleRelease publish --no-daemon --max-workers=1
+
+echo "Go to https://oss.sonatype.org/ to release the final artefact."
+echo "For full release instructions, visit:"
+echo "https://github.com/bugsnag/bugsnag-android-performance/blob/next/docs/RELEASING.md"
+
+# === Close Staging Repository ===
+echo "--- Closing staging repository"
+echo "Fetching staging repositories..."
+
+REPOS_JSON=$(curl -s -u "$PUBLISH_USER:$PUBLISH_PASS" \
+  "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories")
+
+if [[ -z "$REPOS_JSON" ]]; then
+  echo "Failed to retrieve repository list. Check your credentials or network." >&2
+  exit 1
+fi
+
+REPO_KEYS=($(echo "$REPOS_JSON" | jq -r '.repositories[] | select(.state == "open") | .key'))
+
+if [[ "${#REPO_KEYS[@]}" -eq 0 ]]; then
+  echo "No open repositories found."
+  exit 1
+elif [[ "${#REPO_KEYS[@]}" -gt 1 ]]; then
+  echo "Multiple open repositories found. Please specify which one to close:"
+  printf '%s\n' "${REPO_KEYS[@]}"
+  exit 1
+fi
+
+REPO_KEY="${REPO_KEYS[0]}"
+echo "Closing repository $REPO_KEY..."
+
+URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$REPO_KEY?publishing_type=user_managed"
+RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST -u "$PUBLISH_USER:$PUBLISH_PASS" "$URL")
+
+BODY=$(echo "$RESPONSE" | sed -n '/^HTTP_STATUS:/!p')
+STATUS=$(echo "$RESPONSE" | sed -n 's/^HTTP_STATUS://p')
+
+if [[ "$STATUS" != "200" ]]; then
+  echo "Failed to close repository. HTTP Status: $STATUS"
+  echo "$BODY" | jq -r
+  exit 1
+fi
+
+echo "Repository $REPO_KEY closed successfully."

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -27,10 +27,6 @@ mkdir -p "$GRADLE_DIR"
 # === Build and Publish ===
 /app/gradlew assembleRelease publish --no-daemon --max-workers=1
 
-echo "Go to https://oss.sonatype.org/ to release the final artefact."
-echo "For full release instructions, visit:"
-echo "https://github.com/bugsnag/bugsnag-android-performance/blob/next/docs/RELEASING.md"
-
 # === Close Staging Repository ===
 echo "--- Closing staging repository"
 echo "Fetching staging repositories..."
@@ -70,3 +66,7 @@ if [[ "$STATUS" != "200" ]]; then
 fi
 
 echo "Repository $REPO_KEY closed successfully."
+
+echo "Go to https://oss.sonatype.org/ to release the final artefact."
+echo "For full release instructions, visit:"
+echo "https://github.com/bugsnag/bugsnag-android-performance/blob/next/docs/RELEASING.md"


### PR DESCRIPTION
## Goal

Ensure that the `publish` step on CI can close the staging repository using the `ossrh-staging-api`. I have also reworked the script for best practices.

## Testing

Tested [here](https://buildkite.com/bugsnag/bugsnag-android-performance/builds/3056/steps?sid=01971b1b-e26f-4e47-a896-8a1439e42937#01971b1b-e89b-4228-ad9a-c77deba5cd5b/264-269) (error is the result of the versions already existing)