### PR TITLE
Named spans publish fix

### DIFF
--- a/bugsnag-plugin-android-performance-named-spans/gradle.properties
+++ b/bugsnag-plugin-android-performance-named-spans/gradle.properties
@@ -1,0 +1,1 @@
+pomName=Bugsnag Android Performance Named Span Controls Plugin


### PR DESCRIPTION
## Goal
Added the missing pomName to the bugsnag-plugin-android-performance-named-spans module