### PR TITLE
More clearly explain that Span is not stable for inheritance

### DIFF
--- a/bugsnag-android-performance-api/src/main/kotlin/com/bugsnag/android/performance/Span.kt
+++ b/bugsnag-android-performance-api/src/main/kotlin/com/bugsnag/android/performance/Span.kt
@@ -10,7 +10,9 @@ import java.io.Closeable
  *
  * Spans may not be changed once they have been closed.
  *
- * The [Span] interface is not intended for third-party implementation.
+ * ### Not stable for inheritance
+ * **The `Span` interface is not stable for inheritance in third party libraries**. New methods
+ * might be added to this interface in the future. It is stable for use.
  *
  * @see BugsnagPerformance.startSpan
  */


### PR DESCRIPTION
## Goal
Make it clearer that the `Span` interface is intended to be used but not implemented by third-parties and warn that we do not anticipate maintaining source or binary compatibility for implementers.

## Design
The `Span` interface is intended to provide flexibility between our public API surface and our internal implementation. As we add new features, we expect to change and grow the `Span` interface to expose these features as public API. This makes the interface unstable for third-party implementation.

`Span` being an open interface makes it easy to use in unit tests with tools such as Mockito (where the interface stability is not important), but unfortunately also makes it look as though the interface can be easily implemented. Changing to a `sealed interface` would forbid inheritance in Kotlin outside of the core SDK, but we don't want to block solutions where accepting the instability might be an acceptable tradeoff.