### PR TITLE
Cancel timeouts from duplicate spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* `NamedSpanControlsPlugin` better handles timeouts when spans have duplicate names, avoiding holding references for longer than required
+  [#423](https://github.com/bugsnag/bugsnag-android-performance/pull/423)
+
 ## 2.0.0 (2025-07-09)
 
 ### Changes

--- a/bugsnag-android-performance-impl/src/testFixtures/java/com/bugsnag/android/performance/test/TestTimeoutExecutor.java
+++ b/bugsnag-android-performance-impl/src/testFixtures/java/com/bugsnag/android/performance/test/TestTimeoutExecutor.java
@@ -5,10 +5,15 @@ import com.bugsnag.android.performance.internal.processing.TimeoutExecutor;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
 import java.util.PriorityQueue;
 
 public class TestTimeoutExecutor implements TimeoutExecutor {
     private final PriorityQueue<Timeout> timeouts = new PriorityQueue<>();
+
+    public Collection<Timeout> getTimeouts() {
+        return timeouts;
+    }
 
     public void runAllTimeouts() {
         while (!timeouts.isEmpty()) {

--- a/bugsnag-plugin-android-performance-named-spans/src/test/kotlin/com/bugsnag/android/performance/controls/NamedSpanControlProviderTest.kt
+++ b/bugsnag-plugin-android-performance-named-spans/src/test/kotlin/com/bugsnag/android/performance/controls/NamedSpanControlProviderTest.kt
@@ -1,0 +1,68 @@
+package com.bugsnag.android.performance.controls
+
+import com.bugsnag.android.performance.SpanKind
+import com.bugsnag.android.performance.internal.SpanCategory
+import com.bugsnag.android.performance.test.NoopSpanProcessor
+import com.bugsnag.android.performance.test.TestSpanFactory
+import com.bugsnag.android.performance.test.TestTimeoutExecutor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Before
+import org.junit.Test
+
+class NamedSpanControlProviderTest {
+    private lateinit var testTimeoutExecutor: TestTimeoutExecutor
+    private lateinit var namedSpanControlProvider: NamedSpanControlProvider
+    private lateinit var spanFactory: TestSpanFactory
+
+    @Before
+    fun setUp() {
+        testTimeoutExecutor = TestTimeoutExecutor()
+        namedSpanControlProvider =
+            NamedSpanControlProvider(
+                timeoutExecutor = testTimeoutExecutor,
+                timeout = 1000L,
+                timeoutUnit = java.util.concurrent.TimeUnit.MILLISECONDS,
+            )
+        spanFactory = TestSpanFactory()
+    }
+
+    @Test
+    fun duplicateNamedSpansCancelRedundantTimeouts() {
+        val span1 =
+            spanFactory.newSpan(
+                "span1",
+                SpanKind.INTERNAL,
+                1L,
+                null,
+                null,
+                0L,
+                0L,
+                SpanCategory.CATEGORY_CUSTOM,
+                NoopSpanProcessor.INSTANCE,
+            )
+
+        val span1Duplicate =
+            spanFactory.newSpan(
+                "span1",
+                SpanKind.INTERNAL,
+                1L,
+                null,
+                null,
+                0L,
+                0L,
+                SpanCategory.CATEGORY_CUSTOM,
+                NoopSpanProcessor.INSTANCE,
+            )
+
+        namedSpanControlProvider.onSpanStart(span1)
+        assertEquals(1, testTimeoutExecutor.timeouts.size)
+        val timeout1 = testTimeoutExecutor.timeouts.first()
+        namedSpanControlProvider.onSpanStart(span1Duplicate)
+        assertEquals(1, testTimeoutExecutor.timeouts.size)
+        assertNotSame(timeout1, testTimeoutExecutor.timeouts.first())
+        namedSpanControlProvider.onSpanEnd(span1)
+        assertEquals(1, testTimeoutExecutor.timeouts.size)
+        namedSpanControlProvider.onSpanEnd(span1Duplicate)
+    }
+}


### PR DESCRIPTION
## Goal
Avoid holding span references in the `NamedSpanControlsPlugin` when the span tracking stops due to the span being overwritten (when multiple concurrent spans have the same name).

## Testing
New unit test