### PR TITLE
e2e test fixture improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ captures/
 
 # Mazerunner
 maze_output
+maze-runner.log
 
 # Misc
 .DS_Store

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -198,14 +198,15 @@ class MainActivity : AppCompatActivity() {
                 try {
                     // Get the next command from Maze Runner
                     val lastUuid = lastCommandUuid.orEmpty()
-                    val commandStr = readCommand(lastUuid)
+                    val commandUrl = "http://$mazeAddress/command?after=$lastUuid"
+                    val commandStr = readCommand(commandUrl)
                     if (commandStr == "null") {
                         log("No Maze Runner commands queued")
                         continue
                     }
 
                     // Log the received command
-                    log("Received command: $commandStr")
+                    log("Received command from ${commandUrl}\n$commandStr")
                     val command = JSONObject(commandStr)
                     val action = command.getString("action")
 
@@ -295,8 +296,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun readCommand(after: String): String {
-        val commandUrl = "http://$mazeAddress/command?after=$after"
+    private fun readCommand(commandUrl: String): String {
         val urlConnection = URL(commandUrl).openConnection() as HttpURLConnection
         try {
             return urlConnection.inputStream.use { it.reader().readText() }

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -141,7 +141,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Checks general internet and secure tunnel connectivity
-    private fun checkNetwork() {
+    private fun checkNetwork(mazeAddress: String?) {
         log("Checking network connectivity")
         try {
             URL("https://www.google.com").readText()
@@ -150,11 +150,12 @@ class MainActivity : AppCompatActivity() {
             log("Connection to www.google.com FAILED", e)
         }
 
+        val address = "http://${mazeAddress}"
         try {
-            URL("http://bs-local.com:9339").readText()
-            log("Connection to Maze Runner seems ok")
+            URL(address).readText()
+            log("Connection to Maze Runner (${address}) seems ok")
         } catch (e: Exception) {
-            log("Connection to Maze Runner FAILED", e)
+            log("Connection to Maze Runner (${address}) FAILED", e)
         }
     }
 
@@ -402,7 +403,7 @@ class MainActivity : AppCompatActivity() {
             lastCommandUuid = getStoredCommandUUID()
             clearStoredCommandUUID()
         }
-        checkNetwork()
+        checkNetwork(mazeAddress)
         startBugsnag()
     }
 

--- a/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
+++ b/features/fixtures/mazeracer/app/src/main/java/com/bugsnag/mazeracer/MainActivity.kt
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import kotlin.concurrent.thread
 
-const val CONFIG_FILE_TIMEOUT = 5000
+const val CONFIG_FILE_TIMEOUT = 30000
 
 class MainActivity : AppCompatActivity() {
     private val apiKeyKey = "BUGSNAG_API_KEY"
@@ -109,22 +109,28 @@ class MainActivity : AppCompatActivity() {
         val context = MazeRacerApplication.applicationContext()
         val externalFilesDir = context.getExternalFilesDir(null)
         val configFile = File(externalFilesDir, "fixture_config.json")
-        log("Attempting to read Maze Runner address from config file ${configFile.path}")
 
         // Poll for the fixture config file
         val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
         while (System.currentTimeMillis() < pollEnd) {
-            if (configFile.exists()) {
-                val fileContents = configFile.readText()
-                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
-                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
-                if (!mazeAddress.isNullOrBlank()) {
-                    log("Maze Runner address set from config file: $mazeAddress")
-                    break
+            try {
+                log("Attempting to read Maze Runner address from config file ${configFile.path}")
+                if (configFile.exists()) {
+                    val fileContents = configFile.readText()
+                    val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                    mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                    if (!mazeAddress.isNullOrBlank()) {
+                        log("Maze Runner address set from config file: $mazeAddress")
+                        break
+                    }
+                } else {
+                    log("Config file does not exist yet")
                 }
+            } catch (e: Exception) {
+                log("Failed to read Maze Runner address from config file", e)
             }
 
-            Thread.sleep(250)
+            Thread.sleep(1000)
         }
 
         // Assume we are running in legacy mode on BrowserStack

--- a/features/steps/performance_steps.rb
+++ b/features/steps/performance_steps.rb
@@ -14,6 +14,8 @@ def execute_command(action, scenario_name = '', scenario_metadata = '')
 
   command = {
     action: action,
+    cucumber_scenario_name: Maze.scenario.name,
+    cucumber_scenario_location: Maze.scenario.location,
     scenario_name: scenario_name,
     scenario_metadata: scenario_metadata,
     endpoint: "http://#{address}/traces",


### PR DESCRIPTION
## Goal

Improve the resilience and logging of the e2e test fixture.

## Changeset

- Poll for the fixture_config.json file for longer and guard against exceptions that have caused tests to flake.
- Correct the network connection test for Maze Runner to use the address from file and not BS hard-coded.
- Log the full URL including last UUID when fetching a Command
- Include the Cucumber scenario name and location when logging received commands.

## Testing

Covered by CI and inspection of the device logs.