### PR TITLE
Build pipeline and e2e test scenario improvements 

### DIFF
--- a/.buildkite/pipeline.benchmark.yml
+++ b/.buildkite/pipeline.benchmark.yml
@@ -1,24 +1,24 @@
 agents:
-  queue: opensource
+  queue: "opensource"
 
 steps:
-  - label: ':android: Build and upload benchmarks'
-    key: 'benchmark-fixture'
+  - label: ":android: Build and upload benchmarks"
+    key: "benchmark-fixture"
     timeout_in_minutes: 30
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
+      JAVA_VERSION: "17"
     artifact_paths:
       - "build/benchmark_fixture_url.txt"
     commands:
-      - make benchmark-fixture
-      - bundle install
-      - bundle exec upload-app --farm=bb --app=./build/benchmark-fixture.apk --app-id-file=build/benchmark_fixture_url.txt
+      - "make benchmark-fixture"
+      - "bundle install"
+      - "bundle exec upload-app --farm=bb --app=./build/benchmark-fixture.apk --app-id-file=build/benchmark_fixture_url.txt"
 
-  - label: ':bitbar: Benchmarks'
+  - label: ":bitbar: Benchmarks"
     depends_on: "benchmark-fixture"
-    key: 'benchmark-tests'
+    key: "benchmark-tests"
     timeout_in_minutes: 30
     env:
       RUN_BENCHMARKS: "1"
@@ -29,8 +29,8 @@ steps:
           - "maze_output/failed/**/*"
           - "maze_output/metrics.csv"
       docker-compose#v4.8.0:
-        pull: android-maze-runner
-        run: android-maze-runner
+        pull: "android-maze-runner"
+        run: "android-maze-runner"
         service-ports: true
         command:
           - "features/benchmarks"
@@ -42,21 +42,23 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
+    concurrency_group: "bitbar"
+    concurrency_method: "eager"
     retry:
       automatic:
         - exit_status: 103  # Appium session failed
           limit: 2
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
-  - label: 'Send results to Datadog'
+  - label: "Send results to Datadog"
     depends_on: "benchmark-tests"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
         download: "maze_output/metrics.csv"
     agents:
-      queue: macos-15
+      queue: "macos-15"
     commands:
-      - bundle install
-      - bundle exec benchmarks-to-datadog --csv-file maze_output/metrics.csv
+      - "bundle install"
+      - "bundle exec benchmarks-to-datadog --csv-file maze_output/metrics.csv"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,79 +1,79 @@
 agents:
-  queue: opensource
+  queue: "opensource"
 
 steps:
 
-  - label: ':android: Coding standards checks'
+  - label: ":android: Coding standards checks"
     timeout_in_minutes: 20
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
-    command: './gradlew --continue license detekt lint ktlintCheck'
+      JAVA_VERSION: "17"
+    command: "./gradlew --continue license detekt lint ktlintCheck"
 
-  - label: ':android: Binary compatibility checks'
+  - label: ":android: Binary compatibility checks"
     timeout_in_minutes: 20
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
-    command: './gradlew apiCheck'
+      JAVA_VERSION: "17"
+    command: "./gradlew apiCheck"
 
-  - label: ':android: JVM tests'
+  - label: ":android: JVM tests"
     timeout_in_minutes: 10
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
-    command: './gradlew test'
+      JAVA_VERSION: "17"
+    command: "./gradlew test"
     plugins:
       artifacts#v1.9.0:
         upload: "bugsnag-android-performance/build/reports/tests/"
-        compressed: bugsnag-android-performance-test-reports.tgz
+        compressed: "bugsnag-android-performance-test-reports.tgz"
 
-  - label: ':android: Lint test scenarios'
+  - label: ":android: Lint test scenarios"
     timeout_in_minutes: 10
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
+      JAVA_VERSION: "17"
     commands:
-      - cd features/fixtures/mazeracer
-      - ./gradlew ktlintCheck detekt
+      - "cd features/fixtures/mazeracer"
+      - ""./gradlew ktlintCheck detekt"
 
-  - label: ':android: Android size reporting'
+  - label: ":android: Android size reporting"
     timeout_in_minutes: 10
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
-    command: scripts/run-sizer.sh
+      JAVA_VERSION: "17"
+    command: "scripts/run-sizer.sh"
 
-  - label: ':android: Build Example App'
+  - label: ":android: Build Example App"
     timeout_in_minutes: 10
     agents:
-      queue: macos-15
-    command: 'make example-app'
+      queue: "macos-15"
+    command: "make example-app"
     env:
-      JAVA_VERSION: 17
+      JAVA_VERSION: "17"
 
-  - label: ':android: Build and upload test fixture'
-    key: 'fixture'
+  - label: ":android: Build and upload test fixture"
+    key: "fixture"
     timeout_in_minutes: 30
     agents:
-      queue: macos-15
+      queue: "macos-15"
     env:
-      JAVA_VERSION: '17'
+      JAVA_VERSION: "17"
     artifact_paths:
       - "build/fixture_url.txt"
       - "build/fixture_bs_url.txt"
     commands:
-      - make test-fixture
-      - bundle install
-      - bundle exec upload-app --farm=bb --app=./build/test-fixture.apk --app-id-file=build/fixture_url.txt
-      - bundle exec upload-app --farm=bs --app=./build/test-fixture.apk --app-id-file=build/fixture_bs_url.txt
+      - "make test-fixture"
+      - "bundle install"
+      - "bundle exec upload-app --farm=bb --app=./build/test-fixture.apk --app-id-file=build/fixture_url.txt"
+      - "bundle exec upload-app --farm=bs --app=./build/test-fixture.apk --app-id-file=build/fixture_bs_url.txt"
 
-  - label: ':bitbar: {{matrix}} tests'
+  - label: ":bitbar: {{matrix}} tests"
     depends_on: "fixture"
     timeout_in_minutes: 60
     matrix:
@@ -92,8 +92,8 @@ steps:
           - "maze_output/failed/**/*"
           - "maze_output/maze_output.zip"
       docker-compose#v4.8.0:
-        pull: android-maze-runner
-        run: android-maze-runner
+        pull: "android-maze-runner"
+        run: "android-maze-runner"
         service-ports: true
         command:
           - "features/full_tests"
@@ -111,8 +111,8 @@ steps:
         format: "junit"
         branch: "^main|next$$"
     concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
+    concurrency_group: "bitbar"
+    concurrency_method: "eager"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -120,51 +120,51 @@ steps:
         - exit_status: 103  # Appium session failed
           limit: 2
 
-  # If this is the 'main' branch activate a manual publishing step
+  # If this is the "main" branch activate a manual publishing step
 
-  - block: 'Trigger package publish'
+  - block: "Trigger package publish"
     if: build.branch == "main"
-    key: trigger-publish
-    blocked_state: passed
+    key: "trigger-publish"
+    blocked_state: "passed"
 
-  - label: ':docker: Build Android base image'
+  - label: ":docker: Build Android base image"
     if: build.branch == "main"
-    key: 'android-common'
+    key: "android-common"
     timeout_in_minutes: 30
-    depends_on: 'trigger-publish'
+    depends_on: "trigger-publish"
     plugins:
       - docker-compose#v4.7.0:
           build:
-            - android-common
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
+            - "android-common"
+          image-repository: "855461928731.dkr.ecr.us-west-1.amazonaws.com/android"
           cache-from:
-            - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:performance-release
+            - "android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:performance-release"
           push:
-            - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:performance-release
+            - "android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:performance-release"
 
-  - label: 'Publish :rocket:'
+  - label: "Publish :rocket:"
     if: build.branch == "main"
-    depends_on: 'android-common'
+    depends_on: "android-common"
     timeout_in_minutes: 30
     env:
-      BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX: bugsnag-android-publish
+      BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX: "bugsnag-android-publish"
     plugins:
       artifacts#v1.9.0:
         upload:
-          - bugsnag-android-performance/build/outputs/aar/bugsnag-android-performance-release.aar
-          - bugsnag-android-performance-api/build/outputs/aar/bugsnag-android-performance-api-release.aar
-          - bugsnag-android-performance-appcompat/build/outputs/aar/bugsnag-android-performance-appcompat-release.aar
-          - bugsnag-android-performance-compose/build/outputs/aar/bugsnag-android-performance-compose-release.aar
-          - bugsnag-android-performance-coroutines/build/outputs/aar/bugsnag-android-performance-coroutines-release.aar
-          - bugsnag-android-performance-impl/build/outputs/aar/bugsnag-android-performance-impl-release.aar
-          - bugsnag-android-performance-okhttp/build/outputs/aar/bugsnag-android-performance-okhttp-release.aar
-          - bugsnag-plugin-android-performance-named-spans/build/outputs/aar/bugsnag-plugin-android-performance-named-spans-release.aar
+          - "bugsnag-android-performance/build/outputs/aar/bugsnag-android-performance-release.aar"
+          - "bugsnag-android-performance-api/build/outputs/aar/bugsnag-android-performance-api-release.aar"
+          - "bugsnag-android-performance-appcompat/build/outputs/aar/bugsnag-android-performance-appcompat-release.aar"
+          - "bugsnag-android-performance-compose/build/outputs/aar/bugsnag-android-performance-compose-release.aar"
+          - "bugsnag-android-performance-coroutines/build/outputs/aar/bugsnag-android-performance-coroutines-release.aar"
+          - "bugsnag-android-performance-impl/build/outputs/aar/bugsnag-android-performance-impl-release.aar"
+          - "bugsnag-android-performance-okhttp/build/outputs/aar/bugsnag-android-performance-okhttp-release.aar"
+          - "bugsnag-plugin-android-performance-named-spans/build/outputs/aar/bugsnag-plugin-android-performance-named-spans-release.aar"
       docker-compose#v4.7.0:
-        no-cache: true
-        run: android-publisher
+        no-cache: "true"
+        run: "android-publisher"
 
-  - label: 'Conditionally include other pipelines'
+  - label: "Conditionally include other pipelines"
     agents:
-      queue: macos
-    command: sh -c .buildkite/pipeline_trigger.sh
+      queue: "macos"
+    command: "sh -c .buildkite/pipeline_trigger.sh"
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
       JAVA_VERSION: "17"
     commands:
       - "cd features/fixtures/mazeracer"
-      - ""./gradlew ktlintCheck detekt"
+      - "./gradlew ktlintCheck detekt"
 
   - label: ":android: Android size reporting"
     timeout_in_minutes: 10

--- a/features/full_tests/correlation.feature
+++ b/features/full_tests/correlation.feature
@@ -6,8 +6,6 @@ Scenario: Errors notified within a span include the correlation data
   And I wait to receive an error
 
   * a span field "kind" equals 1
-  * a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-  * a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
   # Check the error correlation with the span
   * the event "correlation.traceId" is not null

--- a/features/full_tests/device_metrics.feature
+++ b/features/full_tests/device_metrics.feature
@@ -2,7 +2,11 @@ Feature: Device Metrics
 
   Scenario: CPU & Memory Test
     When I run "DeviceMetricsScenario" configured as "all"
-    * I wait to receive a trace
+    * I wait to receive a span named "FirstClass"
+    * I wait to receive a span named "No Metrics"
+    * I wait to receive a span named "Not FirstClass"
+    * I wait to receive a span named "CPU Metrics Only"
+    * I wait to receive a span named "Memory Metrics Only"
 
     # Check CPU Metrics on first class spans
     * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_total"
@@ -101,7 +105,11 @@ Feature: Device Metrics
 
   Scenario: Configured for CPU Metrics only
     When I run "DeviceMetricsScenario" configured as "cpu"
-    * I wait to receive a trace
+    * I wait to receive a span named "FirstClass"
+    * I wait to receive a span named "No Metrics"
+    * I wait to receive a span named "Not FirstClass"
+    * I wait to receive a span named "CPU Metrics Only"
+    * I wait to receive a span named "Memory Metrics Only"
 
     # Check CPU Metrics on first class spans
     * the "FirstClass" span has double attribute named "bugsnag.system.cpu_mean_total"
@@ -198,7 +206,11 @@ Feature: Device Metrics
 
   Scenario: Configured for Memory Metrics only
     When I run "DeviceMetricsScenario" configured as "memory"
-    * I wait to receive a trace
+    * I wait to receive a span named "FirstClass"
+    * I wait to receive a span named "No Metrics"
+    * I wait to receive a span named "Not FirstClass"
+    * I wait to receive a span named "CPU Metrics Only"
+    * I wait to receive a span named "Memory Metrics Only"
 
     # Check there are no CPU Metrics on first class spans
     * the "FirstClass" span has no "bugsnag.system.cpu_mean_total" attribute

--- a/features/full_tests/frame_metrics.feature
+++ b/features/full_tests/frame_metrics.feature
@@ -2,10 +2,8 @@ Feature: Rendering / Frame Metrics
 
 Scenario: Slow & Frozen Frames are reported
   When I run "FrameMetricsScenario"
-  * I wait to receive a trace
-
-  * a span name equals "Slow Animation"
-  * a span name equals "FrozenFrame"
+  * I wait to receive a span named "Slow Animation"
+  * I wait to receive a span named "FrozenFrame"
 
   # The FrozenFrame span should be a child of Slow Animation
   * a span named "FrozenFrame" has a parent named "Slow Animation"
@@ -16,9 +14,7 @@ Scenario: Slow & Frozen Frames are reported
 
 Scenario: Rending Instrumentation can be turned off
   When I run "FrameMetricsScenario" configured as "disableInstrumentation"
-  * I wait to receive a trace
-
-  * a span name equals "Slow Animation"
+  * I wait to receive a span named "Slow Animation"
 
   * the "Slow Animation" span has no "bugsnag.rendering.slow_frames" attribute
   * the "Slow Animation" span has no "bugsnag.rendering.frozen_frames" attribute

--- a/features/full_tests/instrumentation.feature
+++ b/features/full_tests/instrumentation.feature
@@ -47,7 +47,13 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive at least 6 spans
+    * I wait to receive a span named "[AppStart/AndroidCold]SplashScreen"
+    * I wait to receive a span named "[AppStartPhase/Framework]"
+    * I wait to receive a span named "[ViewLoad/Activity]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityCreate]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]MainActivity"
+
     * a span named "[AppStart/AndroidCold]SplashScreen" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -109,7 +115,9 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive at least 2 spans
+    And I wait to receive a span named "[AppStart/AndroidCold]SplashScreen"
+    And I wait to receive a span named "[ViewLoad/Activity]MainActivity"
+
     * a span named "[AppStart/AndroidCold]SplashScreen" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -161,7 +169,12 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with full ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "FULL"
-    And I wait to receive at least 5 spans
+    And I wait to receive a span named "[ViewLoad/Activity]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityCreate]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoad/Fragment]LoaderFragment"
+
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -195,7 +208,12 @@ Feature: Automatic creation of spans
   @skip_below_android_10
   Scenario: Activity load breakdown with start-only ViewLoad instrumentation
     Given I run "ActivityLoadInstrumentationScenario" configured as "START_ONLY"
-    And I wait to receive at least 5 spans
+    And I wait to receive a span named "[ViewLoad/Activity]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityCreate]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]ActivityViewLoadActivity"
+    * I wait to receive a span named "[ViewLoad/Fragment]LoaderFragment"
+
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -228,7 +246,7 @@ Feature: Automatic creation of spans
 
   Scenario: AppStart/AndroidCold is discarded for background starts
     Given I run "BackgroundAppStartScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "AlarmReceiver"
     * a span named "AlarmReceiver" contains the attributes:
       | attribute                | type      | value |
       | bugsnag.span.first_class | boolValue | true  |
@@ -237,7 +255,7 @@ Feature: Automatic creation of spans
 
   Scenario: ViewLoad spans only appear with app start
     Given I run "DiscardViewLoadOnStopScenario"
-    And I wait to receive a trace
+    And I wait to receive a span named "[ViewLoad/Activity]ActivityViewLoadActivity"
     Then a span named "[ViewLoad/Activity]ActivityViewLoadActivity" contains the attributes:
       | attribute             | type        | value                    |
       | bugsnag.span.category | stringValue | view_load                |
@@ -249,7 +267,16 @@ Feature: Automatic creation of spans
     Given I run "AppStartScenario"
     Then I relaunch the app after shutdown
     * I load scenario "AppStartScenario"
-    And I wait to receive at least 9 spans
+    And I wait to receive a span named "[AppStart/AndroidCold]SplashScreen"
+    * I wait to receive a span named "[AppStartPhase/Framework]"
+    * I wait to receive a span named "[ViewLoad/Activity]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityCreate]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]MainActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityCreate]SplashScreenActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]SplashScreenActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]SplashScreenActivity"
+
     * a span named "[AppStart/AndroidCold]SplashScreen" contains the attributes:
       | attribute                         | type        | value                |
       | bugsnag.span.category             | stringValue | app_start            |
@@ -284,6 +311,7 @@ Feature: Automatic creation of spans
       | bugsnag.span.category | stringValue | view_load_phase |
       | bugsnag.phase         | stringValue | ActivityResume  |
       | bugsnag.view.name     | stringValue | MainActivity    |
+
     * a span named "[ViewLoadPhase/ActivityCreate]SplashScreenActivity" contains the attributes:
       | attribute             | type        | value                |
       | bugsnag.span.category | stringValue | view_load_phase      |
@@ -304,7 +332,7 @@ Feature: Automatic creation of spans
 
   Scenario: Activity ViewLoad spans contain Compose ViewLoad spans
     Given I run "ComposeLoadInstrumentationScenario"
-    And I wait to receive a trace
+    And I wait to receive a span named "[ViewLoad/Compose]Composable"
     * a span named "[ViewLoad/Compose]Composable" contains the attributes:
       | attribute             | type        | value      |
       | bugsnag.span.category | stringValue | view_load  |

--- a/features/full_tests/loading_indicator_view.feature
+++ b/features/full_tests/loading_indicator_view.feature
@@ -2,11 +2,11 @@ Feature: Loading indicator view keep view load span open
 
   Scenario: Loading indicator view
     Given I run "ExtendViewLoadSpanScenario"
-    And I wait to receive a trace
+    And I wait to receive a span named "[ViewLoad/Activity]LoadingIndicatorViewActivity"
     Then the "[ViewLoad/Activity]LoadingIndicatorViewActivity" span took at least 100 ms
 
   Scenario: Loading indicator view with name
     Given I run "NamedLoadingIndicatorScenario"
-    And I wait to receive a trace
+    And I wait to receive a span named "[ViewLoad/Activity]NamedLoadingIndicatorViewActivity"
     Then the "[ViewLoad/Activity]NamedLoadingIndicatorViewActivity" span took at least 100 ms
     And a span named "LoadingIndicatorSpan" has a parent named "[ViewLoad/Activity]NamedLoadingIndicatorViewActivity"

--- a/features/full_tests/manual_spans.feature
+++ b/features/full_tests/manual_spans.feature
@@ -9,15 +9,11 @@ Feature: Manual creation of spans
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
     And the sampling request "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
-    And the trace Bugsnag-Integrity header is valid
-    And the trace "Bugsnag-Sent-At" header is present
     And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
     * a span name equals "ManualSpanScenario"
     * a span field "kind" equals 1
-    * a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "net.host.connection.type" exists
     * every span bool attribute "bugsnag.app.in_foreground" is true
 
@@ -86,22 +82,20 @@ Feature: Manual creation of spans
   Scenario: Send on App backgrounded
     Given I run "AppBackgroundedScenario"
     And I send the app to the background for 5 seconds
-    And I wait to receive at least 1 span
-    Then a span name equals "Span 1"
+    And I wait to receive a span named "Span 1"
 
   # Skip pending PLAT-11356
   @skip
   Scenario: Spans logged in the background
     Given I run "BackgroundSpanScenario"
     And I send the app to the background for 5 seconds
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "BackgroundSpan"
     Then a span name equals "BackgroundSpan"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.app.in_foreground" is false
 
   Scenario: Span attributes are limited based on config
     Given I run "AttributeLimitsScenario"
-    And I wait to receive at least 1 span
-    Then a span name equals "Custom Span"
+    And I wait to receive a span named "Custom Span"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string array attribute "arrayAttribute" equals the array:
       | this is a *** 68 CHARS TRUNCATED |
     * every span string attribute "droppedAttribute" does not exist

--- a/features/full_tests/nested_spans.feature
+++ b/features/full_tests/nested_spans.feature
@@ -3,7 +3,19 @@ Feature: Nested spans
   @skip_below_android_10
   Scenario: Nested spans
     Given I run "NestedSpansScenario"
-    And I wait to receive a trace
+    And I wait to receive a span named "[ViewLoadPhase/ActivityCreate]NestedSpansActivity"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityStart]NestedSpansActivity"
+    * I wait to receive a span named "[ViewLoad/Fragment]FirstFragment"
+    * I wait to receive a span named "[ViewLoadPhase/FragmentCreate]FirstFragment"
+    * I wait to receive a span named "[ViewLoad/Fragment]SecondFragment"
+    * I wait to receive a span named "[ViewLoadPhase/FragmentCreate]SecondFragment"
+    * I wait to receive a span named "[ViewLoadPhase/ActivityResume]NestedSpansActivity"
+    * I wait to receive a span named "[AppStart/AndroidCold]SplashScreen"
+    * I wait to receive a span named "[ViewLoad/Activity]NestedSpansActivity"
+    * I wait to receive a span named "DoStuff"
+    * I wait to receive a span named "LoadData"
+    * I wait to receive a span named "CustomRoot"
+
     # Check we have received all the spans we are expecting
     * a span named "[ViewLoadPhase/ActivityCreate]NestedSpansActivity" contains the attributes:
                 | attribute                         | type        | value               |

--- a/features/full_tests/okhttp_spans.feature
+++ b/features/full_tests/okhttp_spans.feature
@@ -4,8 +4,6 @@ Feature: OkHttp EventListener
     Given I run "OkhttpSpanScenario"
     And I wait to receive a span named "[HTTP/GET]"
     * a span field "kind" equals 3
-    * a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "bugsnag.span.category" equals "network"
     * a span string attribute "http.url" equals "https://google.com/?test=true"
     * a span string attribute "http.method" equals "GET"
@@ -25,10 +23,7 @@ Feature: OkHttp EventListener
     Given I run "OkhttpAutoInstrumentNetworkCallbackScenario"
     And I wait to receive at least 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "http.url" equals "https://www.google.com/"
     * a span string attribute "http.url" equals "https://www.google.com/changed"
 
@@ -36,9 +31,6 @@ Feature: OkHttp EventListener
     Given I run "OkhttpManualNetworkCallbackScenario"
     And I wait to receive at least 2 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "[HTTP/GET]"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "http.url" equals "https://www.google.com/"
     * a span string attribute "http.url" equals "https://www.google.com/changed"


### PR DESCRIPTION
## Goal

Makes the formatting of the Buildkite pipeline more consistent and improves some of the Cucumber step uses.  

## Design

These steps are no longer needed as Maze Runner checks them all:
```
the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
a span field "startTimeUnixNano" matches the regex "^[0-9]+$"
a span field "endTimeUnixNano" matches the regex "^[0-9]+$"
```

I've used the `I wait to receive a span named {string}` step in various locations as it provides better diagnostics if it fails than a simple wait for a number of spans.

## Testing

Covered by CI.
