### PR TITLE
Appium version change for android device and added app activity and app package to benchmark

### DIFF
--- a/.buildkite/pipeline.benchmark.yml
+++ b/.buildkite/pipeline.benchmark.yml
@@ -37,10 +37,12 @@ steps:
           - "--app=@build/benchmark_fixture_url.txt"
           - "--farm=bb"
           - "--device=ANDROID_15_S25"
-          - "--appium-version=1.22"
+          - "--appium-version=2.19"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--app-activity=com.bugsnag.benchmarks"
+          - "--app-package=com.bugsnag.benchmarks"
     concurrency: 25
     concurrency_group: "bitbar"
     concurrency_method: "eager"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,7 +100,7 @@ steps:
           - "--app=@build/fixture_url.txt"
           - "--farm=bb"
           - "--device={{matrix}}"
-          - "--appium-version=1.22"
+          - "--appium-version=2.19"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"


### PR DESCRIPTION
Goal
Bumped --appium-version from 1.22 to 2.19 in the Android Performance Buildkite pipelines.

Design
Earlier pipeline was using appium version 1.22 so we have changed appium version 2.19 commonly.

Changeset
Changed Pipeline.yml files to update version of appium from 1.22 to 2.19
Update app package and app activity in respective yml Files.

Testing
Yes, We have tested manual and automated maze runner test cases BB.